### PR TITLE
print() is a function in Python 3

### DIFF
--- a/lab/branches.py
+++ b/lab/branches.py
@@ -13,11 +13,11 @@ def my_function(x):
 
     i = 0
     while True:
-        print "In while True"
+        print("In while True")
         if i > 0:
             break
         i += 1
-    print "Left the True loop"
+    print("Left the True loop")
 
     # Notice that "while 1" also has this problem.  Even though the compiler
     # knows there's no computation at the top of the loop, it's still expressed
@@ -25,11 +25,11 @@ def my_function(x):
 
     i = 0
     while 1:
-        print "In while 1"
+        print("In while 1")
         if i > 0:
             break
         i += 1
-    print "Left the 1 loop"
+    print("Left the 1 loop")
 
     # Coverage.py lets developers exclude lines that they know will not be
     # executed.  So far, the branch coverage doesn't use all that information
@@ -40,9 +40,9 @@ def my_function(x):
 
     if x < 1000:
         # This branch is always taken
-        print "x is reasonable"
+        print("x is reasonable")
     else:   # pragma: nocover
-        print "this never happens"
+        print("this never happens")
 
     # try-except structures are complex branches.  An except clause with a
     # type is a three-way branch: there could be no exception, there could be
@@ -57,9 +57,9 @@ def my_function(x):
             if y % 2:
                 raise ValueError("y is odd!")
         except ValueError:
-            print "y must have been odd"
-        print "done with y"
-    print "done with 1, 2"
+            print("y must have been odd")
+        print("done with y")
+    print("done with 1, 2")
 
     # Another except clause, but this time all three cases are executed.  No
     # partial lines are shown:
@@ -71,11 +71,11 @@ def my_function(x):
             if y == 0:
                 raise Exception("zero!")
         except ValueError:
-            print "y must have been odd"
+            print("y must have been odd")
         except:
-            print "y is something else"
-        print "done with y"
-    print "done with 0, 1, 2"
+            print("y is something else")
+        print("done with y")
+    print("done with 0, 1, 2")
 
 
 my_function(1)

--- a/lab/run_trace.py
+++ b/lab/run_trace.py
@@ -14,13 +14,13 @@ def trace(frame, event, arg):
         # This can happen when Python is shutting down.
         return None
 
-    print "%s%s %s %d @%d" % (
+    print("%s%s %s %d @%d" % (
         "    " * nest,
         event,
         os.path.basename(frame.f_code.co_filename),
         frame.f_lineno,
         frame.f_lasti,
-        )
+        ))
 
     if event == 'call':
         nest += 1

--- a/lab/show_platform.py
+++ b/lab/show_platform.py
@@ -13,4 +13,4 @@ for n in dir(platform):
             n += "()"
         except:
             continue
-    print "%30s: %r" % (n, v)
+    print("%30s: %r" % (n, v))


### PR DESCRIPTION
This is probably intentional but just in case...

These three files contain __print__ statements instead of __print()__ functions.

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lab/branches.py:16:29: E999 SyntaxError: invalid syntax
        print "In while True"
                            ^
./lab/run_trace.py:17:26: E999 SyntaxError: invalid syntax
    print "%s%s %s %d @%d" % (
                         ^
./lab/show_platform.py:16:20: E999 SyntaxError: invalid syntax
    print "%30s: %r" % (n, v)
                   ^
```