### PR TITLE
CoverageSqliteData.__nonzero__: do not create DB

### DIFF
--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -142,6 +142,8 @@ class CoverageSqliteData(SimpleReprMixin):
         return self._db
 
     def __nonzero__(self):
+        if self._db is None and not os.path.exists(self.filename):
+            return False
         try:
             with self._connect() as con:
                 rows = con.execute("select * from file limit 1")


### PR DESCRIPTION
This makes is more lazy and avoids creating an empty DB unnecessarily.