### PR TITLE
Update version.py to follow semver rules

### DIFF
--- a/coverage/version.py
+++ b/coverage/version.py
@@ -11,12 +11,10 @@ version_info = (5, 0, 0, 'alpha', 4)
 def _make_version(major, minor, micro, releaselevel, serial):
     """Create a readable version string from version_info tuple components."""
     assert releaselevel in ['alpha', 'beta', 'candidate', 'final']
-    version = "%d.%d" % (major, minor)
-    if micro:
-        version += ".%d" % (micro,)
+    version = "%d.%d.%d" % (major, minor, micro)
     if releaselevel != 'final':
         short = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc'}[releaselevel]
-        version += "%s%d" % (short, serial)
+        version += "-%s%d" % (short, serial)
     return version
 
 


### PR DESCRIPTION
In its current state _make_version would generate version strings that were not compatiable with semver rules. This was causing issues in that pre-release versions of the code were being downloaded.

The code has been updated to always include minor version and to use a hyphen to separate pre-release versions.