### PR TITLE
Disallow impossible values for fail_under

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -81,6 +81,7 @@ Matthew Desmarais
 Max Linke
 Michał Bultrowicz
 Mickie Betz
+Mike Fiedler
 Nathan Land
 Noel O'Boyle
 Olivier Grisel

--- a/coverage/results.py
+++ b/coverage/results.py
@@ -283,6 +283,10 @@ def should_fail_under(total, fail_under, precision):
     Returns True if the total should fail.
 
     """
+    # We can never achieve higher than 100% coverage
+    if fail_under > 100.0:
+        raise ValueError("`fail_under` is greater than 100. Please use 100 or lower.")
+
     # Special case for fail_under=100, it must really be 100.
     if fail_under == 100.0 and total != 100.0:
         return True

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -105,3 +105,8 @@ class NumbersTest(CoverageTest):
 ])
 def test_should_fail_under(total, fail_under, precision, result):
     assert should_fail_under(float(total), float(fail_under), precision) == result
+
+
+def test_should_fail_under_invalid_value():
+    with pytest.raises(ValueError):
+        should_fail_under(100.0, 101, 0)


### PR DESCRIPTION
Since there's no way were likely to achieve greater than 100% code coverage,
disallow usage of any value above 100.

Resolves #743

Signed-off-by: Mike Fiedler <miketheman@gmail.com>