### PR TITLE
Context-based Reporting

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -101,6 +101,14 @@ class Opts(object):
             "Accepts shell-style wildcards, which must be quoted."
         ),
     )
+    contexts = optparse.make_option(
+        '', '--contexts', action='store',
+        metavar="PAT1,PAT2,...",
+        help=(
+            "Only count the lines covered in given contexts. "
+            "Accepts shell-style wildcards, which must be quoted."
+        ),
+    )
     output_xml = optparse.make_option(
         '-o', '', action='store', dest="outfile",
         metavar="OUTFILE",
@@ -176,6 +184,7 @@ class CoverageOptionParser(optparse.OptionParser, object):
             include=None,
             module=None,
             omit=None,
+            contexts=None,
             parallel_mode=None,
             pylib=None,
             rcfile=True,
@@ -348,6 +357,7 @@ CMDS = {
             Opts.ignore_errors,
             Opts.include,
             Opts.omit,
+            Opts.contexts,
             Opts.show_missing,
             Opts.skip_covered,
             ] + GLOBAL_ARGS,
@@ -478,6 +488,7 @@ class CoverageScript(object):
         omit = unshell_list(options.omit)
         include = unshell_list(options.include)
         debug = unshell_list(options.debug)
+        contexts = unshell_list(options.contexts)
 
         # Do something.
         self.coverage = Coverage(
@@ -519,6 +530,7 @@ class CoverageScript(object):
             ignore_errors=options.ignore_errors,
             omit=omit,
             include=include,
+            contexts=contexts,
             )
 
         # We need to be able to import from the current directory, because

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -93,6 +93,10 @@ class Opts(object):
         '--skip-covered', action='store_true',
         help="Skip files with 100% coverage.",
     )
+    show_contexts = optparse.make_option(
+        '--show-contexts', action='store_true',
+        help="Show contexts for covered lines.",
+    )
     omit = optparse.make_option(
         '', '--omit', action='store',
         metavar="PAT1,PAT2,...",
@@ -190,6 +194,7 @@ class CoverageOptionParser(optparse.OptionParser, object):
             rcfile=True,
             show_missing=None,
             skip_covered=None,
+            show_contexts=None,
             source=None,
             timid=None,
             title=None,
@@ -341,6 +346,7 @@ CMDS = {
             Opts.omit,
             Opts.title,
             Opts.skip_covered,
+            Opts.show_contexts
             ] + GLOBAL_ARGS,
         usage="[options] [modules]",
         description=(
@@ -553,6 +559,7 @@ class CoverageScript(object):
                 directory=options.directory,
                 title=options.title,
                 skip_covered=options.skip_covered,
+                show_contexts=options.show_contexts,
                 **report_args
                 )
         elif options.action == "xml":

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -202,6 +202,7 @@ class CoverageConfig(object):
         self.precision = 0
         self.show_missing = False
         self.skip_covered = False
+        self.show_contexts = False
 
         # Defaults for [html]
         self.extra_css = None

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -177,6 +177,7 @@ class CoverageConfig(object):
         self.command_line = None
         self.concurrency = None
         self.context = None
+        self.query_contexts = None
         self.cover_pylib = False
         self.data_file = ".coverage"
         self.debug = []

--- a/coverage/context.py
+++ b/coverage/context.py
@@ -46,32 +46,36 @@ def qualname_from_frame(frame):
     co = frame.f_code
     fname = co.co_name
     if not co.co_varnames:
-        return fname
+        func = frame.f_globals[fname]
+        return func.__module__ + '.' + fname
 
     first_arg = co.co_varnames[0]
     if co.co_argcount and first_arg == "self":
         self = frame.f_locals["self"]
     else:
-        return fname
+        func = frame.f_globals[fname]
+        return func.__module__ + '.' + fname
 
     method = getattr(self, fname, None)
     if method is None:
-        return fname
+        func = frame.f_globals[fname]
+        return func.__module__ + '.' + fname
 
     func = getattr(method, '__func__', None)
     if func is None:
-        return fname
+        cls = self.__class__
+        return cls.__module__ + '.' + cls.__name__ + "." + fname
 
     if hasattr(func, '__qualname__'):
-        qname = func.__qualname__
+        qname = func.__module__ + '.' + func.__qualname__
     else:
         for cls in getattr(self.__class__, '__mro__', ()):
             f = cls.__dict__.get(fname, None)
             if f is None:
                 continue
             if f is func:
-                qname = cls.__name__ + "." + fname
+                qname = cls.__module__ + '.' + cls.__name__ + "." + fname
                 break
         else:
-            qname = fname
+            qname = func.__module__ + '.' + fname
     return qname

--- a/coverage/context.py
+++ b/coverage/context.py
@@ -78,5 +78,19 @@ def qualname_from_frame(frame):
                 qname = cls.__module__ + '.' + cls.__name__ + "." + fname
                 break
         else:
-            qname = func.__module__ + '.' + fname
+            # Support for old-style classes.
+            def mro(bases):
+                for base in bases:
+                    f = base.__dict__.get(fname, None)
+                    if f is func:
+                        return base.__module__ + '.' + base.__name__ + "." + fname
+                for base in bases:
+                    qname = mro(base.__bases__)
+                    if qname is not None:
+                        return qname
+                return None
+            qname = mro([self.__class__])
+            if qname is None:
+                qname = func.__module__ + '.' + fname
+
     return qname

--- a/coverage/context.py
+++ b/coverage/context.py
@@ -36,7 +36,8 @@ def combine_context_switchers(context_switchers):
 
 def should_start_context_test_function(frame):
     """Is this frame calling a test_* function?"""
-    if frame.f_code.co_name.startswith("test"):
+    co_name = frame.f_code.co_name
+    if co_name.startswith("test") or co_name == "runTest":
         return qualname_from_frame(frame)
     return None
 

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -788,7 +788,7 @@ class Coverage(object):
 
     def html_report(self, morfs=None, directory=None, ignore_errors=None,
                     omit=None, include=None, extra_css=None, title=None,
-                    skip_covered=None, contexts=None):
+                    skip_covered=None, show_contexts=None, contexts=None):
         """Generate an HTML report.
 
         The HTML is written to `directory`.  The file "index.html" is the
@@ -809,7 +809,7 @@ class Coverage(object):
         self.config.from_args(
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,
             html_dir=directory, extra_css=extra_css, html_title=title,
-            skip_covered=skip_covered, query_contexts=contexts,
+            skip_covered=skip_covered, show_contexts=show_contexts, query_contexts=contexts,
             )
         reporter = HtmlReporter(self, self.config)
         return reporter.report(morfs)

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -731,6 +731,7 @@ class Coverage(object):
         self, morfs=None, show_missing=None, ignore_errors=None,
         file=None,                  # pylint: disable=redefined-builtin
         omit=None, include=None, skip_covered=None,
+        contexts=None,
     ):
         """Write a textual summary report to `file`.
 
@@ -759,13 +760,14 @@ class Coverage(object):
         self.config.from_args(
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,
             show_missing=show_missing, skip_covered=skip_covered,
+            query_contexts=contexts,
             )
         reporter = SummaryReporter(self, self.config)
         return reporter.report(morfs, outfile=file)
 
     def annotate(
         self, morfs=None, directory=None, ignore_errors=None,
-        omit=None, include=None,
+        omit=None, include=None, contexts=None,
     ):
         """Annotate a list of modules.
 
@@ -778,14 +780,15 @@ class Coverage(object):
 
         """
         self.config.from_args(
-            ignore_errors=ignore_errors, report_omit=omit, report_include=include
+            ignore_errors=ignore_errors, report_omit=omit,
+            report_include=include, query_contexts=contexts,
             )
         reporter = AnnotateReporter(self, self.config)
         reporter.report(morfs, directory=directory)
 
     def html_report(self, morfs=None, directory=None, ignore_errors=None,
                     omit=None, include=None, extra_css=None, title=None,
-                    skip_covered=None):
+                    skip_covered=None, contexts=None):
         """Generate an HTML report.
 
         The HTML is written to `directory`.  The file "index.html" is the
@@ -806,14 +809,14 @@ class Coverage(object):
         self.config.from_args(
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,
             html_dir=directory, extra_css=extra_css, html_title=title,
-            skip_covered=skip_covered,
+            skip_covered=skip_covered, query_contexts=contexts,
             )
         reporter = HtmlReporter(self, self.config)
         return reporter.report(morfs)
 
     def xml_report(
         self, morfs=None, outfile=None, ignore_errors=None,
-        omit=None, include=None,
+        omit=None, include=None, contexts=None,
     ):
         """Generate an XML report of coverage results.
 
@@ -829,7 +832,7 @@ class Coverage(object):
         """
         self.config.from_args(
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,
-            xml_output=outfile,
+            xml_output=outfile, query_contexts=contexts,
             )
         file_to_close = None
         delete_file = False

--- a/coverage/data.py
+++ b/coverage/data.py
@@ -175,6 +175,13 @@ class CoverageJsonData(object):
     ## Reading data
     ##
 
+    def set_query_contexts(self, contexts=None):
+        """Set the query contexts.
+
+        No-op, since contexts are not supported for this data format.
+        """
+        pass
+
     def has_arcs(self):
         """Does this data have arcs?
 
@@ -186,7 +193,7 @@ class CoverageJsonData(object):
         """
         return self._has_arcs()
 
-    def lines(self, filename):
+    def lines(self, filename, contexts=None):
         """Get the list of lines executed for a file.
 
         If the file was not measured, returns None.  A file might be measured,
@@ -195,6 +202,8 @@ class CoverageJsonData(object):
         If the file was executed, returns a list of integers, the line numbers
         executed in the file. The list is in no particular order.
 
+        `contexts` is ignored, since contexts are not supported for this data
+        format.
         """
         if self._arcs is not None:
             arcs = self._arcs.get(filename)
@@ -205,7 +214,7 @@ class CoverageJsonData(object):
             return self._lines.get(filename)
         return None
 
-    def arcs(self, filename):
+    def arcs(self, filename, contexts=None):
         """Get the list of arcs executed for a file.
 
         If the file was not measured, returns None.  A file might be measured,
@@ -221,6 +230,8 @@ class CoverageJsonData(object):
         If the ending ling number is -N, it's an exit from the code object that
         starts at line N.
 
+        `contexts` is ignored, since contexts are not supported for this data
+        format.
         """
         if self._arcs is not None:
             if filename in self._arcs:

--- a/coverage/data.py
+++ b/coverage/data.py
@@ -253,6 +253,9 @@ class CoverageJsonData(object):
             return self._file_tracers.get(filename, "")
         return None
 
+    def contexts_by_lineno(self, filename):
+        return collections.defaultdict(list)
+
     def run_infos(self):
         """Return the list of dicts of run information.
 

--- a/coverage/data.py
+++ b/coverage/data.py
@@ -3,6 +3,7 @@
 
 """Coverage data for coverage.py."""
 
+import collections
 import glob
 import itertools
 import json

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -214,6 +214,9 @@ class HtmlReporter(Reporter):
         c_mis = "mis"
         c_par = "par " + c_run
 
+        # Lookup line number contexts.
+        contexts_by_lineno = analysis.data.contexts_by_lineno(fr.filename)
+
         lines = []
 
         for lineno, line in enumerate(fr.source_token_lines(), start=1):
@@ -268,6 +271,7 @@ class HtmlReporter(Reporter):
                 'html': ''.join(html),
                 'number': lineno,
                 'class': ' '.join(line_class) or "pln",
+                'contexts': sorted(filter(None, contexts_by_lineno[lineno])) or None,
                 'annotate': annotate_html,
                 'annotate_long': annotate_long,
             })
@@ -279,6 +283,7 @@ class HtmlReporter(Reporter):
             'c_par': c_par,
             'c_run': c_run,
             'has_arcs': self.has_arcs,
+            'show_contexts': self.config.show_contexts,
             'extra_css': self.extra_css,
             'fr': fr,
             'nums': nums,

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -3,6 +3,7 @@
 
 """HTML reporting for coverage.py."""
 
+import collections
 import datetime
 import json
 import os
@@ -214,8 +215,10 @@ class HtmlReporter(Reporter):
         c_mis = "mis"
         c_par = "par " + c_run
 
-        # Lookup line number contexts.
-        contexts_by_lineno = analysis.data.contexts_by_lineno(fr.filename)
+        contexts_by_lineno = collections.defaultdict(list)
+        if self.config.show_contexts:
+            # Lookup line number contexts.
+            contexts_by_lineno = analysis.data.contexts_by_lineno(fr.filename)
 
         lines = []
 
@@ -271,7 +274,9 @@ class HtmlReporter(Reporter):
                 'html': ''.join(html),
                 'number': lineno,
                 'class': ' '.join(line_class) or "pln",
-                'contexts': sorted(filter(None, contexts_by_lineno[lineno])) or None,
+                'contexts': \
+                    (sorted(filter(None, contexts_by_lineno[lineno])) or None)
+                    if self.config.show_contexts else None,
                 'annotate': annotate_html,
                 'annotate_long': annotate_long,
             })

--- a/coverage/htmlfiles/pyfile.html
+++ b/coverage/htmlfiles/pyfile.html
@@ -88,6 +88,23 @@
     </p>
 {% endfor %}
             </td>
+            {% if show_contexts -%}
+            <td class="contexts">
+              {% for line in lines -%}
+                <p>{#-#}
+                  {% if line.contexts -%}
+                    <span class="context-button">ctx</span>{#-#}
+                    <span class="context-list">
+                      {% for context in line.contexts -%}
+                      <span class="context-line">{{context}}</span>{#-#}
+                      {% endfor -%}
+                    </span>{#-#}
+                  {% endif -%}
+                  &nbsp;
+                </p>{#-#}
+              {% endfor %}
+            </td>
+            {% endif -%}
         </tr>
     </table>
 </div>

--- a/coverage/htmlfiles/pyfile.html
+++ b/coverage/htmlfiles/pyfile.html
@@ -104,7 +104,7 @@
                 </p>{#-#}
               {% endfor %}
             </td>
-            {% endif -%}
+            {% endif %}
         </tr>
     </table>
 </div>

--- a/coverage/htmlfiles/style.css
+++ b/coverage/htmlfiles/style.css
@@ -297,6 +297,53 @@ td.text {
     color: #000080;
     }
 
+td.contexts p {
+    margin: 0;
+    padding: 0 .5em;
+    color: #999999;
+    font-family: verdana, sans-serif;
+    white-space: nowrap;
+    position: relative;
+    }
+
+td.contexts p:hover {
+    background: #eee;
+    }
+
+td.contexts p span.context-list {
+    display: none;
+    }
+
+td.contexts p:hover span.context-list {
+    display: block;
+    min-width: 30em;
+    //max-width: 50%;
+    white-space: normal;
+    float: right;
+    position: absolute;
+    top: 1.75em;
+    right: 1em;
+    height: auto;
+    color: #333;
+    background: #ffffcc;
+    border: 1px solid #888;
+    padding: .25em .5em;
+    z-index: 999;
+    border-radius: .2em;
+    box-shadow: #cccccc .2em .2em .2em;
+    }
+
+span.context-list span.context-line {
+  display: block;
+}
+
+td.contexts p span.context-button {
+    display: inline-block;
+    cursor: pointer;
+    font-size: .8333em;   /* 10/12 */
+    line-height: 1em;
+    }
+
 /* index styles */
 #index td, #index th {
     text-align: right;

--- a/coverage/htmlfiles/style.css
+++ b/coverage/htmlfiles/style.css
@@ -297,6 +297,7 @@ td.text {
     color: #000080;
     }
 
+/* Line contexts */
 td.contexts p {
     margin: 0;
     padding: 0 .5em;
@@ -305,15 +306,12 @@ td.contexts p {
     white-space: nowrap;
     position: relative;
     }
-
 td.contexts p:hover {
     background: #eee;
     }
-
 td.contexts p span.context-list {
     display: none;
     }
-
 td.contexts p:hover span.context-list {
     display: block;
     min-width: 30em;
@@ -332,11 +330,9 @@ td.contexts p:hover span.context-list {
     border-radius: .2em;
     box-shadow: #cccccc .2em .2em .2em;
     }
-
 span.context-list span.context-line {
-  display: block;
-}
-
+    display: block;
+    }
 td.contexts p span.context-button {
     display: inline-block;
     cursor: pointer;

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -662,7 +662,12 @@ class Sqlite(SimpleReprMixin):
         # has non-ascii characters in it.  Opening a relative file name avoids
         # a problem if the current directory has non-ascii.
         filename = os.path.relpath(self.filename)
-        self.con = sqlite3.connect(filename)
+        # It can happen that Python switches threads while the tracer writes
+        # data. The second thread will also try to write to the data,
+        # effectively causing a nested context. However, given the indempotent
+        # nature of the tracer operations, sharing a conenction among threads
+        # is not a problem.
+        self.con = sqlite3.connect(filename, check_same_thread=False)
 
         # This pragma makes writing faster. It disables rollbacks, but we never need them.
         # PyPy needs the .close() calls here, or sqlite gets twisted up:

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -95,6 +95,8 @@ class CoverageSqliteData(SimpleReprMixin):
 
         self._current_context = None
         self._current_context_id = None
+        self._query_contexts = None
+        self._query_context_ids = None
 
     def _choose_filename(self):
         self._filename = self._basename

--- a/coverage/summary.py
+++ b/coverage/summary.py
@@ -42,6 +42,7 @@ class SummaryReporter(Reporter):
 
         fmt_err = u"%s   %s: %s"
 
+        self.coverage.get_data().set_query_contexts(self.config.query_contexts)
         for fr in self.find_file_reporters(morfs):
             try:
                 analysis = self.coverage._analyze(fr)

--- a/tests/gold/html/styled/style.css
+++ b/tests/gold/html/styled/style.css
@@ -297,6 +297,49 @@ td.text {
     color: #000080;
     }
 
+/* Line contexts */
+td.contexts p {
+    margin: 0;
+    padding: 0 .5em;
+    color: #999999;
+    font-family: verdana, sans-serif;
+    white-space: nowrap;
+    position: relative;
+    }
+td.contexts p:hover {
+    background: #eee;
+    }
+td.contexts p span.context-list {
+    display: none;
+    }
+td.contexts p:hover span.context-list {
+    display: block;
+    min-width: 30em;
+    //max-width: 50%;
+    white-space: normal;
+    float: right;
+    position: absolute;
+    top: 1.75em;
+    right: 1em;
+    height: auto;
+    color: #333;
+    background: #ffffcc;
+    border: 1px solid #888;
+    padding: .25em .5em;
+    z-index: 999;
+    border-radius: .2em;
+    box-shadow: #cccccc .2em .2em .2em;
+    }
+span.context-list span.context-line {
+    display: block;
+    }
+td.contexts p span.context-button {
+    display: inline-block;
+    cursor: pointer;
+    font-size: .8333em;   /* 10/12 */
+    line-height: 1em;
+    }
+
 /* index styles */
 #index td, #index th {
     text-align: right;

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -556,8 +556,10 @@ class ApiTest(CoverageTest):
         filenames = self.get_measured_filenames(data)
         suite_filename = filenames['testsuite.py']
 
-        self.assertEqual([2, 8], data.lines(suite_filename, context="multiply_six"))
-        self.assertEqual([2, 5], data.lines(suite_filename, context="multiply_zero"))
+        self.assertEqual(
+            [2, 8], data.lines(suite_filename, contexts=["multiply_six"]))
+        self.assertEqual(
+            [2, 5], data.lines(suite_filename, contexts=["multiply_zero"]))
 
     def test_switch_context_with_static(self):
         # This test simulates a coverage-aware test runner,
@@ -594,8 +596,10 @@ class ApiTest(CoverageTest):
         filenames = self.get_measured_filenames(data)
         suite_filename = filenames['testsuite.py']
 
-        self.assertEqual([2, 8], data.lines(suite_filename, context="mysuite|multiply_six"))
-        self.assertEqual([2, 5], data.lines(suite_filename, context="mysuite|multiply_zero"))
+        self.assertEqual(
+            [2, 8], data.lines(suite_filename, contexts=["mysuite|multiply_six"]))
+        self.assertEqual(
+            [2, 5], data.lines(suite_filename, contexts=["mysuite|multiply_zero"]))
 
     def test_switch_context_unstarted(self):
         # Coverage must be started to switch context

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -32,17 +32,19 @@ class BaseCmdLineTest(CoverageTest):
     _defaults = mock.Mock()
     _defaults.Coverage().annotate(
         directory=None, ignore_errors=None, include=None, omit=None, morfs=[],
+        contexts=None,
     )
     _defaults.Coverage().html_report(
         directory=None, ignore_errors=None, include=None, omit=None, morfs=[],
-        skip_covered=None, title=None
+        skip_covered=None, title=None, contexts=None,
     )
     _defaults.Coverage().report(
         ignore_errors=None, include=None, omit=None, morfs=[],
-        show_missing=None, skip_covered=None
+        show_missing=None, skip_covered=None, contexts=None,
     )
     _defaults.Coverage().xml_report(
         ignore_errors=None, include=None, omit=None, morfs=[], outfile=None,
+        contexts=None,
     )
     _defaults.Coverage(
         cover_pylib=None, data_suffix=None, timid=None, branch=None,
@@ -362,6 +364,11 @@ class CmdLineTest(BaseCmdLineTest):
             cov = Coverage()
             cov.load()
             cov.report(skip_covered=True)
+            """)
+        self.cmd_executes("report --contexts=foo,bar", """\
+            cov = Coverage()
+            cov.load()
+            cov.report(contexts=["foo", "bar"])
             """)
 
     def test_run(self):

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -36,7 +36,7 @@ class BaseCmdLineTest(CoverageTest):
     )
     _defaults.Coverage().html_report(
         directory=None, ignore_errors=None, include=None, omit=None, morfs=[],
-        skip_covered=None, title=None, contexts=None,
+        skip_covered=None, show_contexts=None, title=None, contexts=None,
     )
     _defaults.Coverage().report(
         ignore_errors=None, include=None, omit=None, morfs=[],

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -172,10 +172,15 @@ class DynamicContextTest(CoverageTest):
 
         full_names = {os.path.basename(f): f for f in data.measured_files()}
         fname = full_names["two_tests.py"]
-        self.assertCountEqual(data.measured_contexts(), ["stat", "stat|test_one", "stat|test_two"])
-        self.assertCountEqual(data.lines(fname, "stat"), self.OUTER_LINES)
-        self.assertCountEqual(data.lines(fname, "stat|test_one"), self.TEST_ONE_LINES)
-        self.assertCountEqual(data.lines(fname, "stat|test_two"), self.TEST_TWO_LINES)
+        self.assertCountEqual(
+            data.measured_contexts(),
+            ["stat", "stat|two_tests.test_one", "stat|two_tests.test_two"])
+        self.assertCountEqual(
+            data.lines(fname, ["stat"]), self.OUTER_LINES)
+        self.assertCountEqual(
+            data.lines(fname, ["stat|two_tests.test_one"]), self.TEST_ONE_LINES)
+        self.assertCountEqual(
+            data.lines(fname, ["stat|two_tests.test_two"]), self.TEST_TWO_LINES)
 
 
 class DynamicContextWithPythonTracerTest(CoverageTest):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -284,4 +284,4 @@ class QualnameTest(CoverageTest):
         if not env.PY2:
             self.skipTest("Old-style classes are only in Python 2")
         self.assertEqual(OldStyle().meth(), "tests.test_context.OldStyle.meth")
-        self.assertEqual(OldChild().meth(), "tests.test_context.OldChild.meth")
+        self.assertEqual(OldChild().meth(), "tests.test_context.OldStyle.meth")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -153,10 +153,15 @@ class DynamicContextTest(CoverageTest):
 
         full_names = {os.path.basename(f): f for f in data.measured_files()}
         fname = full_names["two_tests.py"]
-        self.assertCountEqual(data.measured_contexts(), ["", "test_one", "test_two"])
+        self.assertCountEqual(
+            data.measured_contexts(),
+            ["", "two_tests.test_one", "two_tests.test_two"])
         self.assertCountEqual(data.lines(fname, [""]), self.OUTER_LINES)
-        self.assertCountEqual(data.lines(fname, ["test_one"]), self.TEST_ONE_LINES)
-        self.assertCountEqual(data.lines(fname, ["test_two"]), self.TEST_TWO_LINES)
+        self.assertCountEqual(
+            data.lines(fname, ["two_tests.test_one"]),
+            self.TEST_ONE_LINES)
+        self.assertCountEqual(
+            data.lines(fname, ["two_tests.test_two"]), self.TEST_TWO_LINES)
 
     def test_static_and_dynamic(self):
         self.make_file("two_tests.py", self.SOURCE)
@@ -248,34 +253,35 @@ class QualnameTest(CoverageTest):
     run_in_temp_dir = False
 
     def test_method(self):
-        self.assertEqual(Parent().meth(), "Parent.meth")
+        self.assertEqual(Parent().meth(), "tests.test_context.Parent.meth")
 
     def test_inherited_method(self):
-        self.assertEqual(Child().meth(), "Parent.meth")
+        self.assertEqual(Child().meth(), "tests.test_context.Parent.meth")
 
     def test_mi_inherited_method(self):
-        self.assertEqual(MultiChild().meth(), "Parent.meth")
+        self.assertEqual(MultiChild().meth(), "tests.test_context.Parent.meth")
 
     def test_no_arguments(self):
-        self.assertEqual(no_arguments(), "no_arguments")
+        self.assertEqual(no_arguments(), "tests.test_context.no_arguments")
 
     def test_plain_old_function(self):
-        self.assertEqual(plain_old_function(0, 1), "plain_old_function")
+        self.assertEqual(
+            plain_old_function(0, 1), "tests.test_context.plain_old_function")
 
     def test_fake_out(self):
-        self.assertEqual(fake_out(0), "fake_out")
+        self.assertEqual(fake_out(0), "tests.test_context.fake_out")
 
     def test_property(self):
-        # I'd like this to be "Parent.a_property", but this might be ok too.
-        self.assertEqual(Parent().a_property, "a_property")
+        self.assertEqual(
+            Parent().a_property, "tests.test_context.Parent.a_property")
 
     def test_changeling(self):
         c = Child()
         c.meth = patch_meth
-        self.assertEqual(c.meth(c), "patch_meth")
+        self.assertEqual(c.meth(c), "tests.test_context.patch_meth")
 
     def test_oldstyle(self):
         if not env.PY2:
             self.skipTest("Old-style classes are only in Python 2")
-        self.assertEqual(OldStyle().meth(), "meth")
-        self.assertEqual(OldChild().meth(), "meth")
+        self.assertEqual(OldStyle().meth(), "tests.test_context.OldStyle.meth")
+        self.assertEqual(OldChild().meth(), "tests.test_context.OldChild.meth")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -77,10 +77,10 @@ class StaticContextTest(CoverageTest):
             fred = full_names['red.py']
             fblue = full_names['blue.py']
 
-            self.assertEqual(combined.lines(fred, context='red'), self.LINES)
-            self.assertEqual(combined.lines(fred, context='blue'), [])
-            self.assertEqual(combined.lines(fblue, context='red'), [])
-            self.assertEqual(combined.lines(fblue, context='blue'), self.LINES)
+            self.assertEqual(combined.lines(fred, contexts=['red']), self.LINES)
+            self.assertEqual(combined.lines(fred, contexts=['blue']), [])
+            self.assertEqual(combined.lines(fblue, contexts=['red']), [])
+            self.assertEqual(combined.lines(fblue, contexts=['blue']), self.LINES)
 
     def test_combining_arc_contexts(self):
         red_data, blue_data = self.run_red_blue(branch=True)
@@ -97,15 +97,15 @@ class StaticContextTest(CoverageTest):
             fred = full_names['red.py']
             fblue = full_names['blue.py']
 
-            self.assertEqual(combined.lines(fred, context='red'), self.LINES)
-            self.assertEqual(combined.lines(fred, context='blue'), [])
-            self.assertEqual(combined.lines(fblue, context='red'), [])
-            self.assertEqual(combined.lines(fblue, context='blue'), self.LINES)
+            self.assertEqual(combined.lines(fred, contexts=['red']), self.LINES)
+            self.assertEqual(combined.lines(fred, contexts=['blue']), [])
+            self.assertEqual(combined.lines(fblue, contexts=['red']), [])
+            self.assertEqual(combined.lines(fblue, contexts=['blue']), self.LINES)
 
-            self.assertEqual(combined.arcs(fred, context='red'), self.ARCS)
-            self.assertEqual(combined.arcs(fred, context='blue'), [])
-            self.assertEqual(combined.arcs(fblue, context='red'), [])
-            self.assertEqual(combined.arcs(fblue, context='blue'), self.ARCS)
+            self.assertEqual(combined.arcs(fred, contexts=['red']), self.ARCS)
+            self.assertEqual(combined.arcs(fred, contexts=['blue']), [])
+            self.assertEqual(combined.arcs(fblue, contexts=['red']), [])
+            self.assertEqual(combined.arcs(fblue, contexts=['blue']), self.ARCS)
 
 
 class DynamicContextTest(CoverageTest):
@@ -154,9 +154,9 @@ class DynamicContextTest(CoverageTest):
         full_names = {os.path.basename(f): f for f in data.measured_files()}
         fname = full_names["two_tests.py"]
         self.assertCountEqual(data.measured_contexts(), ["", "test_one", "test_two"])
-        self.assertCountEqual(data.lines(fname, ""), self.OUTER_LINES)
-        self.assertCountEqual(data.lines(fname, "test_one"), self.TEST_ONE_LINES)
-        self.assertCountEqual(data.lines(fname, "test_two"), self.TEST_TWO_LINES)
+        self.assertCountEqual(data.lines(fname, [""]), self.OUTER_LINES)
+        self.assertCountEqual(data.lines(fname, ["test_one"]), self.TEST_ONE_LINES)
+        self.assertCountEqual(data.lines(fname, ["test_two"]), self.TEST_TWO_LINES)
 
     def test_static_and_dynamic(self):
         self.make_file("two_tests.py", self.SOURCE)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -95,6 +95,30 @@ class HtmlTestHelpers(CoverageTest):
         )
 
 
+class HtmlWithContextsTest(HtmlTestHelpers, CoverageTest):
+    """Tests of the HTML reports with shown contexts."""
+
+    def setUp(self):
+        super(HtmlWithContextsTest, self).setUp()
+
+        # At least one of our tests monkey-patches the version of coverage.py,
+        # so grab it here to restore it later.
+        self.real_coverage_version = coverage.__version__
+        self.addCleanup(setattr, coverage, "__version__", self.real_coverage_version)
+
+    def test_html_created(self):
+        # Test basic HTML generation: files should be created.
+        self.create_initial_files()
+        self.run_coverage(htmlargs={'show_contexts': True})
+
+        self.assert_exists("htmlcov/index.html")
+        self.assert_exists("htmlcov/main_file_py.html")
+        self.assert_exists("htmlcov/helper1_py.html")
+        self.assert_exists("htmlcov/helper2_py.html")
+        self.assert_exists("htmlcov/style.css")
+        self.assert_exists("htmlcov/coverage_html.js")
+
+
 class HtmlDeltaTest(HtmlTestHelpers, CoverageTest):
     """Tests of the HTML delta speed-ups."""
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -997,15 +997,15 @@ class DynamicContextPluginTest(CoverageTest):
         )
         self.assertEqual(
             [2],
-            data.lines(filenames['rendering.py'], context="doctest:HTML_TAG"),
+            data.lines(filenames['rendering.py'], contexts=["doctest:HTML_TAG"]),
         )
         self.assertEqual(
             [2],
-            data.lines(filenames['rendering.py'], context="test:HTML_TAG"),
+            data.lines(filenames['rendering.py'], contexts=["test:HTML_TAG"]),
         )
         self.assertEqual(
             [2, 5, 8, 11],
-            data.lines(filenames['rendering.py'], context="test:RENDERERS"),
+            data.lines(filenames['rendering.py'], contexts=["test:RENDERERS"]),
         )
 
     def test_static_context(self):
@@ -1047,20 +1047,20 @@ class DynamicContextPluginTest(CoverageTest):
         data = cov.get_data()
         filenames = self.get_measured_filenames(data)
         self.assertEqual(
-            ['', 'doctest:HTML_TAG', 'test_html_tag', 'test_renderers'],
+            ['', 'doctest:HTML_TAG', 'testsuite.test_html_tag', 'testsuite.test_renderers'],
             sorted(data.measured_contexts()),
         )
         self.assertEqual(
             [2],
-            data.lines(filenames['rendering.py'], context="doctest:HTML_TAG"),
+            data.lines(filenames['rendering.py'], contexts=["doctest:HTML_TAG"]),
         )
         self.assertEqual(
             [2],
-            data.lines(filenames['rendering.py'], context="test_html_tag"),
+            data.lines(filenames['rendering.py'], contexts=["testsuite.test_html_tag"]),
         )
         self.assertEqual(
             [2, 5, 8, 11],
-            data.lines(filenames['rendering.py'], context="test_renderers"),
+            data.lines(filenames['rendering.py'], contexts=["testsuite.test_renderers"]),
         )
 
     def test_multiple_plugins(self):
@@ -1094,23 +1094,23 @@ class DynamicContextPluginTest(CoverageTest):
         self.assertEqual(expected, sorted(data.measured_contexts()))
         self.assertEqual(
             [2],
-            data.lines(filenames['rendering.py'], context="test:HTML_TAG"),
+            data.lines(filenames['rendering.py'], contexts=["test:HTML_TAG"]),
         )
         self.assertEqual(
             [2, 5, 8, 11],
-            data.lines(filenames['rendering.py'], context="test:RENDERERS"),
+            data.lines(filenames['rendering.py'], contexts=["test:RENDERERS"]),
         )
         self.assertEqual(
             [2],
-            data.lines(filenames['rendering.py'], context="doctest:HTML_TAG"),
+            data.lines(filenames['rendering.py'], contexts=["doctest:HTML_TAG"]),
         )
         self.assertEqual(
             [2, 5],
-            data.lines(filenames['rendering.py'], context="renderer:paragraph"),
+            data.lines(filenames['rendering.py'], contexts=["renderer:paragraph"]),
         )
         self.assertEqual(
             [2, 8],
-            data.lines(filenames['rendering.py'], context="renderer:span"),
+            data.lines(filenames['rendering.py'], contexts=["renderer:span"]),
         )
 
 


### PR DESCRIPTION
This PR implements context-based reporting in two ways:

1. Select the contexts to report on in the "report" and "html" reporting function. (Globs are supported)

```
  $ coverage report --contexts=my.pkg.sub1*,my.pkg.sub2* ...
```
This feature in combination with `--include` allows you to ensure that the tests for a particular sub-package cover the package itself as expected.

2. Report the contexts in which a line was covered as part of the HTML coverage report. For each covered line, a little hover target is provided that gives you a popover witht he contexts. It can be invoked using:

```
  $ coverage html --show-contexts ...
```

In order to accomplish implement the feature, we made the following extensions:

1. Function contexts are now fully-qualified Python paths. This allows you to select a group of contexts easily and avoids incorrect context reporting due to identical names.

2. The signature of `CoverageData.lines(filename, context=None)` and `CoverageData.arcs(filename, context=None)` changed to expecting multiple context specs. The `context` argument got renamed to `contexts`.

3. The `CoverageData` classes grew a method `set_query_contexts(contexts=None)` that allows one to set contexts for all read operations. This is not just a convenience method, but also an important optimization, since we can cache the context id lookup, which is expensive on a larger code base with lots of tests. (We produced 14k contexts and are frequently selecting a few 1k contexts for analysis.)

4. The `CoverageData` classes grew a method called `contexts_by_lineno(filename)` that reports the contexts for each covered line of a given file. It uses a simple join to make that lookup most efficient.

5. The `CoverageJsonData` class was adjusted to handle all new context argumetns and methods and provides decent defaults that mimic ignoring contexts completely.

@nedbat Please let me know what you need us to do in order to get this PR accepted:

1. Where would be a good place to document the new functionality?

2. The `test_data.py` and `test_html.py` tests are a bit of a mess (and you seem to agree based on the comments in them), so how much do you want us to test the new functionality? The entire project is not 100% code covered so it is hard to tell what we are missing.

3. I have tried to conform to your coding style as much as possible, but sometimes it was not clear especially line width. If you could review the code, then I will fix things up.