### PR TITLE
Fix canonical filename cache.

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -59,6 +59,7 @@ def canonical_filename(filename):
 
     """
     if filename not in CANONICAL_FILENAME_CACHE:
+        cf = filename
         if not os.path.isabs(filename):
             for path in [os.curdir] + sys.path:
                 if path is None:
@@ -69,9 +70,9 @@ def canonical_filename(filename):
                 except UnicodeError:
                     exists = False
                 if exists:
-                    filename = f
+                    cf = f
                     break
-        cf = abs_file(filename)
+        cf = abs_file(cf)
         CANONICAL_FILENAME_CACHE[filename] = cf
     return CANONICAL_FILENAME_CACHE[filename]
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -57,6 +57,19 @@ class FilesTest(CoverageTest):
         rel = os.path.join('sub', trick, 'file1.py')
         self.assertEqual(files.relative_filename(abs_file(rel)), rel)
 
+    def test_canonical_filename_ensure_cache_hit(self):
+        self.make_file("sub/proj1/file1.py")
+        d = os.path.normpath("sub/proj1")
+        self.chdir(d)
+        files.set_relative_directory()
+        canonical_path = files.canonical_filename('sub/proj1/file1.py')
+        self.assertEqual(canonical_path, self.abs_path('file1.py'))
+        # After the filename has been converted, it should be in the cache.
+        self.assertIn('sub/proj1/file1.py', files.CANONICAL_FILENAME_CACHE)
+        self.assertEqual(
+            files.canonical_filename('sub/proj1/file1.py'),
+            self.abs_path('file1.py'))
+
 
 @pytest.mark.parametrize("original, flat", [
     (u"a/b/c.py", u"a_b_c_py"),


### PR DESCRIPTION
On our systems with a large `sys.path` this improves performance by 25x.

(Note: It is always a bad idea to reassign the cachekey during the computation.)