### PR TITLE
Distinct list values for  `CoverageSqliteData.arcs()` and `CoverageSqliteData.lines()`

### DIFF
--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -468,7 +468,7 @@ class CoverageSqliteData(SimpleReprMixin):
             if file_id is None:
                 return None
             else:
-                query = "select lineno from line where file_id = ?"
+                query = "select distinct lineno from line where file_id = ?"
                 data = [file_id]
                 if context is not None:
                     query += " and context_id = ?"
@@ -483,7 +483,7 @@ class CoverageSqliteData(SimpleReprMixin):
             if file_id is None:
                 return None
             else:
-                query = "select fromno, tono from arc where file_id = ?"
+                query = "select distinct fromno, tono from arc where file_id = ?"
                 data = [file_id]
                 if context is not None:
                     query += " and context_id = ?"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -199,6 +199,22 @@ class CoverageDataTest(DataTestHelpers, CoverageTest):
         covdata.add_run_info(count=17)
         self.assertEqual(covdata.run_infos(), [{"hello": "there", "count": 17}])
 
+    def test_no_duplicate_lines(self):
+        covdata = CoverageData()
+        covdata.set_context("context1")
+        covdata.add_lines(LINES_1)
+        covdata.set_context("context2")
+        covdata.add_lines(LINES_1)
+        self.assertEqual(covdata.lines('a.py'), A_PY_LINES_1)
+
+    def test_no_duplicate_arcs(self):
+        covdata = CoverageData()
+        covdata.set_context("context1")
+        covdata.add_arcs(ARCS_3)
+        covdata.set_context("context2")
+        covdata.add_arcs(ARCS_3)
+        self.assertEqual(covdata.arcs('x.py'), X_PY_ARCS_3)
+
     def test_no_arcs_vs_unmeasured_file(self):
         covdata = CoverageData()
         covdata.add_arcs(ARCS_3)


### PR DESCRIPTION
Now the return values properly reflect the data from the JSON data implementation.

(It is also a huge performance improvement!)