### PR TITLE
Expose switch_context in coverage API

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -477,6 +477,20 @@ class Coverage(object):
         self._data.erase(parallel=self.config.parallel)
         self._data = None
 
+    def switch_context(self, new_context):
+        """Switch to a new dynamic context.
+
+        `new_context` is a string to use as the context label
+        for collected data.
+
+        Coverage collection must be started already.
+        """
+        if not self._started:
+            raise CoverageException(                    # pragma: only jython
+                "Cannot switch context, coverage is not started"
+                )
+        self._collector.switch_context(new_context)
+
     def clear_exclude(self, which='exclude'):
         """Clear the exclude list."""
         self._init()

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -484,6 +484,8 @@ class Coverage(object):
         for collected data.
 
         Coverage collection must be started already.
+
+        .. versionadded:: 5.0
         """
         if not self._started:
             raise CoverageException(                    # pragma: only jython

--- a/tests/coveragetest.py
+++ b/tests/coveragetest.py
@@ -8,6 +8,7 @@ import datetime
 import functools
 import glob
 import os
+import os.path
 import random
 import re
 import shlex
@@ -513,6 +514,15 @@ class CoverageTest(
     def last_line_squeezed(self, report):
         """Return the last line of `report` with the spaces squeezed down."""
         return self.squeezed_lines(report)[-1]
+
+    def get_measured_filenames(self, coverage_data):
+        """Get paths to measured files.
+
+        Returns a dict of {filename: absolute path to file}
+        for given CoverageData.
+        """
+        return {os.path.basename(filename): filename
+                for filename in coverage_data.measured_files()}
 
 
 class UsingModulesMixin(object):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -494,7 +494,7 @@ class ApiTest(CoverageTest):
 
         Returns absolute path to the file.
         """
-        filename = self.make_file("testsuite.py", """\
+        self.make_file("testsuite.py", """\
             def timestwo(x):
                 return x*2
 
@@ -504,12 +504,11 @@ class ApiTest(CoverageTest):
             def test_multiply_six():
                 assert timestwo(6) == 12
             """)
-        return os.path.abspath(filename)
 
     def test_switch_context_testrunner(self):
         # This test simulates a coverage-aware test runner,
         # measuring labeled coverage via public API
-        suite_filename = self.make_testsuite()
+        self.make_testsuite()
 
         # Test runner starts
         cov = coverage.Coverage()
@@ -536,6 +535,9 @@ class ApiTest(CoverageTest):
             sorted(data.measured_contexts()),
             [u'', u'multiply_six', u'multiply_zero'])
 
+        filenames = self.get_measured_filenames(data)
+        suite_filename = filenames['testsuite.py']
+
         self.assertEqual(
             data.lines(suite_filename, context="multiply_six"),
             [2, 8])
@@ -547,7 +549,7 @@ class ApiTest(CoverageTest):
         # This test simulates a coverage-aware test runner,
         # measuring labeled coverage via public API,
         # with static label prefix.
-        suite_filename = self.make_testsuite()
+        self.make_testsuite()
 
         # Test runner starts
         cov = coverage.Coverage(context="mysuite")
@@ -573,6 +575,9 @@ class ApiTest(CoverageTest):
         self.assertEqual(
             sorted(data.measured_contexts()),
             [u'mysuite', u'mysuite:multiply_six', u'mysuite:multiply_zero'])
+
+        filenames = self.get_measured_filenames(data)
+        suite_filename = filenames['testsuite.py']
 
         self.assertEqual(
             data.lines(suite_filename, context="mysuite:multiply_six"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -489,6 +489,112 @@ class ApiTest(CoverageTest):
             b.py        1      0   100%
             """))
 
+    def make_testsuite(self):
+        """Create a simple file representing a method with two tests.
+
+        Returns absolute path to the file.
+        """
+        filename = self.make_file("testsuite.py", """\
+            def timestwo(x):
+                return x*2
+
+            def test_multiply_zero():
+                assert timestwo(0) == 0
+
+            def test_multiply_six():
+                assert timestwo(6) == 12
+            """)
+        return os.path.abspath(filename)
+
+    def test_switch_context_testrunner(self):
+        # This test simulates a coverage-aware test runner,
+        # measuring labeled coverage via public API
+        suite_filename = self.make_testsuite()
+
+        # Test runner starts
+        cov = coverage.Coverage()
+        cov.start()
+
+        # Imports the test suite
+        suite = import_local_file("testsuite")
+
+        # Measures test case 1
+        cov.switch_context('multiply_zero')
+        suite.test_multiply_zero()
+
+        # Measures test case 2
+        cov.switch_context('multiply_six')
+        suite.test_multiply_six()
+
+        # Runner finishes
+        cov.save()
+        cov.stop()
+
+        # Labeled data is collected
+        data = cov.get_data()
+        self.assertEqual(
+            sorted(data.measured_contexts()),
+            [u'', u'multiply_six', u'multiply_zero'])
+
+        self.assertEqual(
+            data.lines(suite_filename, context="multiply_six"),
+            [2, 8])
+        self.assertEqual(
+            data.lines(suite_filename, context="multiply_zero"),
+            [2, 5])
+
+    def test_switch_context_with_static(self):
+        # This test simulates a coverage-aware test runner,
+        # measuring labeled coverage via public API,
+        # with static label prefix.
+        suite_filename = self.make_testsuite()
+
+        # Test runner starts
+        cov = coverage.Coverage(context="mysuite")
+        cov.start()
+
+        # Imports the test suite
+        suite = import_local_file("testsuite")
+
+        # Measures test case 1
+        cov.switch_context('multiply_zero')
+        suite.test_multiply_zero()
+
+        # Measures test case 2
+        cov.switch_context('multiply_six')
+        suite.test_multiply_six()
+
+        # Runner finishes
+        cov.save()
+        cov.stop()
+
+        # Labeled data is collected
+        data = cov.get_data()
+        self.assertEqual(
+            sorted(data.measured_contexts()),
+            [u'mysuite', u'mysuite:multiply_six', u'mysuite:multiply_zero'])
+
+        self.assertEqual(
+            data.lines(suite_filename, context="mysuite:multiply_six"),
+            [2, 8])
+        self.assertEqual(
+            data.lines(suite_filename, context="mysuite:multiply_zero"),
+            [2, 5])
+
+    def test_switch_context_unstarted(self):
+        # Coverage must be started to switch context
+
+        cov = coverage.Coverage()
+        with self.assertRaises(CoverageException):
+            cov.switch_context("test1")
+
+        cov.start()
+        cov.switch_context("test2")
+
+        cov.stop()
+        with self.assertRaises(CoverageException):
+            cov.switch_context("test3")
+
 
 class NamespaceModuleTest(UsingModulesMixin, CoverageTest):
     """Test PEP-420 namespace modules."""


### PR DESCRIPTION
This PR adds `Coverage.switch_context` method.

I think this is a quite efficient way to expose dynamic context to test runners that already use coverage API.

For example, `nose` test runner:  https://nose.readthedocs.io/en/latest/plugins/cover.html
The runner already knows the test case name, so there is no need to check each frame dymamically if it entered a test function.   In addition, this would allow runners to report labels consistently with their test case name format.

Excerpt from `nose` coverage support:
```python
class Coverage(Plugin):
<...>

    def configure(self, options, conf):
        <...>
        if self.enabled:
            self.status['active'] = True
            self.coverInstance = coverage.coverage(auto_data=False,
                branch=self.coverBranches, data_suffix=conf.worker,
                source=self.coverPackages, config_file=self.coverConfigFile)
            self.coverInstance._warn_no_data = False
            self.coverInstance.is_worker = conf.worker
            self.coverInstance.exclude('#pragma[: ]+[nN][oO] [cC][oO][vV][eE][rR]')
        <...>

    def beforeTest(self, *args, **kwargs):
        """
        Begin recording coverage information.
        """

        if self.coverInstance.is_worker:
            self.coverInstance.load()
            self.coverInstance.start()
```

What do you think about this approach?