### PR TITLE
Plugin support for dynamic context

### DIFF
--- a/coverage/plugin.py
+++ b/coverage/plugin.py
@@ -78,6 +78,26 @@ change the configuration.
 In your ``coverage_init`` function, use the ``add_configurer`` method to
 register your configurer.
 
+Dynamic Contexts
+================
+
+.. versionadded:: 5.0
+
+Context plugins implement the :meth:`~coverage.CoveragePlugin.dynamic_context` method
+to dynamically compute the context label for each measured frame.
+
+Computed context labels are useful when you want to group measured data without
+modifying the source code.
+
+For example, you could write a plugin that inspects `frame.f_code` to get the
+the currently executed method, and set label to a fully qualified method
+name if it's an instance method of unittest.TestCase and method name starts
+with 'test_'.  Such plugin would provide basic coverage grouping by unit
+test for test runners that have no built-in support for coveragepy.
+
+In your ``coverage_init`` function, use the ``add_dynamic_context`` method to
+register your file tracer.
+
 """
 
 from coverage import files
@@ -139,6 +159,17 @@ class CoveragePlugin(object):
 
         """
         _needs_to_implement(self, "file_reporter")
+
+    def dynamic_context(self, frame):       # pylint: disable=unused-argument
+        """Get dynamically computed context label for collected data.
+
+        Plug-in type: dynamic context.
+
+        This method is invoked for each frame.  If it returns a string,
+        a new context label is set for this and deeper frames.
+
+        """
+        return None
 
     def find_executable_files(self, src_dir):       # pylint: disable=unused-argument
         """Yield all of the executable files in `src_dir`, recursively.

--- a/coverage/plugin.py
+++ b/coverage/plugin.py
@@ -89,11 +89,11 @@ to dynamically compute the context label for each measured frame.
 Computed context labels are useful when you want to group measured data without
 modifying the source code.
 
-For example, you could write a plugin that inspects `frame.f_code` to get the
+For example, you could write a plugin that check `frame.f_code` to inspect
 the currently executed method, and set label to a fully qualified method
-name if it's an instance method of unittest.TestCase and method name starts
-with 'test_'.  Such plugin would provide basic coverage grouping by unit
-test for test runners that have no built-in support for coveragepy.
+name if it's an instance method of `unittest.TestCase` and the method name
+starts with 'test'.  Such plugin would provide basic coverage grouping by test
+and could be used with test runners that have no built-in coveragepy support.
 
 In your ``coverage_init`` function, use the ``add_dynamic_context`` method to
 register your file tracer.

--- a/coverage/plugin_support.py
+++ b/coverage/plugin_support.py
@@ -21,6 +21,7 @@ class Plugins(object):
         self.names = {}
         self.file_tracers = []
         self.configurers = []
+        self.context_switchers = []
 
         self.current_module = None
         self.debug = None
@@ -69,6 +70,15 @@ class Plugins(object):
 
         """
         self._add_plugin(plugin, self.configurers)
+
+    def add_dynamic_context(self, plugin):
+        """Add a dynamic context plugin.
+
+        `plugin` is an instance of a third-party plugin class.  It must
+        implement the :meth:`CoveragePlugin.dynamic_context` method.
+
+        """
+        self._add_plugin(plugin, self.context_switchers)
 
     def add_noop(self, plugin):
         """Add a plugin that does nothing.

--- a/tests/coveragetest.py
+++ b/tests/coveragetest.py
@@ -8,6 +8,7 @@ import datetime
 import functools
 import glob
 import os
+import os.path
 import random
 import re
 import shlex
@@ -513,6 +514,15 @@ class CoverageTest(
     def last_line_squeezed(self, report):
         """Return the last line of `report` with the spaces squeezed down."""
         return self.squeezed_lines(report)[-1]
+
+    def get_measured_filenames(self, coverage_data):
+        """Get paths to measured files.
+
+        Returns a dict of {filename: absolute path to file}
+        for given CoverageData.
+        """
+        return {os.path.basename(filename): filename
+                for filename in coverage_data.measured_files()}
 
 
 class UsingModulesMixin(object):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -916,7 +916,7 @@ class DynamicContextPluginTest(CoverageTest):
 
     def make_testsuite(self):
         filenames = []
-        filename_rendering = self.make_file("rendering.py", """\
+        self.make_file("rendering.py", """\
             def html_tag(tag, content):
                 return '<%s>%s</%s>' % (tag, content, tag)
 
@@ -930,7 +930,7 @@ class DynamicContextPluginTest(CoverageTest):
                 return html_tag('b', text)
                 """)
 
-        filename_testsuite = self.make_file("testsuite.py", """\
+        self.make_file("testsuite.py", """\
             import rendering
 
             def test_html_tag():
@@ -953,11 +953,6 @@ class DynamicContextPluginTest(CoverageTest):
                 return html
             """)
 
-        return {
-            filename: os.path.abspath(filename)
-            for filename in [filename_rendering, filename_testsuite]
-            }
-
     def run_testsuite(self, coverage, suite_name):
         coverage.start()
         suite = import_local_file(suite_name)
@@ -973,7 +968,7 @@ class DynamicContextPluginTest(CoverageTest):
 
     def test_plugin_standalone(self):
         self.make_plugin_capitalized_testnames('plugin_tests.py')
-        filenames = self.make_testsuite()
+        self.make_testsuite()
 
         # Enable dynamic context plugin
         cov = coverage.Coverage()
@@ -984,6 +979,7 @@ class DynamicContextPluginTest(CoverageTest):
 
         # Labeled coverage is collected
         data = cov.get_data()
+        filenames = self.get_measured_filenames(data)
         self.assertEqual(
             sorted(data.measured_contexts()),
             ['', 'doctest:HTML_TAG', 'test:HTML_TAG', 'test:RENDERERS'])
@@ -999,7 +995,7 @@ class DynamicContextPluginTest(CoverageTest):
 
     def test_static_context(self):
         self.make_plugin_capitalized_testnames('plugin_tests.py')
-        filenames = self.make_testsuite()
+        self.make_testsuite()
 
         # Enable dynamic context plugin for coverage with named context
         cov = coverage.Coverage(context='mytests')
@@ -1010,6 +1006,7 @@ class DynamicContextPluginTest(CoverageTest):
 
         # Static context prefix is preserved
         data = cov.get_data()
+        filenames = self.get_measured_filenames(data)
         self.assertEqual(
             sorted(data.measured_contexts()),
             ['mytests',
@@ -1019,7 +1016,7 @@ class DynamicContextPluginTest(CoverageTest):
 
     def test_plugin_with_test_function(self):
         self.make_plugin_capitalized_testnames('plugin_tests.py')
-        filenames = self.make_testsuite()
+        self.make_testsuite()
 
         # Enable both a plugin and test_function dynamic context
         cov = coverage.Coverage()
@@ -1033,6 +1030,7 @@ class DynamicContextPluginTest(CoverageTest):
         # functions that are not labeled by test_function are
         # labeled by plugin_tests.
         data = cov.get_data()
+        filenames = self.get_measured_filenames(data)
         self.assertEqual(
             sorted(data.measured_contexts()),
             ['', 'doctest:HTML_TAG', 'test_html_tag', 'test_renderers'])
@@ -1049,7 +1047,7 @@ class DynamicContextPluginTest(CoverageTest):
     def test_multiple_plugins(self):
         self.make_plugin_capitalized_testnames('plugin_tests.py')
         self.make_plugin_track_render('plugin_renderers.py')
-        filenames = self.make_testsuite()
+        self.make_testsuite()
 
         # Enable two plugins
         cov = coverage.Coverage()
@@ -1065,6 +1063,7 @@ class DynamicContextPluginTest(CoverageTest):
         # render_paragraph and render_span (lines 5, 8) are directly called by
         # testsuite.build_full_html, so they get labeled by renderers plugin.
         data = cov.get_data()
+        filenames = self.get_measured_filenames(data)
         self.assertEqual(
             sorted(data.measured_contexts()),
             ['',


### PR DESCRIPTION
This PR allows writing simple dynamic context plugins.

```python
class TestMethodPlugin(coverage.CoveragePlugin):

    def dynamic_context(self, frame):
        if frame.f_code.co_name.startswith("test_"):
            return coverage.context.qualname_from_frame(frame)
        return None

def coverage_init(reg, options):
    reg.add_dynamic_context(TestMethodPlugin())
```

I kept the `dynamic_context = test_function` setting for backwards compatibility.