### PR TITLE
[postponed] Set f_trace_lines = 0/False on ignored frames

### DIFF
--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -535,7 +535,9 @@ CTracer_handle_call(CTracer *self, PyFrameObject *frame)
         self->pcur_entry->file_data = NULL;
         self->pcur_entry->file_tracer = Py_None;
         SHOWLOG(self->pdata_stack->depth, frame->f_lineno, filename, "skipped");
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
         frame->f_trace_lines = 0;
+#endif
     }
 
     self->pcur_entry->disposition = disposition;

--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -382,7 +382,7 @@ CTracer_handle_call(CTracer *self, PyFrameObject *frame)
         self->pcur_entry->started_context = FALSE;
     }
 
-    /* Check if we should trace this line. */
+    /* Check if we should trace this code block. */
     filename = frame->f_code->co_filename;
     disposition = PyDict_GetItem(self->should_trace_cache, filename);
     if (disposition == NULL) {
@@ -535,6 +535,7 @@ CTracer_handle_call(CTracer *self, PyFrameObject *frame)
         self->pcur_entry->file_data = NULL;
         self->pcur_entry->file_tracer = Py_None;
         SHOWLOG(self->pdata_stack->depth, frame->f_lineno, filename, "skipped");
+        frame->f_trace_lines = 0;
     }
 
     self->pcur_entry->disposition = disposition;

--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -15,6 +15,9 @@ if env.PY2:
     YIELD_VALUE = chr(YIELD_VALUE)
 
 
+HAS_F_TRACE_LINES = sys.version_info >= (3, 7)
+
+
 class PyTracer(object):
     """Python implementation of the raw data tracer."""
 
@@ -118,7 +121,8 @@ class PyTracer(object):
                     self.data[tracename] = {}
                 self.cur_file_dict = self.data[tracename]
             else:
-                frame.f_trace_lines = False
+                if HAS_F_TRACE_LINES:
+                    frame.f_trace_lines = False
             # The call event is really a "start frame" event, and happens for
             # function calls and re-entering generators.  The f_lasti field is
             # -1 for calls, and a real offset for generators.  Use <0 as the

--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -117,6 +117,8 @@ class PyTracer(object):
                 if tracename not in self.data:
                     self.data[tracename] = {}
                 self.cur_file_dict = self.data[tracename]
+            else:
+                frame.f_trace_lines = False
             # The call event is really a "start frame" event, and happens for
             # function calls and re-entering generators.  The f_lasti field is
             # -1 for calls, and a real offset for generators.  Use <0 as the


### PR DESCRIPTION
This is meant for optimization, so that the trace handler is not called
for lines in blocks that are not traced.

TODO:

- [ ] needs fix in cpython (https://bugs.python.org/issue36494), or another way to reset/restore it then
- [ ] test ?