### PR TITLE
Document about incremental report generation in html_report

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -784,6 +784,10 @@ class Coverage(object):
 
         Returns a float, the total percentage covered.
 
+        .. warning::
+            HTML report is generated in incremental way. You should be
+            careful about mutating the files in the folder where the
+            HTML report is generated.
         """
         self.config.from_args(
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,


### PR DESCRIPTION
I see it was in one of the old releases,
https://coverage.readthedocs.io/en/v4.5.x/changes.html#version-3-5b1-2011-06-05
but I think it is not documented well in the api docs.

We had an issue in https://github.com/sympy/sympy/pull/16694 because we had been mutating the files without getting warned.

I have used `.. warning::` directive, and here is the new doc

<img src=https://user-images.githubusercontent.com/34944973/56499928-a95a6a80-6543-11e9-921e-7d48e9b4c755.png width=512px>

I think there are some other details about how the incremental reporting works. For example, I find that the `index.html` is regenerated, but other html files are not regenerated after deleting manually.
Also, is there an option to generate the full report from scratch with subsequent calls?