### PR TITLE
Fix mutated html report file not recovered in subsequent run

### DIFF
--- a/coverage/html.py
+++ b/coverage/html.py
@@ -376,7 +376,7 @@ class HtmlStatus(object):
         usable = False
         try:
             status_file = os.path.join(directory, self.STATUS_FILE)
-            with open(status_file, "r") as fstatus:
+            with open(status_file) as fstatus:
                 status = json.load(fstatus)
         except (IOError, ValueError):
             usable = False

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -198,10 +198,8 @@ class HtmlReporter(Reporter):
         if os.path.isfile(html_path):
             this_hash = ""
             with open(html_path, "rb") as f:
-                hasher = Hasher()
                 html_str = f.read().decode("UTF-8")
-                hasher.update(source + html_str)
-                this_hash = hasher.hexdigest()
+                this_hash = self.file_hash(source + html_str, fr)
             that_hash = self.status.file_hash(rootname)
 
             if this_hash == that_hash:
@@ -294,10 +292,8 @@ class HtmlReporter(Reporter):
         write_html(html_path, html)
 
         with open(html_path, "rb") as f:
-            hasher = Hasher()
             html_str = f.read().decode("UTF-8")
-            hasher.update(source + html_str)
-            this_hash = hasher.hexdigest()
+            this_hash = self.file_hash(source + html_str, fr)
             self.status.set_file_hash(rootname, this_hash)
 
         # Save this file's information for the index file.

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -199,7 +199,9 @@ class HtmlReporter(Reporter):
             this_hash = ""
             with open(html_path, "rb") as f:
                 hasher = Hasher()
-                hasher.update(f.read().decode("UTF-8"))
+                html_str = f.read().decode("UTF-8")
+                source_str = source.encode('UTF-8')
+                hasher.update(source_str + html_str)
                 this_hash = hasher.hexdigest()
             that_hash = self.status.file_hash(rootname)
 
@@ -294,7 +296,9 @@ class HtmlReporter(Reporter):
 
         with open(html_path, "rb") as f:
             hasher = Hasher()
-            hasher.update(f.read().decode("UTF-8"))
+            html_str = f.read().decode("UTF-8")
+            source_str = source.encode('UTF-8')
+            hasher.update(source_str + html_str)
             this_hash = hasher.hexdigest()
             self.status.set_file_hash(rootname, this_hash)
 

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -197,9 +197,9 @@ class HtmlReporter(Reporter):
         # Find out if the file on disk is already correct.
         if os.path.isfile(html_path):
             this_hash = ""
-            with open(html_path, "r", encoding="utf-8") as f:
+            with open(html_path, "rb") as f:
                 hasher = Hasher()
-                hasher.update(f.read())
+                hasher.update(f.read().decode("UTF-8"))
                 this_hash = hasher.hexdigest()
             that_hash = self.status.file_hash(rootname)
 
@@ -292,9 +292,9 @@ class HtmlReporter(Reporter):
 
         write_html(html_path, html)
 
-        with open(html_path, "r", encoding="utf-8") as f:
+        with open(html_path, "rb") as f:
             hasher = Hasher()
-            hasher.update(f.read())
+            hasher.update(f.read().decode("UTF-8"))
             this_hash = hasher.hexdigest()
             self.status.set_file_hash(rootname, this_hash)
 

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -200,8 +200,7 @@ class HtmlReporter(Reporter):
             with open(html_path, "rb") as f:
                 hasher = Hasher()
                 html_str = f.read().decode("UTF-8")
-                source_str = source.encode('UTF-8')
-                hasher.update(source_str + html_str)
+                hasher.update(source + html_str)
                 this_hash = hasher.hexdigest()
             that_hash = self.status.file_hash(rootname)
 
@@ -297,8 +296,7 @@ class HtmlReporter(Reporter):
         with open(html_path, "rb") as f:
             hasher = Hasher()
             html_str = f.read().decode("UTF-8")
-            source_str = source.encode('UTF-8')
-            hasher.update(source_str + html_str)
+            hasher.update(source + html_str)
             this_hash = hasher.hexdigest()
             self.status.set_file_hash(rootname, this_hash)
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -141,11 +141,11 @@ class HtmlDeltaTest(HtmlTestHelpers, CoverageTest):
 
         self.run_coverage()
 
-        # Only the changed files should have been created.
+        # Deleted files should be recreated
         self.assert_exists("htmlcov/index.html")
         self.assert_exists("htmlcov/helper1_py.html")
-        self.assert_doesnt_exist("htmlcov/main_file_py.html")
-        self.assert_doesnt_exist("htmlcov/helper2_py.html")
+        self.assert_exists("htmlcov/main_file_py.html")
+        self.assert_exists("htmlcov/helper2_py.html")
         index2 = self.get_html_index_content()
         self.assertMultiLineEqual(index1, index2)
 
@@ -165,11 +165,11 @@ class HtmlDeltaTest(HtmlTestHelpers, CoverageTest):
 
         self.run_coverage()
 
-        # Only the changed files should have been created.
+        # Deleted files should be recreated
         self.assert_exists("htmlcov/index.html")
         self.assert_exists("htmlcov/helper1_py.html")
         self.assert_exists("htmlcov/main_file_py.html")
-        self.assert_doesnt_exist("htmlcov/helper2_py.html")
+        self.assert_exists("htmlcov/helper2_py.html")
 
     def test_html_delta_from_settings_change(self):
         # HTML generation can create only the files that have changed.

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -141,11 +141,11 @@ class HtmlDeltaTest(HtmlTestHelpers, CoverageTest):
 
         self.run_coverage()
 
-        # Deleted files should be recreated
+        # Only the changed files should have been created.
         self.assert_exists("htmlcov/index.html")
         self.assert_exists("htmlcov/helper1_py.html")
-        self.assert_exists("htmlcov/main_file_py.html")
-        self.assert_exists("htmlcov/helper2_py.html")
+        self.assert_doesnt_exist("htmlcov/main_file_py.html")
+        self.assert_doesnt_exist("htmlcov/helper2_py.html")
         index2 = self.get_html_index_content()
         self.assertMultiLineEqual(index1, index2)
 
@@ -165,11 +165,11 @@ class HtmlDeltaTest(HtmlTestHelpers, CoverageTest):
 
         self.run_coverage()
 
-        # Deleted files should be recreated
+        # Only the changed files should have been created.
         self.assert_exists("htmlcov/index.html")
         self.assert_exists("htmlcov/helper1_py.html")
         self.assert_exists("htmlcov/main_file_py.html")
-        self.assert_exists("htmlcov/helper2_py.html")
+        self.assert_doesnt_exist("htmlcov/helper2_py.html")
 
     def test_html_delta_from_settings_change(self):
         # HTML generation can create only the files that have changed.


### PR DESCRIPTION
Closes #798

Okay, I have found that there is a hash validation scheme.
But it is only comparing the hash of the coverage data residing in the memory, with the hash written in `status.json`

I think that the hash scheme should be changed, so that the hash of the actual file should be written in the json, and used in comparison.

This is an initial draft to fix the bug I have encountered.
