### PR TITLE
Upgrade to PyPy 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ python:
   - '3.6'
   - '3.7'
   - '3.8-dev'
-  - 'pypy2.7-6.0'
-  - 'pypy3.5-6.0'
+  - 'pypy'
+  - 'pypy3'
 
 env:
   matrix:


### PR DESCRIPTION
The basic `pypy` and `pypy3` now point to the latest PyPy releases: 

* https://travis-ci.community/t/add-pypy-7-support/2228/6?u=hugovk

Some arc tests are failing on PyPy 7.