### PR TITLE
Fix appending to .coverage if exec ends in non-existent directory

### DIFF
--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -193,7 +193,11 @@ class PyRunner(object):
 
         # Execute the code object.
         try:
+            # Return to the original directory in case the test code exits in
+            # a non-existent directory.
+            cwd = os.getcwd()
             exec(code, main_mod.__dict__)
+            os.chdir(cwd)
         except SystemExit:                          # pylint: disable=try-except-raise
             # The user called sys.exit().  Just pass it along to the upper
             # layers, where it will be handled.


### PR DESCRIPTION
The `--append` option causes `coverage run` to fail if the `<pyfile>` that is executed does a chdir to a directory that is subsequently removed before the exec completes.

For example, with the following file, `test.py`:

```python
import tempfile
import os

with tempfile.TemporaryDirectory() as tmpdir:
    os.chdir(tmpdir)
```
Run coverage on this as follows:
```
python -m coverage run --append test.py
```

This results in a `FileNotFoundError` because the SQLite database connector internally tries to find the relative path to the database file, which fails since the cwd does not exist. The traceback looks like:

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/x/repos/coveragepy/coverage/__main__.py", line 8, in <module>
    sys.exit(main())
  File "/home/x/repos/coveragepy/coverage/cmdline.py", line 762, in main
    status = CoverageScript().command_line(argv)
  File "/home/x/repos/coveragepy/coverage/cmdline.py", line 506, in command_line
    return self.do_run(options, args)
  File "/home/x/repos/coveragepy/coverage/cmdline.py", line 649, in do_run
    self.coverage.save()
  File "/home/x/repos/coveragepy/coverage/control.py", line 553, in save
    data = self.get_data()
  File "/home/x/repos/coveragepy/coverage/control.py", line 607, in get_data
    if self._collector and self._collector.flush_data():
  File "/home/x/repos/coveragepy/coverage/collector.py", line 425, in flush_data
    self.covdata.add_lines(abs_file_dict(self.data))
  File "/home/x/repos/coveragepy/coverage/sqldata.py", line 245, in add_lines
    self._choose_lines_or_arcs(lines=True)
  File "/home/x/repos/coveragepy/coverage/sqldata.py", line 288, in _choose_lines_or_arcs
    with self._connect() as con:
  File "/home/x/repos/coveragepy/coverage/sqldata.py", line 616, in __enter__
    self.connect()
  File "/home/x/repos/coveragepy/coverage/sqldata.py", line 601, in connect
    filename = os.path.relpath(self.filename)
  File "/usr/lib/python3.7/posixpath.py", line 475, in relpath
    start_list = [x for x in abspath(start).split(sep) if x]
  File "/usr/lib/python3.7/posixpath.py", line 383, in abspath
    cwd = os.getcwd()
FileNotFoundError: [Errno 2] No such file or directory
```

This patch avoids this problem by ensuring that we return to a known directory (the original directory we ran in) once the `exec` completes.

One could argue that it is the exec'd script's responsibility for ensuring that it doesn't end in an invalid directory, but it seems reasonable for `coverage` to handle this case since it can do so easily (and because temporary directories are likely to be a common occurrence in a test suite).

I believe this issue also warrants a unit test, but I couldn't make out the right way to do this after a perusal of the test suite. Please feel free to add a test or to guide me to a good example for how to implement it. Thank you!