### PR TITLE
WIP, ENH: add docstring cov to html

### DIFF
--- a/coverage/config.py
+++ b/coverage/config.py
@@ -206,6 +206,7 @@ class CoverageConfig(object):
         self.extra_css = None
         self.html_dir = "htmlcov"
         self.html_title = "Coverage report"
+        self.html_docstr = False
 
         # Defaults for [xml]
         self.xml_output = "coverage.xml"
@@ -353,6 +354,7 @@ class CoverageConfig(object):
         ('extra_css', 'html:extra_css'),
         ('html_dir', 'html:directory'),
         ('html_title', 'html:title'),
+        ('html_docstr', 'html:docstring_display'),
 
         # [xml]
         ('xml_output', 'xml:output'),

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -252,6 +252,13 @@ class HtmlReporter(Reporter):
                     )
             elif lineno in analysis.statements:
                 line_class.append(c_run)
+            elif self.config.html_docstr:
+                # count docstring line as "executed"
+                # doctest SKIP directives will not
+                # prevent a line from being marked
+                # as executed, but will influence
+                # the associated source code proper
+                line_class.append(c_run)
 
             # Build the HTML for the line.
             html = []


### PR DESCRIPTION
One of the items on the [wishlist](https://github.com/numpy/numpy/issues/12548) for testing docstrings in NumPy / SciPy is the ability to report "coverage" for those docstrings that are probed by doctesting infrastructure. In particular, I had in mind the idea that labels in the html coverage reports that one often finds as part of the CI for large OSS scientific projects might be expanded to include hits on docstrings.

This lead to me to a simple [example on StackOverflow](https://stackoverflow.com/a/45262687/2942522) by @rhettinger, which really got me excited even more. However, I noticed that executing the exact same code and trying to display with `coverage html` effectively ignores the docstring using both stable and master branch of `coveragepy`. I dug a little deeper and noticed that `coverage annotate` actually has a much shorter / simpler loop for doing the labelling vs. html, and I figured I'd take a look at the html assignment of lines to label classes, and see if I could get it to do what I want.

This PR has a draft of what I had in mind that I initially thought was working, but actually seems to be not quite right yet. There are probably various ecosystem considerations & things like trying to fuse these results with results that don't have docstrings labelled, etc. But if I I can't get this "simple" case to work, the prospects for expanding the "feature" usage to large packages wouldn't be great.

With this feature branch and my `.coveragerc` initially looking like this:
```
[html]
docstring_display = True
```

with the original example code from StackOverflow we get the docstring now highlighted along with the source itself that was ultimately executed by doctest:

![image](https://user-images.githubusercontent.com/7903078/58755030-33c1b280-8490-11e9-9768-4391d293edab.png)

and with a doctest SKIP directive added in to Raymond's example, another design question comes up--would it be possible / worth the trouble to have a separate highlight color / category for docstring examples that are not executed? (notice that the source proper is still correctly marked as not executed, since the docstring didn't get executed, although the docstring was "considered but skipped" so perhaps technically "covered"):

![image](https://user-images.githubusercontent.com/7903078/58754740-d9265780-848b-11e9-8368-450eb2896751.png)

So, as I was writing this up, I thought "hey this is working just like the annotate case so must be good," but then I commented out the doctest execution and it seems the docstring lines are just getting labelled as a fallback, not because the tracing infrastructure knows that they are getting executed:

![image](https://user-images.githubusercontent.com/7903078/58755204-923c6000-8493-11e9-956f-62103179da3e.png)

Ok, so maybe I got excited a little too early. That got me curious about Raymond's original example with annotate. If I turn off the docstring execution there by commenting out the `doctest.testmod()` line I get a result suggesting that docstring hits are not actually meaningful results from `coveragepy` tracing / interpretation infrastructure:

```python
> def linear(a, b):
>     ''' Solve ax + b = 0
  
>         >>> linear(3, 5)
>         -1.6666666666666667
  
>     '''
!     if a == 0 and b != 0:
!         raise ValueError('No solutions')
!     return -b  / a
```

This suggests to me that there may be another "meta" level to the tracing if we want to handle `doctest` probing of those string lines as "hits." That might be split into two categories:

1) was the string "probed" by doctest infrastructure?
2) was a line in that string `exec(compile())` run by doctest or subclassed doctest infrastructure in a library like NumPy / SciPy?