### PR TITLE
Twisted concurrency model

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -37,6 +37,7 @@ class Opts(object):
     )
     CONCURRENCY_CHOICES = [
         "thread", "gevent", "greenlet", "eventlet", "multiprocessing",
+        "twisted",
     ]
     concurrency = optparse.make_option(
         '', '--concurrency', action='store', metavar="LIB",
@@ -635,16 +636,16 @@ class CoverageScript(object):
             show_help("Can't append to data files in parallel mode.")
             return ERR
 
-        if options.concurrency == "multiprocessing":
+        if options.concurrency in ("multiprocessing", "twisted"):
             # Can't set other run-affecting command line options with
-            # multiprocessing.
+            # multiprocessing or Twisted.
             for opt_name in ['branch', 'include', 'omit', 'pylib', 'source', 'timid']:
                 # As it happens, all of these options have no default, meaning
                 # they will be None if they have not been specified.
                 if getattr(options, opt_name) is not None:
                     show_help(
-                        "Options affecting multiprocessing must only be specified "
-                        "in a configuration file.\n"
+                        "Options affecting multiprocessing and twisted must "
+                        "only be specified in a configuration file.\n"
                         "Remove --{} from the command line.".format(opt_name)
                     )
                     return ERR

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -37,6 +37,11 @@ except ImportError:                                         # pragma: only jytho
     # Jython has no multiprocessing module.
     patch_multiprocessing = None
 
+try:
+    from coverage.twistedproc import patch_twisted
+except ImportError:
+    patch_twisted = None
+
 os = isolate_module(os)
 
 
@@ -110,8 +115,8 @@ class Coverage(object):
         `concurrency` is a string indicating the concurrency library being used
         in the measured code.  Without this, coverage.py will get incorrect
         results if these libraries are in use.  Valid strings are "greenlet",
-        "eventlet", "gevent", "multiprocessing", or "thread" (the default).
-        This can also be a list of these strings.
+        "eventlet", "gevent", "multiprocessing", "twisted", or "thread" (the
+        default).  This can also be a list of these strings.
 
         If `check_preimported` is true, then when coverage is started, the
         aleady-imported files will be checked to see if they should be measured
@@ -335,10 +340,9 @@ class Coverage(object):
         if not should_skip:
             self._data.read()
 
-    def _init_for_start(self):
-        """Initialization for start()"""
-        # Construct the collector.
-        concurrency = self.config.concurrency or []
+    def _init_multiprocessing(self, concurrency):
+        """Enable collection in multiprocessing workers, if requested.
+        """
         if "multiprocessing" in concurrency:
             if not patch_multiprocessing:
                 raise CoverageException(                    # pragma: only jython
@@ -348,6 +352,28 @@ class Coverage(object):
             # Multi-processing uses parallel for the subprocesses, so also use
             # it for the main process.
             self.config.parallel = True
+
+    def _init_twisted(self, concurrency):
+        """Enable collection in Twisted-spawned children, if requested.
+        """
+        if "twisted" in concurrency:
+            if patch_twisted is None:
+                # XXX Untested
+                raise CoverageException(
+                    "twisted is not supported on this Python"
+                )
+            patch_twisted(
+                rcfile=self.config.config_file,
+            )
+            # XXX Untested
+            self.config.parallel = True
+
+    def _init_for_start(self):
+        """Initialization for start()"""
+        # Construct the collector.
+        concurrency = self.config.concurrency or []
+        self._init_multiprocessing(concurrency)
+        self._init_twisted(concurrency)
 
         dycon = self.config.dynamic_context
         if not dycon or dycon == "none":

--- a/coverage/twistedproc.py
+++ b/coverage/twistedproc.py
@@ -1,0 +1,85 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
+
+"""Monkey-patching to add Twisted support for coverage.py
+"""
+
+from functools import partial
+from tempfile import mkdtemp
+from os.path import join
+
+# XXX do it without installing the default reactor
+import twisted.internet.reactor
+
+from coverage.misc import contract
+
+# An attribute that will be set on the module to indicate that it has been
+# monkey-patched.  Value copied from multiproc.py.
+PATCHED_MARKER = "_coverage$patched"
+
+@contract(rcfile=str)
+def patch_twisted(rcfile):
+    """
+    The twisted.internet.interfaces.IReactorProcess.spawnProcess
+    implementation of the Twisted reactor is patched to enable coverage
+    collection in spawned processes.
+
+    This works by clobbering sitecustomize.
+    """
+    if getattr(twisted.internet, PATCHED_MARKER, False):
+        return
+
+    origSpawnProcess = twisted.internet.reactor.spawnProcess
+    twisted.internet.reactor.spawnProcess = partial(
+        _coverageSpawnProcess,
+        origSpawnProcess,
+        rcfile,
+    )
+    setattr(twisted.internet, PATCHED_MARKER, True)
+
+
+def _coverageSpawnProcess(
+    origSpawnProcess,
+    rcfile,
+    processProtocol,
+    executable,
+    args=(),
+    env=None,
+    *a,
+    **kw
+):
+    """
+    Spawn a process using ``origSpawnProcess``.  Set up its environment so
+    that coverage its collected, if it is a Python process.
+    """
+    if env is None:
+        env = os.environ.copy()
+    pythonpath = env.get(u"PYTHONPATH", u"").split(u":")
+    dtemp = mkdtemp()
+    pythonpath.insert(0, dtemp)
+    sitecustomize = join(dtemp, u"sitecustomize.py")
+    with open(sitecustomize, "wt") as f:
+        f.write("""\
+import sys, os.path
+sys.path.remove({dtemp!r})
+os.remove({sitecustomize!r})
+if os.path.exists({sitecustomizec!r}):
+    os.remove({sitecustomizec!r})
+os.rmdir({dtemp!r})
+import coverage
+coverage.process_startup()
+""".format(
+    sitecustomize=sitecustomize,
+    sitecustomizec=sitecustomize + u"c",
+    dtemp=dtemp,
+))
+        env[u"PYTHONPATH"] = u":".join(pythonpath)
+        env[u"COVERAGE_PROCESS_START"] = rcfile
+    return origSpawnProcess(
+        processProtocol,
+        executable,
+        args,
+        env,
+        *a,
+        **kw
+    )

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -517,7 +517,11 @@ class TwistedTest(CoverageTest):
 
         x = 41
         y = x + 1
-        out = self.run_command("coverage run spawnprocess.py master %s %s" % (x, y))
+        command = (
+            "coverage run --concurrency=twisted "
+            "spawnprocess.py master %s %s" % (x, y)
+        )
+        out = self.run_command(command)
         expected_out = (
             "work(%s) = %s\n"
             "work(%s) = %s\n"

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     -r requirements/pytest.pip
     pip==19.1.1
     setuptools==41.0.1
+    twisted==19.2.1
     # gevent 1.3 causes a failure: https://github.com/nedbat/coveragepy/issues/663
     py{27,35,36}: gevent==1.2.2
     py{27,35,36,37,38}: eventlet==0.24.1


### PR DESCRIPTION
Adds `--concurrency=twisted` which causes coverage to be tracked across child processes created with Twisted's `reactor.spawnProcess`.

I'm not entirely happy with the sitecustomize management code.  Also it seems like this could probably easily be a `--concurrency=exec` feature instead, with a the sitecustomize being written and PYTHONPATH updated early.  Then all processes forked & exec'd will get the logic.  It's less clear when to do cleanup but it's probably still possible.

Also this approach comes with the downside that it obscures any existing sitecustomize.  I don't really know what people use sitecustomize for so I'm not sure how big of a deal this is.

Any other solution for fork&exec seems like a challenge because there is no general way to inject some code into a process you've just exec'd.  exec is inherently about giving up control of what's running to some other program.  There might be some platform-specific tricks but that doesn't seem like an appealing avenue.

While working on this, https://pypi.org/project/coverage_enable_subprocess/ was also pointed out to me and it seems to accomplish roughly the same thing.  It uses the pth file approach instead but this means it requires a virtualenv (or for you to splat junk into your probably-OS-managed Python install which is not a great idea).  It also collects coverage from all Python programs instead of all programs in a tree under the one you start but I don't know if that's much of a practical difference.

