### PR TITLE
Json report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ Unreleased
 - `debug=plugin` didn't properly support configuration or dynamic context
   plugins, but now it does, closing `issue 834`_.
 
+- Added a JSON report `issue 720`_.
+
+.. _issue 720: https://github.com/nedbat/coveragepy/issues/720
 .. _issue 822: https://github.com/nedbat/coveragepy/issues/822
 .. _issue 834: https://github.com/nedbat/coveragepy/issues/834
 .. _issue 829: https://github.com/nedbat/coveragepy/issues/829

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -79,6 +79,7 @@ Marc Abramowitz
 Marcus Cobden
 Mark van der Wal
 Martin Fuzzey
+Matt Bachmann
 Matthew Boehm
 Matthew Desmarais
 Max Linke

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -118,6 +118,15 @@ class Opts(object):
         metavar="OUTFILE",
         help="Write the XML report to this file. Defaults to 'coverage.xml'",
     )
+    output_json = optparse.make_option(
+        '-o', '', action='store', dest="outfile",
+        metavar="OUTFILE",
+        help="Write the JSON report to this file. Defaults to 'coverage.json'",
+    )
+    json_pretty_print = optparse.make_option(
+        '', '--pretty-print', action='store_true',
+        help="Print the json formatted for human readers",
+    )
     parallel_mode = optparse.make_option(
         '-p', '--parallel-mode', action='store_true',
         help=(
@@ -402,6 +411,22 @@ CMDS = {
         usage="[options] [modules]",
         description="Generate an XML report of coverage results."
     ),
+
+    'json': CmdOptionParser(
+        "json",
+        [
+            Opts.fail_under,
+            Opts.ignore_errors,
+            Opts.include,
+            Opts.omit,
+            Opts.output_json,
+            Opts.json_pretty_print,
+            Opts.show_contexts,
+            Opts.contexts,
+            ] + GLOBAL_ARGS,
+        usage="[options] [modules]",
+        description="Generate a JSON report of coverage results."
+    ),
 }
 
 
@@ -565,6 +590,14 @@ class CoverageScript(object):
         elif options.action == "xml":
             outfile = options.outfile
             total = self.coverage.xml_report(outfile=outfile, **report_args)
+        elif options.action == "json":
+            outfile = options.outfile
+            total = self.coverage.json_report(
+                outfile=outfile,
+                pretty_print=options.pretty_print,
+                show_contexts=options.show_contexts,
+                **report_args
+            )
 
         if total is not None:
             # Apply the command line fail-under options, and then use the config
@@ -752,6 +785,7 @@ HELP_TOPICS = {
             erase       Erase previously collected coverage data.
             help        Get help on using coverage.py.
             html        Create an HTML report.
+            json        Create a JSON report of coverage results.
             report      Report coverage stats on modules.
             run         Run a Python program and measure code execution.
             xml         Create an XML report of coverage results.

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -215,6 +215,11 @@ class CoverageConfig(object):
         self.xml_output = "coverage.xml"
         self.xml_package_depth = 99
 
+        # Defaults for [JSON]
+        self.json_output = "coverage.json"
+        self.json_pretty_print = False
+        self.json_show_contexts = False
+
         # Defaults for [paths]
         self.paths = {}
 
@@ -363,6 +368,11 @@ class CoverageConfig(object):
         # [xml]
         ('xml_output', 'xml:output'),
         ('xml_package_depth', 'xml:package_depth', 'int'),
+
+        # [json]
+        ('json_output', 'json:output'),
+        ('json_pretty_print', 'json:pretty_print', 'boolean'),
+        ('json_show_contexts', 'json:show_contexts', 'boolean'),
     ]
 
     def _set_attr_from_config_option(self, cp, attr, where, type_=''):

--- a/coverage/jsonreport.py
+++ b/coverage/jsonreport.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
+
+"""Json reporting for coverage.py"""
+import datetime
+import json
+import sys
+
+from coverage import __version__
+from coverage.report import get_analysis_to_report
+from coverage.results import Numbers
+
+
+class JsonReporter(object):
+    """A reporter for writing JSON coverage results."""
+
+    def __init__(self, coverage):
+        self.coverage = coverage
+        self.config = self.coverage.config
+        self.total = Numbers()
+        self.report_data = {}
+
+    def report(self, morfs, outfile=None):
+        """Generate a json report for `morfs`.
+
+        `morfs` is a list of modules or file names.
+
+        `outfile` is a file object to write the json to
+
+        """
+        outfile = outfile or sys.stdout
+        coverage_data = self.coverage.get_data()
+        coverage_data.set_query_contexts(self.config.report_contexts)
+        self.report_data["meta"] = {
+            "version": __version__,
+            "timestamp": datetime.datetime.now().isoformat(),
+            "branch_coverage": coverage_data.has_arcs(),
+            "show_contexts": self.config.json_show_contexts,
+        }
+
+        measured_files = {}
+        for file_reporter, analysis in get_analysis_to_report(self.coverage, morfs):
+            measured_files[file_reporter.relative_filename()] = self.report_one_file(
+                coverage_data,
+                file_reporter,
+                analysis
+            )
+
+        self.report_data["files"] = measured_files
+
+        self.report_data["totals"] = {
+            'covered_lines': self.total.n_executed,
+            'num_statements': self.total.n_statements,
+            'percent_covered': self.total.pc_covered,
+            'missing_lines': self.total.n_missing,
+            'excluded_lines': self.total.n_excluded,
+        }
+
+        if coverage_data.has_arcs():
+            self.report_data["totals"].update({
+                'num_branches': self.total.n_branches,
+                'num_partial_branches': self.total.n_partial_branches,
+            })
+
+        json.dump(
+            self.report_data,
+            outfile,
+            indent=4 if self.config.json_pretty_print else None
+        )
+
+        return self.total.n_statements and self.total.pc_covered
+
+    def report_one_file(self, coverage_data, file_reporter, analysis):
+        """Extract the relevant report data for a single file"""
+        nums = analysis.numbers
+        self.total += nums
+        summary = {
+            'covered_lines': nums.n_executed,
+            'num_statements': nums.n_statements,
+            'percent_covered': nums.pc_covered,
+            'missing_lines': nums.n_missing,
+            'excluded_lines': nums.n_excluded,
+        }
+        reported_file = {
+            'executed_lines': sorted(analysis.executed),
+            'summary': summary,
+            'missing_lines': sorted(analysis.missing),
+            'excluded_lines': sorted(analysis.excluded)
+        }
+        if self.config.json_show_contexts:
+            reported_file['contexts'] = analysis.data.contexts_by_lineno(
+                file_reporter.filename
+            )
+        if coverage_data.has_arcs():
+            reported_file['summary'].update({
+                'num_branches': nums.n_branches,
+                'num_partial_branches': nums.n_partial_branches,
+            })
+        return reported_file

--- a/coverage/report.py
+++ b/coverage/report.py
@@ -2,9 +2,45 @@
 # For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
 
 """Reporter foundation for coverage.py."""
+import sys
 
+from coverage import env
 from coverage.files import prep_patterns, FnmatchMatcher
-from coverage.misc import CoverageException, NoSource, NotPython
+from coverage.misc import CoverageException, NoSource, NotPython, ensure_dir_for_file, file_be_gone
+
+
+def render_report(output_path, reporter, morfs):
+    """Run the provided reporter ensuring any required setup and cleanup is done
+
+    At a high level this method ensures the output file is ready to be written to. Then writes the
+    report to it. Then closes the file and deletes any garbage created if necessary.
+    """
+    file_to_close = None
+    delete_file = False
+    if output_path:
+        if output_path == '-':
+            outfile = sys.stdout
+        else:
+            # Ensure that the output directory is created; done here
+            # because this report pre-opens the output file.
+            # HTMLReport does this using the Report plumbing because
+            # its task is more complex, being multiple files.
+            ensure_dir_for_file(output_path)
+            open_kwargs = {}
+            if env.PY3:
+                open_kwargs['encoding'] = 'utf8'
+            outfile = open(output_path, "w", **open_kwargs)
+            file_to_close = outfile
+    try:
+        return reporter.report(morfs, outfile=outfile)
+    except CoverageException:
+        delete_file = True
+        raise
+    finally:
+        if file_to_close:
+            file_to_close.close()
+            if delete_file:
+                file_be_gone(output_path)
 
 
 def get_analysis_to_report(coverage, morfs):

--- a/coverage/results.py
+++ b/coverage/results.py
@@ -23,7 +23,8 @@ class Analysis(object):
         # Identify missing statements.
         executed = self.data.lines(self.filename) or []
         executed = self.file_reporter.translate_lines(executed)
-        self.missing = self.statements - executed
+        self.executed = executed
+        self.missing = self.statements - self.executed
 
         if self.data.has_arcs():
             self._arc_possibilities = sorted(self.file_reporter.arcs())

--- a/doc/branch.rst
+++ b/doc/branch.rst
@@ -55,8 +55,9 @@ The HTML report gives information about which lines had missing branches. Lines
 that were missing some branches are shown in yellow, with an annotation at the
 far right showing branch destination line numbers that were not exercised.
 
-The XML report produced by ``coverage xml`` also includes branch information,
-including separate statement and branch coverage percentages.
+The XML and JSON reports produced by ``coverage xml`` and ``coverage json``
+respectively also include branch information, including separate statement and
+branch coverage percentages.
 
 
 How it works

--- a/doc/cmd.rst
+++ b/doc/cmd.rst
@@ -22,6 +22,7 @@ Coverage.py command line usage
 .. :history: 20121117T091000, Added command aliases.
 .. :history: 20140924T193000, Added --concurrency
 .. :history: 20150802T174700, Updated for 4.0b1
+.. :history: 20190828T212200, added json report
 
 .. highlight:: console
 
@@ -40,6 +41,8 @@ Coverage.py has a number of commands which determine the action performed:
 * **report** -- Report coverage results.
 
 * **html** -- Produce annotated HTML listings with coverage results.
+
+* **json** -- Produce a JSON report with coverage results.
 
 * **xml** -- Produce an XML report with coverage results.
 
@@ -292,7 +295,8 @@ Reporting
 ---------
 
 Coverage.py provides a few styles of reporting, with the **report**, **html**,
-**annotate**, and **xml** commands.  They share a number of common options.
+**annotate**, **json**, and **xml** commands.  They share a number of common
+options.
 
 The command-line arguments are module or file names to report on, if you'd like
 to report on a subset of the data collected.
@@ -468,6 +472,17 @@ The **xml** command writes coverage data to a "coverage.xml" file in a format
 compatible with `Cobertura`_.
 
 .. _Cobertura: http://cobertura.github.io/cobertura/
+
+You can specify the name of the output file with the ``-o`` switch.
+
+Other common reporting options are described above in :ref:`cmd_reporting`.
+
+.. _cmd_json:
+
+JSON reporting
+-------------
+
+The **json** command writes coverage data to a "coverage.json" file.
 
 You can specify the name of the output file with the ``-o`` switch.
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -301,3 +301,22 @@ also apply to XML output, where appropriate.
 identified as packages in the report.  Directories deeper than this depth are
 not reported as packages.  The default is that all directories are reported as
 packages.
+
+.. _config_json:
+
+[json]
+-----
+
+Values particular to json reporting.  The values in the ``[report]`` section
+also apply to JSON output, where appropriate.
+
+``json_output`` (string, default "coverage.json"): where to write the json
+report.
+
+``json_pretty_print`` (boolean, default false): controls if fields in the json
+are outputted with whitespace formatted for human consumption (True) or for
+minimum file size (False)
+
+``json_show_contexts`` (boolean, default false): should the json report include
+an indication on each line of which contexts executed the line.
+See :ref:`dynamic_contexts` for details.

--- a/doc/howitworks.rst
+++ b/doc/howitworks.rst
@@ -83,8 +83,8 @@ Reporting
 
 Once we have the set of executed lines and missing lines, reporting is just a
 matter of formatting that information in a useful way.  Each reporting method
-(text, html, annotated source, xml) has a different output format, but the
-process is the same: write out the information in the particular format,
+(text, html, json, annotated source, xml) has a different output format, but
+the process is the same: write out the information in the particular format,
 possibly including the source code itself.
 
 

--- a/doc/source.rst
+++ b/doc/source.rst
@@ -80,11 +80,11 @@ reported.  Usually you want to see all the code that was measured, but if you
 are measuring a large project, you may want to get reports for just certain
 parts.
 
-The report commands (``report``, ``html``, ``annotate``, and ``xml``) all take
-optional ``modules`` arguments, and ``--include`` and ``--omit`` switches. The
-``modules`` arguments specify particular modules to report on.  The ``include``
-and ``omit`` values are lists of file name patterns, just as with the ``run``
-command.
+The report commands (``report``, ``html``, ``json``, ``annotate``, and ``xml``)
+all take optional ``modules`` arguments, and ``--include`` and ``--omit``
+switches. The ``modules`` arguments specify particular modules to report on.
+The ``include`` and ``omit`` values are lists of file name patterns, just as
+with the ``run`` command.
 
 Remember that the reporting commands can only report on the data that has been
 collected, so the data you're looking for may not be in the data available for

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -332,6 +332,10 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
         hello = world
         ; comments still work.
         names = Jane/John/Jenny
+
+        [{section}json]
+        pretty_print = True
+        show_contexts = True
         """
 
     # Just some sample setup.cfg text from the docs.
@@ -399,6 +403,8 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
             'names': 'Jane/John/Jenny',
         })
         self.assertEqual(cov.config.get_plugin_options("plugins.another"), {})
+        self.assertEqual(cov.config.json_show_contexts, True)
+        self.assertEqual(cov.config.json_pretty_print, True)
 
     def test_config_file_settings(self):
         self.make_file(".coveragerc", self.LOTSA_SETTINGS.format(section=""))

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,144 @@
+# coding: utf-8
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
+
+"""Test json-based summary reporting for coverage.py"""
+from datetime import datetime
+import json
+import os
+
+import coverage
+from tests.coveragetest import UsingModulesMixin, CoverageTest
+
+
+class JsonReportTest(UsingModulesMixin, CoverageTest):
+    """Tests of the JSON reports from coverage.py."""
+    def _assert_expected_json_report(self, cov, expected_result):
+        """
+        Helper for tests that handles the common ceremony so the tests can be clearly show the
+        consequences of setting various arguments.
+        """
+        self.make_file("a.py", """\
+            a = {'b': 1}
+            if a.get('a'):
+                b = 1
+            """)
+        a = self.start_import_stop(cov, "a")
+        output_path = os.path.join(self.temp_dir, "a.json")
+        cov.json_report(a, outfile=output_path)
+        with open(output_path) as result_file:
+            parsed_result = json.load(result_file)
+        self.assert_recent_datetime(
+            datetime.strptime(parsed_result['meta']['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
+        )
+        del (parsed_result['meta']['timestamp'])
+        assert parsed_result == expected_result
+
+    def test_branch_coverage(self):
+        cov = coverage.Coverage(branch=True)
+        expected_result = {
+            'meta': {
+                "version": coverage.__version__,
+                "branch_coverage": True,
+                "show_contexts": False,
+            },
+            'files': {
+                'a.py': {
+                    'executed_lines': [1, 2],
+                    'missing_lines': [3],
+                    'excluded_lines': [],
+                    'summary': {
+                        'missing_lines': 1,
+                        'covered_lines': 2,
+                        'num_statements': 3,
+                        'num_branches': 2,
+                        'excluded_lines': 0,
+                        'num_partial_branches': 1,
+                        'percent_covered': 60.0
+                    }
+                }
+            },
+            'totals': {
+                'missing_lines': 1,
+                'covered_lines': 2,
+                'num_statements': 3,
+                'num_branches': 2,
+                'excluded_lines': 0,
+                'num_partial_branches': 1,
+                'percent_covered': 60.0
+            }
+        }
+        self._assert_expected_json_report(cov, expected_result)
+
+    def test_simple_line_coverage(self):
+        cov = coverage.Coverage()
+        expected_result = {
+            'meta': {
+                "version": coverage.__version__,
+                "branch_coverage": False,
+                "show_contexts": False,
+            },
+            'files': {
+                'a.py': {
+                    'executed_lines': [1, 2],
+                    'missing_lines': [3],
+                    'excluded_lines': [],
+                    'summary': {
+                        'excluded_lines': 0,
+                        'missing_lines': 1,
+                        'covered_lines': 2,
+                        'num_statements': 3,
+                        'percent_covered': 66.66666666666667
+                    }
+                }
+            },
+            'totals': {
+                'excluded_lines': 0,
+                'missing_lines': 1,
+                'covered_lines': 2,
+                'num_statements': 3,
+                'percent_covered': 66.66666666666667
+            }
+        }
+        self._assert_expected_json_report(cov, expected_result)
+
+    def test_context(self):
+        cov = coverage.Coverage(context="cool_test")
+        cov.config.json_show_contexts = True
+        expected_result = {
+            'meta': {
+                "version": coverage.__version__,
+                "branch_coverage": False,
+                "show_contexts": True,
+            },
+            'files': {
+                'a.py': {
+                    'executed_lines': [1, 2],
+                    'missing_lines': [3],
+                    'excluded_lines': [],
+                    "contexts": {
+                        "1": [
+                            "cool_test"
+                        ],
+                        "2": [
+                            "cool_test"
+                        ]
+                    },
+                    'summary': {
+                        'excluded_lines': 0,
+                        'missing_lines': 1,
+                        'covered_lines': 2,
+                        'num_statements': 3,
+                        'percent_covered': 66.66666666666667
+                    }
+                }
+            },
+            'totals': {
+                'excluded_lines': 0,
+                'missing_lines': 1,
+                'covered_lines': 2,
+                'num_statements': 3,
+                'percent_covered': 66.66666666666667
+            }
+        }
+        self._assert_expected_json_report(cov, expected_result)


### PR DESCRIPTION
The goal of this pr is to eventually lead to closing  https://github.com/nedbat/coveragepy/issues/720

Some example reports from a non trivial project
without Contexts: https://gist.github.com/Bachmann1234/418311192ebff1faca1e3fc54453602c
with Contexts: https://gist.github.com/Bachmann1234/bb799bdc5978a81a1e26daeb1881b950

command help:

```
venv ❯ coverage --help
Coverage.py, version 5.0a7 with C extension
Measure, collect, and report on code coverage in Python programs.

usage: coverage <command> [options] [args]

Commands:
    annotate    Annotate source files with execution information.
    combine     Combine a number of data files.
    erase       Erase previously collected coverage data.
    help        Get help on using coverage.py.
    html        Create an HTML report.
    json        Create a JSON report of coverage results.
    report      Report coverage stats on modules.
    run         Run a Python program and measure code execution.
    xml         Create an XML report of coverage results.

Use "coverage help <command>" for detailed help on any command.
Full documentation is at https://coverage.readthedocs.io/en/coverage-5.0a7
```

```
venv ❯ coverage json --help
Usage: coverage json [options] [modules]

Generate a JSON report of coverage results.

Options:
  --fail-under=MIN      Exit with a status of 2 if the total coverage is less
                        than MIN.
  -i, --ignore-errors   Ignore errors while reading source files.
  --include=PAT1,PAT2,...
                        Include only files whose paths match one of these
                        patterns. Accepts shell-style wildcards, which must be
                        quoted.
  --omit=PAT1,PAT2,...  Omit files whose paths match one of these patterns.
                        Accepts shell-style wildcards, which must be quoted.
  -o OUTFILE            Write the JSON report to this file. Defaults to
                        'coverage.json'
  --pretty-print        Print the json formatted for human readers
  --show-contexts       Show contexts for covered lines.
  --contexts=PAT1,PAT2,...
                        Only display data from lines covered in the given
                        contexts. Accepts shell-style wildcards, which must be
                        quoted.
  --debug=OPTS          Debug options, separated by commas. [env:
                        COVERAGE_DEBUG]
  -h, --help            Get help on this command.
  --rcfile=RCFILE       Specify configuration file. By default '.coveragerc',
                        'setup.cfg' and 'tox.ini' are tried. [env:
                        COVERAGE_RCFILE]

Full documentation is at https://coverage.readthedocs.io/en/coverage-5.0a7
```

simple report:
```
{
    "meta": {
        "version": "5.0a7",
        "timestamp": "2019-08-18T13:50:07.353011",
        "branch_coverage": true,
        "show_contexts": false
    },
    "files": {
        "a.py": {
            "executed_lines": [
                1,
                2
            ],
            "summary": {
                "covered_lines": 2,
                "num_statements": 3,
                "percent_covered": 60.0,
                "missing_lines": 1,
                "excluded_lines": 0,
                "num_branches": 2,
                "num_partial_branches": 1
            },
            "missing_lines": [
                3
            ],
            "excluded_lines": []
        }
    },
    "totals": {
        "covered_lines": 2,
        "num_statements": 3,
        "percent_covered": 60.0,
        "missing_lines": 1,
        "excluded_lines": 0,
        "num_branches": 2,
        "num_partial_branches": 1
    }
}
```

TODO: 
-     Iterate on the schema
-     document the report in the formal docs