### PR TITLE
Try to fix #745 by providing ModuleSpec for __main__.

### DIFF
--- a/coverage/backward.py
+++ b/coverage/backward.py
@@ -175,6 +175,11 @@ try:
 except AttributeError:
     PYC_MAGIC_NUMBER = imp.get_magic()
 
+try:
+    from importlib.machinery import ModuleSpec
+except ImportError:
+    ModuleSpec = None
+
 
 try:
     from types import SimpleNamespace

--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -12,7 +12,7 @@ import types
 
 from coverage import env
 from coverage.backward import BUILTINS
-from coverage.backward import PYC_MAGIC_NUMBER, imp, importlib_util_find_spec
+from coverage.backward import PYC_MAGIC_NUMBER, imp, importlib_util_find_spec, ModuleSpec
 from coverage.misc import CoverageException, ExceptionDuringRun, NoCode, NoSource, isolate_module
 from coverage.phystokens import compile_unicode
 from coverage.python import get_python_source
@@ -175,6 +175,12 @@ class PyRunner(object):
             main_mod.__loader__ = DummyLoader(self.modulename)
 
         main_mod.__builtins__ = BUILTINS
+        if ModuleSpec is not None:
+            main_mod.__spec__ = ModuleSpec(
+                '__main__',
+                main_mod.__loader__,
+                origin=main_mod.__file__,
+                is_package=self.package)
 
         # Set sys.argv properly.
         sys.argv = self.args

--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -175,12 +175,12 @@ class PyRunner(object):
             main_mod.__loader__ = DummyLoader(self.modulename)
 
         main_mod.__builtins__ = BUILTINS
-        if ModuleSpec is not None:
+        if self.package and ModuleSpec is not None:
             main_mod.__spec__ = ModuleSpec(
                 '__main__',
                 main_mod.__loader__,
                 origin=main_mod.__file__,
-                is_package=self.package)
+                is_package=True)
 
         # Set sys.argv properly.
         sys.argv = self.args

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -40,7 +40,8 @@ def run_command(cmd):
         stdin=subprocess.PIPE, stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT
         )
-    output, _ = proc.communicate()
+    # timeout in case the process locks up
+    output, _ = proc.communicate(**({'timeout': 30} if env.PYVERSION >= (3, 3) else {}))
     status = proc.returncode
 
     # Get the output, and canonicalize it to strings with newlines.

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -484,6 +484,7 @@ MULTI_UNITTEST_SPAWN_CODE = """
     """
 
 
+@flaky(max_runs=10)         # Sometimes a test fails due to inherent randomness. Try more times.
 class MultiprocessingUnittestTest(CoverageTest):
     """Test support of the multiprocessing module running in a unit test."""
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -491,6 +491,8 @@ class MultiprocessingUnittestTest(CoverageTest):
     def setUp(self):
         if not multiprocessing:
             self.skipTest("No multiprocessing in this Python")      # pragma: only jython
+        elif env.PY2 and not env.WINDOWS:
+            self.skipTest("No forking in this Python")
         super(MultiprocessingUnittestTest, self).setUp()
 
     def try_multiprocessing_unittest(
@@ -504,7 +506,11 @@ class MultiprocessingUnittestTest(CoverageTest):
             source = .
             """ % concurrency)
 
-        status, out = self.run_command_status("coverage run -m unittest multi.py")
+        if env.PY2:
+            run_command = "coverage run -m unittest discover -p multi.py"
+        else:
+            run_command = "coverage run -m unittest multi.py"
+        status, out = self.run_command_status(run_command)
         self.assertEqual(status, 0)
         expected_cant_trace = cant_trace_msg(concurrency, the_module)
 


### PR DESCRIPTION
I investigated #745 and found the main difference (compared to running the unit test without coverage) seemed to be the lack of a `__spec__` for `sys.modules['__main__']`, so I tried to add one.

I also added a test which triggers the problem based off @adamklein's example in the issue.

However, after the fix we don't get coverage inside the spawned process, and it locks up MultiprocessingTest when using spawn.  I don't know why though.  Suggestions would be appreciated.

