### PR TITLE
Implement the pytest --cov-context option in an "add-on" pytest plugin

### DIFF
--- a/coverage/__init__.py
+++ b/coverage/__init__.py
@@ -1,11 +1,11 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
-
 """Code coverage measurement for Python.
 
 Ned Batchelder
 https://nedbatchelder.com/code/coverage
 
+PYTEST_DONT_REWRITE
 """
 
 import sys

--- a/coverage/pytest_plugin.py
+++ b/coverage/pytest_plugin.py
@@ -1,0 +1,53 @@
+"""
+PYTEST_DONT_REWRITE
+"""
+import argparse
+
+
+def validate_context(arg):
+    if arg != "test":
+        msg = '--cov-context=test is the only supported value'
+        raise argparse.ArgumentTypeError(msg)
+    return arg
+
+
+def pytest_addoption(parser):
+    try:
+        import pytest_cov
+    except ImportError:
+        pass
+    else:
+        group = parser.getgroup('cov', 'coverage reporting with distributed testing support')
+        group.addoption('--cov-context', action='store', metavar='CONTEXT',
+                        type=validate_context,
+                        help='Dynamic context to use. Available contexts: only "test" for now.')
+
+
+def pytest_sessionstart(session):
+    config = session.config
+    cov = config.pluginmanager.get_plugin('_cov')
+    if (
+        config.known_args_namespace.cov_context == 'test'
+        and cov
+        and cov.cov_controller
+        and config.known_args_namespace.cov_source
+    ):
+        config.pluginmanager.register(TestContextPlugin(cov.cov_controller.cov), '_cov_contexts')
+
+
+class TestContextPlugin(object):
+    def __init__(self, cov):
+        self.cov = cov
+
+    def pytest_runtest_setup(self, item):
+        self.switch_context(item, 'setup')
+
+    def pytest_runtest_teardown(self, item):
+        self.switch_context(item, 'teardown')
+
+    def pytest_runtest_call(self, item):
+        self.switch_context(item, 'run')
+
+    def switch_context(self, item, when):
+        context = "{item.nodeid}|{when}".format(item=item, when=when)
+        self.cov.switch_context(context)

--- a/requirements/pytest.pip
+++ b/requirements/pytest.pip
@@ -4,6 +4,7 @@
 # The pytest specifics used by coverage.py
 
 pytest==4.6.2
+pytest-cov==2.7.1
 pytest-xdist==1.28.0
 flaky==3.5.3
 mock==3.0.5

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,9 @@ setup_args = dict(
             'coverage%d = coverage.cmdline:main' % sys.version_info[:1],
             'coverage-%d.%d = coverage.cmdline:main' % sys.version_info[:2],
         ],
+        'pytest11': [
+            'coverage_pytest_plugin = coverage.pytest_plugin',
+        ],
     },
 
     # We need to get HTML assets from our htmlfiles directory.

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,0 +1,52 @@
+import sqlite3
+
+import pytest
+
+pytest_plugins = 'pytester',
+
+xdist_params = pytest.mark.parametrize('opts', [
+    '',
+    pytest.param('-n 1', marks=pytest.mark.skipif('sys.platform == "win32" and platform.python_implementation() == "PyPy"'))
+], ids=['nodist', 'xdist'])
+
+
+CONTEXTFUL_TESTS = '''\
+import unittest
+
+def test_one():
+    assert 1 == 1
+
+def test_two():
+    assert 2 == 2
+
+class OldStyleTests(unittest.TestCase):
+    def setUp(self):
+        self.three = 3
+    def tearDown(self):
+        self.three = None
+    def test_three(self):
+        assert self.three == 3
+'''
+
+
+@xdist_params
+def test_contexts(testdir, opts):
+    script = testdir.makepyfile(CONTEXTFUL_TESTS)
+    result = testdir.runpytest('-vv', '-s',
+                               '--cov=%s' % script.dirpath(),
+                               '--cov-context=test',
+                               script,
+                               *opts.split()
+                               )
+    result.stdout.fnmatch_lines([
+        'test_contexts* 100%*',
+    ])
+    con = sqlite3.connect(".coverage")
+    cur = con.cursor()
+    contexts = set(r[0] for r in cur.execute("select context from context"))
+    assert contexts == {
+        '',
+        'test_contexts.py::test_two|run',
+        'test_contexts.py::test_one|run',
+        'test_contexts.py::OldStyleTests::test_three|run',
+    }


### PR DESCRIPTION
This is a port of https://github.com/pytest-dev/pytest-cov/pull/342

Few notes about this:

- if develop installs are used (they appear to be in the tox configuration) then you get these pesky `Module already imported so cannot be rewritten: __main__` warnings. They are caused by an unfortunate combination of problems: there's a `__main__.py` file in the root of the repo (which shouldn't exist IMO) and the fact that pytest will enumerate all the installed files (importlib_metadata will wrongly enumerate files that aren't normally installed when install is a develop install).
- the `pytest-cov==2.7.1` dep should be replaced to something that is the pytest-cov master
- I've fixed the xdist support (the correct activation point is pytest_sessionstart - otherwise we'd bind to the wrong cov_controller)
- I've renamed `--cov-contexts` to `--cov-context` - I don't get why it was pluralized since there's no comma splitting or something like that in validate_context.

So my suggestion is to take this approach to get more alpha/beta releases of coveragepy out since this whole thing needs overall more work anyway (customization of context, showing something in the reporting about contexts and so on).