### PR TITLE
Print TOTAL of coverage anyway with 1 or more files

### DIFF
--- a/coverage/summary.py
+++ b/coverage/summary.py
@@ -110,16 +110,15 @@ class SummaryReporter(object):
         for line in lines:
             self.writeout(line[0])
 
-        # Write a TOTAl line if we had more than one file.
-        if self.total.n_files > 1:
-            self.writeout(rule)
-            args = ("TOTAL", self.total.n_statements, self.total.n_missing)
-            if self.branches:
-                args += (self.total.n_branches, self.total.n_partial_branches)
-            args += (self.total.pc_covered_str,)
-            if self.config.show_missing:
-                args += ("",)
-            self.writeout(fmt_coverage % args)
+        # Write a TOTAL line if had 1 or more files.
+        self.writeout(rule)
+        args = ("TOTAL", self.total.n_statements, self.total.n_missing)
+        if self.branches:
+            args += (self.total.n_branches, self.total.n_partial_branches)
+        args += (self.total.pc_covered_str,)
+        if self.config.show_missing:
+            args += ("",)
+        self.writeout(fmt_coverage % args)
 
         # Write other final lines.
         if not self.total.n_files and not self.skipped_count:


### PR DESCRIPTION
We use coveragepy on GitlabCi pipelines to get coverage total of a repository and get metrics for other purposes. (https://docs.gitlab.com/ee/ci/yaml/#coverage)

Some times we have repositories with 1 file and many libs (that we run coverage on another pipeline) and we need to grep (with regex) the total of coverage. If coveragepy print TOTAL every run, anyway, we can make a generic script to get the coverage.