### PR TITLE
DO-NOT-MERGE: Patched-on LCOV file format support for coveragepy v4.x

### DIFF
--- a/coverage/annotate.py
+++ b/coverage/annotate.py
@@ -7,6 +7,8 @@ import io
 import os
 import re
 
+from coverage import files
+
 from coverage.files import flat_rootname
 from coverage.misc import isolate_module
 from coverage.report import Reporter
@@ -36,30 +38,86 @@ class AnnotateReporter(Reporter):
 
     """
 
-    def __init__(self, coverage, config):
+    def __init__(self, coverage, config, lcov_file=None):
         super(AnnotateReporter, self).__init__(coverage, config)
         self.directory = None
 
     blank_re = re.compile(r"\s*(#|$)")
     else_re = re.compile(r"\s*else\s*:\s*(#|$)")
 
-    def report(self, morfs, directory=None):
+    def report(self, morfs, directory=None, lcov_file=None):
         """Run the report.
 
         See `coverage.report()` for arguments.
 
         """
-        self.report_files(self.annotate_file, morfs, directory)
+        self.report_files(self.annotate_file, morfs, directory,
+                          lcov_file=lcov_file)
 
-    def annotate_file(self, fr, analysis):
+    def print_ba_lines(self, lcov_file, analysis):
+      # This function takes advantage of the fact that the functions
+      # in Analysis returns arcs in sorted order of their line numbers
+      # and mark the branch numbers in the same order of the
+      # destination line numbers of the arcs. For example:
+      #
+      # Line
+      # 10    if (something):
+      # 11      do_something
+      # 12    else:
+      # 13      do_something_else
+      #
+      # In the coverage analysis result, the tool returns arc list [
+      # ... (10,11), (10, 13) ...].  We will then regard (10,11) as
+      # the first branch at line 10 and (10, 13) as the second branch
+      # at line 10. This is important as in lcov file the branch
+      # coverage info must appear in order, e.g., suppose the test
+      # code executes the 'if' branch, the results in lcov format will
+      # be
+      #
+      #  BA: 10, 2  (the first branch is taken)
+      #  BA: 10, 1  (the second branch is executed but not taken)
+      #
+      # Note that in other languages the branch ordering might be
+      # treated differently.
+
+      all_arcs = analysis.arc_possibilities()
+      branch_lines = set(analysis.branch_lines())
+      missing_branch_arcs = analysis.missing_branch_arcs()
+      missing = analysis.missing
+
+      for source_line,target_line in all_arcs:
+        if source_line in branch_lines:
+          if source_line in missing:
+            # Not executed
+            lcov_file.write('BA:%d,0\n' % source_line)
+          else:
+            if (source_line in missing_branch_arcs) and (
+                target_line in missing_branch_arcs[source_line]):
+              # Executed and not taken
+              lcov_file.write('BA:%d,1\n' % source_line)
+            else:
+              # Executed and taken
+              lcov_file.write('BA:%d,2\n' % source_line)
+
+    (MISSED, COVERED, BLANK, EXCLUDED) = ('!', '>', ' ', '-')
+    def annotate_file(self, fr, analysis, lcov_file=None):
         """Annotate a single file.
 
         `fr` is the FileReporter for the file to annotate.
 
         """
+        reverse_mapping = files.get_filename_from_cf(fr.filename)
+
+        filename = fr.filename
+        if reverse_mapping:
+            filename = reverse_mapping
+
         statements = sorted(analysis.statements)
         missing = sorted(analysis.missing)
         excluded = sorted(analysis.excluded)
+
+        if lcov_file:
+            lcov_file.write("SF:%s\n" % filename)
 
         if self.directory:
             dest_file = os.path.join(self.directory, flat_rootname(fr.relative_filename()))
@@ -69,7 +127,11 @@ class AnnotateReporter(Reporter):
         else:
             dest_file = fr.filename + ",cover"
 
-        with io.open(dest_file, 'w', encoding='utf8') as dest:
+        if not lcov_file:
+            dest = io.open(dest_file, 'w', encoding='utf8')
+
+        if True:  # GOOGLE: force indent for easy comparison; original:
+                  # with io.open(dest_file, 'w', encoding='utf8') as dest:
             i = 0
             j = 0
             covered = True
@@ -82,22 +144,36 @@ class AnnotateReporter(Reporter):
                 if i < len(statements) and statements[i] == lineno:
                     covered = j >= len(missing) or missing[j] > lineno
                 if self.blank_re.match(line):
-                    dest.write(u'  ')
+                    line_type = self.BLANK
                 elif self.else_re.match(line):
                     # Special logic for lines containing only 'else:'.
                     if i >= len(statements) and j >= len(missing):
-                        dest.write(u'! ')
+                        line_type = self.MISSED
                     elif i >= len(statements) or j >= len(missing):
-                        dest.write(u'> ')
+                        line_type = self.COVERED
                     elif statements[i] == missing[j]:
-                        dest.write(u'! ')
+                        line_type = self.MISSED
                     else:
-                        dest.write(u'> ')
+                        line_type = self.COVERED
                 elif lineno in excluded:
-                    dest.write(u'- ')
+                    line_type = self.EXCLUDED
                 elif covered:
-                    dest.write(u'> ')
+                    line_type = self.COVERED
                 else:
-                    dest.write(u'! ')
+                    line_type = self.MISSED
 
-                dest.write(line)
+                if not lcov_file:
+                    dest.write("%s %s" % (line_type, line))
+                else:
+                    # Omit BLANK & EXCLUDED line types from this lcov output type.
+                    if line_type == self.COVERED:
+                        lcov_file.write("DA:%d,1\n" % lineno)
+                    elif line_type == self.MISSED:
+                      lcov_file.write("DA:%d,0\n" % lineno)
+        # Write branch coverage results
+        if lcov_file and analysis.has_arcs():
+            self.print_ba_lines(lcov_file, analysis)
+        if lcov_file:
+            lcov_file.write("end_of_record\n")
+        else:
+            dest.close()  # XXX try: finally: more "appropriate" than "if True"

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -70,6 +70,11 @@ class Opts(object):
             "Accepts shell-style wildcards, which must be quoted."
         ),
     )
+    lcov = optparse.make_option(
+        '-l', '--lcov', action='store', dest="lcov_file",
+        metavar="OUTFILE",
+        help="report in lcov format"
+    )
     pylib = optparse.make_option(
         '-L', '--pylib', action='store_true',
         help=(
@@ -271,6 +276,7 @@ CMDS = {
             Opts.ignore_errors,
             Opts.include,
             Opts.omit,
+            Opts.lcov,
             ] + GLOBAL_ARGS,
         usage="[options] [modules]",
         description=(
@@ -363,6 +369,7 @@ CMDS = {
             Opts.parallel_mode,
             Opts.source,
             Opts.timid,
+            Opts.lcov,
             ] + GLOBAL_ARGS,
         usage="[options] <pyfile> [program options]",
         description="Run a Python program, measuring code execution."
@@ -499,11 +506,18 @@ class CoverageScript(object):
             return OK
 
         # Remaining actions are reporting, with some common options.
+        if options.lcov_file:
+          lcovfile = open(options.lcov_file, "w")
+        else:
+          print("No Report generated: missing --lcov=<file> argument")
+          return ERR
+
         report_args = dict(
             morfs=unglob_args(args),
             ignore_errors=options.ignore_errors,
             omit=omit,
             include=include,
+            lcov_file = lcovfile,
             )
 
         self.coverage.load()

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -51,6 +51,14 @@ def relative_filename(filename):
     return unicode_filename(filename)
 
 
+def get_filename_from_cf(cf):
+    """Return the reverse mapping of canonical_filename."""
+    for f in CANONICAL_FILENAME_CACHE.keys():
+        if CANONICAL_FILENAME_CACHE[f] == cf and not f == cf:
+            return f
+    return None
+
+
 @contract(returns='unicode')
 def canonical_filename(filename):
     """Return a canonical file name for `filename`.

--- a/coverage/report.py
+++ b/coverage/report.py
@@ -65,7 +65,7 @@ class Reporter(object):
         self._file_reporters = sorted(reporters)
         return self._file_reporters
 
-    def report_files(self, report_fn, morfs, directory=None):
+    def report_files(self, report_fn, morfs, directory=None, lcov_file=None):
         """Run a reporting function on a number of morfs.
 
         `report_fn` is called for each relative morf in `morfs`.  It is called
@@ -88,7 +88,7 @@ class Reporter(object):
 
         for fr in file_reporters:
             try:
-                report_fn(fr, self.coverage._analyze(fr))
+                report_fn(fr, self.coverage._analyze(fr), lcov_file=lcov_file)
             except NoSource:
                 if not self.config.ignore_errors:
                     raise

--- a/coverage/summary.py
+++ b/coverage/summary.py
@@ -18,7 +18,7 @@ class SummaryReporter(Reporter):
         super(SummaryReporter, self).__init__(coverage, config)
         self.branches = coverage.data.has_arcs()
 
-    def report(self, morfs, outfile=None):
+    def report(self, morfs, outfile=None, lcov_file=None):
         """Writes a report summarizing coverage statistics per module.
 
         `outfile` is a file object to write the summary to. It must be opened


### PR DESCRIPTION
This is gross as is, it was originally done in a way that minized diffs.  :/

This PR is for discussion purposes only. I expect a new PR to be created by anyone interested on master to add lcov support in a non-hacky manner. :)

I'm making the PR on a branch of v4.5.x as our existing changes do not apply cleanly after some of the refactoring in the git master (v5) code.

We are using a patched 4.4.2 internally at the time of PR creation.  This patch comes from Google where we've been carrying around some variant of this patch on top of coverage for a very long time.  It clearly belongs upstream (starting that here), as the LCOV format seems to be supported by a variety of IDEs and other systems(?).

I don't expect to do future work in this PR itself.  Follow https://github.com/nedbat/coveragepy/issues/587 for actual details.

Lacking: Any LCOV format unittests. (sadface)

(I did not successfully run the coverage testsuite on this PR but that might have been my lack of trying and possibly a weird environment?  They don't seem to run properly for me when following the v4.5.x branch howto.txt instructions but I didn't try to debug why)