### PR TITLE
Finish the TOML support started in #699

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ Unreleased
 - The HTML and textual reports now have a ``--skip-empty`` option that skips
   files with no statements (notably, ``__init__.py`` files).  Thanks, Reya B.
 
+- Configuration can now be read from `TOML`_ files.  This requires installing
+  coverage.py with the ``[toml]`` extra.  The standard "pyproject.toml" file
+  will be read automatically if no other configuration file is found, with
+  settings in the ``[tool.coverage.]`` namespace.  Thanks to Frazer McLean for
+  implementation and persistence.  Finishes `issue 664`_.
+
 - The HTML report has been reimplemented (no more table around the source
   code). This allowed for a better presentation of the context information,
   hopefully resolving `issue 855`_.
@@ -33,6 +39,8 @@ Unreleased
   ``coverage html --show-contexts``) will issue a warning if there were no
   contexts measured (`issue 851`_).
 
+.. _TOML: https://github.com/toml-lang/toml#toml
+.. _issue 664: https://github.com/nedbat/coveragepy/issues/664
 .. _issue 851: https://github.com/nedbat/coveragepy/issues/851
 .. _issue 855: https://github.com/nedbat/coveragepy/issues/855
 
@@ -79,15 +87,11 @@ Version 5.0a7 --- 2019-09-21
 - ``debug=plugin`` didn't properly support configuration or dynamic context
   plugins, but now it does, closing `issue 834`_.
 
-
-- Added TOML configuration support, including pyproject.toml `issue 664`_.
-
 .. _issue 720: https://github.com/nedbat/coveragepy/issues/720
 .. _issue 822: https://github.com/nedbat/coveragepy/issues/822
 .. _issue 834: https://github.com/nedbat/coveragepy/issues/834
 .. _issue 829: https://github.com/nedbat/coveragepy/issues/829
 .. _issue 846: https://github.com/nedbat/coveragepy/issues/846
-.. _issue 664: https://github.com/nedbat/coveragepy/issues/664
 
 
 .. _changes_50a6:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,11 +80,14 @@ Version 5.0a7 --- 2019-09-21
   plugins, but now it does, closing `issue 834`_.
 
 
+- Added TOML configuration support, including pyproject.toml `issue 664`_.
+
 .. _issue 720: https://github.com/nedbat/coveragepy/issues/720
 .. _issue 822: https://github.com/nedbat/coveragepy/issues/822
 .. _issue 834: https://github.com/nedbat/coveragepy/issues/834
 .. _issue 829: https://github.com/nedbat/coveragepy/issues/829
 .. _issue 846: https://github.com/nedbat/coveragepy/issues/846
+.. _issue 664: https://github.com/nedbat/coveragepy/issues/664
 
 
 .. _changes_50a6:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -51,6 +51,7 @@ Eduardo Schettino
 Emil Madsen
 Edward Loper
 Federico Bond
+Frazer McLean
 Geoff Bache
 George Paci
 George Song

--- a/coverage/backward.py
+++ b/coverage/backward.py
@@ -3,7 +3,7 @@
 
 """Add things to old Pythons so I can pretend they are newer."""
 
-# This file does tricky stuff, so disable a pylint warning.
+# This file's purpose is to provide modules to be imported from here.
 # pylint: disable=unused-import
 
 import os
@@ -26,11 +26,6 @@ try:
     import ConfigParser as configparser
 except ImportError:
     import configparser
-
-try:
-    import toml
-except ImportError:
-    toml = None
 
 # What's a string called?
 try:

--- a/coverage/backward.py
+++ b/coverage/backward.py
@@ -6,6 +6,7 @@
 # This file does tricky stuff, so disable a pylint warning.
 # pylint: disable=unused-import
 
+import os
 import sys
 
 from coverage import env
@@ -25,6 +26,11 @@ try:
     import ConfigParser as configparser
 except ImportError:
     import configparser
+
+try:
+    import toml
+except ImportError:
+    toml = None
 
 # What's a string called?
 try:
@@ -54,6 +60,15 @@ try:
     from thread import get_ident as get_thread_id
 except ImportError:
     from threading import get_ident as get_thread_id
+
+try:
+    os.PathLike
+except AttributeError:
+    # This is Python 2 and 3
+    path_types = (bytes, string_class, unicode_class)
+else:
+    # 3.6+
+    path_types = (bytes, str, os.PathLike)
 
 # shlex.quote is new, but there's an undocumented implementation in "pipes",
 # who knew!?

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -150,8 +150,8 @@ class Opts(object):
         '', '--rcfile', action='store',
         help=(
             "Specify configuration file. "
-            "By default '.coveragerc', 'setup.cfg' and 'tox.ini' are tried. "
-            "[env: COVERAGE_RCFILE]"
+            "By default '.coveragerc', 'pyproject.toml', 'setup.cfg' and "
+            "'tox.ini' are tried. [env: COVERAGE_RCFILE]"
         ),
     )
     source = optparse.make_option(

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -9,7 +9,7 @@ import os
 import re
 
 from coverage import env
-from coverage.backward import configparser, iitems, string_class, toml
+from coverage.backward import configparser, iitems, string_class
 from coverage.misc import contract, CoverageException, isolate_module
 from coverage.misc import substitute_variables
 
@@ -260,6 +260,7 @@ class CoverageConfig(object):
         """
         _, ext = os.path.splitext(filename)
         if ext == '.toml':
+            from coverage.optional import toml
             if toml is None:
                 return False
             cp = TomlConfigParser(our_file)
@@ -482,9 +483,9 @@ def config_files_to_try(config_file):
         config_file = ".coveragerc"
     files_to_try = [
         (config_file, True, specified_file),
-        ("pyproject.toml", False, False),
         ("setup.cfg", False, False),
         ("tox.ini", False, False),
+        ("pyproject.toml", False, False),
     ]
     return files_to_try
 

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -260,9 +260,6 @@ class CoverageConfig(object):
         """
         _, ext = os.path.splitext(filename)
         if ext == '.toml':
-            from coverage.optional import toml
-            if toml is None:
-                return False
             cp = TomlConfigParser(our_file)
         else:
             cp = HandyConfigParser(our_file)

--- a/coverage/optional.py
+++ b/coverage/optional.py
@@ -1,0 +1,68 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
+
+"""
+Imports that we need at runtime, but might not be present.
+
+When importing one of these modules, always do it in the function where you
+need the module.  Some tests will need to remove the module.  If you import
+it at the top level of your module, then the test won't be able to simulate
+the module being unimportable.
+
+The import will always succeed, but the value will be None if the module is
+unavailable.
+
+Bad::
+
+    # MyModule.py
+    from coverage.optional import unsure
+
+    def use_unsure():
+        unsure.something()
+
+Good::
+
+    # MyModule.py
+
+    def use_unsure():
+        from coverage.optional import unsure
+        if unsure is None:
+            raise Exception("Module unsure isn't available!")
+
+        unsure.something()
+
+"""
+
+import contextlib
+
+# This file's purpose is to provide modules to be imported from here.
+# pylint: disable=unused-import
+
+# TOML support is an install-time extra option.
+try:
+    import toml
+except ImportError:         # pragma: not covered
+    toml = None
+
+
+@contextlib.contextmanager
+def without(modname):
+    """Hide a module for testing.
+
+    Use this in a test function to make an optional module unavailable during
+    the test::
+
+        with coverage.optional.without('toml'):
+            use_toml_somehow()
+
+    Arguments:
+        modname (str): the name of a module importable from
+            `coverage.optional`.
+
+    """
+    real_module = globals()[modname]
+    try:
+        globals()[modname] = None
+        yield
+    finally:
+        globals()[modname] = real_module

--- a/coverage/tomlconfig.py
+++ b/coverage/tomlconfig.py
@@ -1,3 +1,8 @@
+# Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+# For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
+
+"""TOML configuration support for coverage.py"""
+
 import io
 import os
 import re
@@ -9,9 +14,16 @@ from coverage.misc import CoverageException, substitute_variables
 
 class TomlDecodeError(Exception):
     """An exception class that exists even when toml isn't installed."""
+    pass
 
 
 class TomlConfigParser:
+    """TOML file reading with the interface of HandyConfigParser."""
+
+    # This class has the same interface as config.HandyConfigParser, no
+    # need for docstrings.
+    # pylint: disable=missing-function-docstring
+
     def __init__(self, our_file):
         self.getters = [lambda obj: obj['tool']['coverage']]
         if our_file:
@@ -101,7 +113,8 @@ class TomlConfigParser:
         if not isinstance(value, bool):
             raise ValueError(
                 'Option {!r} in section {!r} is not a boolean: {!r}'
-                .format(option, section, value))
+                    .format(option, section, value)
+            )
         return value
 
     def getlist(self, section, option):
@@ -109,7 +122,8 @@ class TomlConfigParser:
         if not isinstance(values, list):
             raise ValueError(
                 'Option {!r} in section {!r} is not a list: {!r}'
-                .format(option, section, values))
+                    .format(option, section, values)
+            )
         for i, value in enumerate(values):
             if isinstance(value, string_class):
                 values[i] = substitute_variables(value, os.environ)
@@ -132,7 +146,8 @@ class TomlConfigParser:
         if not isinstance(value, int):
             raise ValueError(
                 'Option {!r} in section {!r} is not an integer: {!r}'
-                .format(option, section, value))
+                    .format(option, section, value)
+            )
         return value
 
     def getfloat(self, section, option):
@@ -142,5 +157,6 @@ class TomlConfigParser:
         if not isinstance(value, float):
             raise ValueError(
                 'Option {!r} in section {!r} is not a float: {!r}'
-                .format(option, section, value))
+                    .format(option, section, value)
+            )
         return value

--- a/coverage/tomlconfig.py
+++ b/coverage/tomlconfig.py
@@ -1,0 +1,146 @@
+import io
+import os
+import re
+
+from coverage import env
+from coverage.backward import configparser, path_types, string_class, toml
+from coverage.misc import CoverageException, substitute_variables
+
+
+class TomlDecodeError(Exception):
+    """An exception class that exists even when toml isn't installed."""
+
+
+class TomlConfigParser:
+    def __init__(self, our_file):
+        self.getters = [lambda obj: obj['tool']['coverage']]
+        if our_file:
+            self.getters.append(lambda obj: obj)
+
+        self._data = []
+
+    def read(self, filenames):
+        if toml is None:
+            raise RuntimeError('toml module is not installed.')
+
+        if isinstance(filenames, path_types):
+            filenames = [filenames]
+        read_ok = []
+        for filename in filenames:
+            try:
+                with io.open(filename, encoding='utf-8') as fp:
+                    self._data.append(toml.load(fp))
+            except IOError:
+                continue
+            except toml.TomlDecodeError as err:
+                raise TomlDecodeError(*err.args)
+            if env.PYVERSION >= (3, 6):
+                filename = os.fspath(filename)
+            read_ok.append(filename)
+        return read_ok
+
+    def has_option(self, section, option):
+        for data in self._data:
+            for getter in self.getters:
+                try:
+                    getter(data)[section][option]
+                except KeyError:
+                    continue
+                return True
+        return False
+
+    def has_section(self, section):
+        for data in self._data:
+            for getter in self.getters:
+                try:
+                    getter(data)[section]
+                except KeyError:
+                    continue
+                return section
+        return False
+
+    def options(self, section):
+        for data in self._data:
+            for getter in self.getters:
+                try:
+                    section = getter(data)[section]
+                except KeyError:
+                    continue
+                return list(section.keys())
+        raise configparser.NoSectionError(section)
+
+    def get_section(self, section):
+        d = {}
+        for opt in self.options(section):
+            d[opt] = self.get(section, opt)
+        return d
+
+    def get(self, section, option):
+        found_section = False
+        for data in self._data:
+            for getter in self.getters:
+                try:
+                    section = getter(data)[section]
+                except KeyError:
+                    continue
+
+                found_section = True
+                try:
+                    value = section[option]
+                except KeyError:
+                    continue
+                if isinstance(value, string_class):
+                    value = substitute_variables(value, os.environ)
+                return value
+        if not found_section:
+            raise configparser.NoSectionError(section)
+        raise configparser.NoOptionError(option, section)
+
+    def getboolean(self, section, option):
+        value = self.get(section, option)
+        if not isinstance(value, bool):
+            raise ValueError(
+                'Option {!r} in section {!r} is not a boolean: {!r}'
+                .format(option, section, value))
+        return value
+
+    def getlist(self, section, option):
+        values = self.get(section, option)
+        if not isinstance(values, list):
+            raise ValueError(
+                'Option {!r} in section {!r} is not a list: {!r}'
+                .format(option, section, values))
+        for i, value in enumerate(values):
+            if isinstance(value, string_class):
+                values[i] = substitute_variables(value, os.environ)
+        return values
+
+    def getregexlist(self, section, option):
+        values = self.getlist(section, option)
+        for value in values:
+            value = value.strip()
+            try:
+                re.compile(value)
+            except re.error as e:
+                raise CoverageException(
+                    "Invalid [%s].%s value %r: %s" % (section, option, value, e)
+                )
+        return values
+
+    def getint(self, section, option):
+        value = self.get(section, option)
+        if not isinstance(value, int):
+            raise ValueError(
+                'Option {!r} in section {!r} is not an integer: {!r}'
+                .format(option, section, value))
+        return value
+
+    def getfloat(self, section, option):
+        value = self.get(section, option)
+        if isinstance(value, int):
+            value = float(value)
+        if not isinstance(value, float):
+            raise ValueError(
+                'Option {!r} in section {!r} is not a float: {!r}'
+                .format(option, section, value))
+        return value

--- a/coverage/tomlconfig.py
+++ b/coverage/tomlconfig.py
@@ -8,7 +8,7 @@ import os
 import re
 
 from coverage import env
-from coverage.backward import configparser, path_types, toml
+from coverage.backward import configparser, path_types
 from coverage.misc import CoverageException, substitute_variables
 
 
@@ -32,6 +32,7 @@ class TomlConfigParser:
         self._data = []
 
     def read(self, filenames):
+        from coverage.optional import toml
         if toml is None:
             raise RuntimeError('toml module is not installed.')
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -29,10 +29,10 @@ Coverage.py will read settings from other usual configuration files if no other
 configuration file is used.  It will automatically read from "setup.cfg" or
 "tox.ini" if they exist.  In this case, the section names have "coverage:"
 prefixed, so the ``[run]`` options described below will be found in the
-``[coverage:run]`` section of the file. If Coverage.py is installed with the
+``[coverage:run]`` section of the file. If coverage.py is installed with the
 ``toml`` extra (``pip install coverage[toml]``), it will automatically read
-from "pyproject.toml". Configuration must be within the `[tool.coverage]`
-section, e.g. ``[tool.coverage.run]`.
+from "pyproject.toml". Configuration must be within the ``[tool.coverage]``
+section, for example, ``[tool.coverage.run]``.
 
 
 Syntax

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -29,7 +29,10 @@ Coverage.py will read settings from other usual configuration files if no other
 configuration file is used.  It will automatically read from "setup.cfg" or
 "tox.ini" if they exist.  In this case, the section names have "coverage:"
 prefixed, so the ``[run]`` options described below will be found in the
-``[coverage:run]`` section of the file.
+``[coverage:run]`` section of the file. If Coverage.py is installed with the
+``toml`` extra (``pip install coverage[toml]``), it will automatically read
+from "pyproject.toml". Configuration must be within the `[tool.coverage]`
+section, e.g. ``[tool.coverage.run]`.
 
 
 Syntax

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup_args = dict(
     },
 
     extras_require={
-        # Enable pyproject.toml support
+        # Enable pyproject.toml support.
         'toml': ['toml'],
     },
 

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,11 @@ setup_args = dict(
         ],
     },
 
+    extras_require={
+        # Enable pyproject.toml support
+        'toml': ['toml'],
+    },
+
     # We need to get HTML assets from our htmlfiles directory.
     zip_safe=False,
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,7 +229,7 @@ class ConfigTest(CoverageTest):
         self.make_file("pyproject.toml", """\
             [tool.coverage.run]
             data_file = "$DATA_FILE.fooey"
-            branch = true
+            branch = $BRANCH
             [tool.coverage.report]
             exclude_lines = [
                 "the_$$one",
@@ -239,6 +239,7 @@ class ConfigTest(CoverageTest):
                 "huh$${X}what",
             ]
             """)
+        self.set_environ("BRANCH", "true")
         self.set_environ("DATA_FILE", "hello-world")
         self.set_environ("THING", "ZZZ")
         cov = coverage.Coverage()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -15,6 +15,7 @@ import coverage
 from coverage.backunittest import TestCase, unittest
 from coverage.files import actual_path
 from coverage.misc import StopEverything
+import coverage.optional
 
 from tests.coveragetest import CoverageTest, convert_skip_exceptions
 from tests.helpers import CheckUniqueFilenames, re_lines, re_line
@@ -308,3 +309,14 @@ def _same_python_executable(e1, e2):
         return True
 
     return False                                        # pragma: only failure
+
+
+def test_optional_without():
+    # pylint: disable=reimported
+    from coverage.optional import toml as toml1
+    with coverage.optional.without('toml'):
+        from coverage.optional import toml as toml2
+    from coverage.optional import toml as toml3
+
+    assert toml1 is toml3 is not None
+    assert toml2 is None

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ toxworkdir = {env:TOXWORKDIR:.tox}
 
 [testenv]
 usedevelop = True
+extras =
+    toml
 
 deps =
     # Check here for what might be out of date:
@@ -15,7 +17,6 @@ deps =
     -r requirements/pytest.pip
     pip==19.3.1
     setuptools==41.4.0
-    toml
     # gevent 1.3 causes a failure: https://github.com/nedbat/coveragepy/issues/663
     py{27,35,36}: gevent==1.2.2
     py{27,35,36,37,38}: eventlet==0.25.1

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     -r requirements/pytest.pip
     pip==19.3.1
     setuptools==41.4.0
+    toml
     # gevent 1.3 causes a failure: https://github.com/nedbat/coveragepy/issues/663
     py{27,35,36}: gevent==1.2.2
     py{27,35,36,37,38}: eventlet==0.25.1


### PR DESCRIPTION
On top of what @RazerM did in #699, this:
- Provides error messages for trying to use TOML when toml isn't installed.
- Tests the no-toml-installed scenarios.
- Expands environment variables in all TOML settings.