### PR TITLE
Memoize a syscall-intensive function

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import fnmatch
+import functools
 import ntpath
 import os
 import os.path
@@ -158,6 +159,7 @@ else:
         return filename
 
 
+@functools.lru_cache(None)
 @contract(returns='unicode')
 def abs_file(path):
     """Return the absolute normalized form of `path`."""


### PR DESCRIPTION
This commit adds memoization to the abs_file function, speeding up coverage
collection in a significative way.

This was originally done to improve the number of executions per second of
[pythonfuzz](https://github.com/fuzzitdev/pythonfuzz), with the original
benchmark available [here](https://github.com/fuzzitdev/pythonfuzz/issues/9),
yielding roughly 55% more performances.