### PR TITLE
fix context reporting for relative_files

### DIFF
--- a/coverage/html.py
+++ b/coverage/html.py
@@ -95,7 +95,7 @@ class HtmlDataGeneration(object):
             arcs_executed = analysis.arcs_executed()
 
         if self.config.show_contexts:
-            contexts_by_lineno = analysis.data.contexts_by_lineno(fr.filename)
+            contexts_by_lineno = analysis.data.contexts_by_lineno(analysis.filename)
 
         lines = []
 

--- a/coverage/jsonreport.py
+++ b/coverage/jsonreport.py
@@ -43,7 +43,6 @@ class JsonReporter(object):
         for file_reporter, analysis in get_analysis_to_report(self.coverage, morfs):
             measured_files[file_reporter.relative_filename()] = self.report_one_file(
                 coverage_data,
-                file_reporter,
                 analysis
             )
 
@@ -71,7 +70,7 @@ class JsonReporter(object):
 
         return self.total.n_statements and self.total.pc_covered
 
-    def report_one_file(self, coverage_data, file_reporter, analysis):
+    def report_one_file(self, coverage_data, analysis):
         """Extract the relevant report data for a single file"""
         nums = analysis.numbers
         self.total += nums
@@ -90,7 +89,7 @@ class JsonReporter(object):
         }
         if self.config.json_show_contexts:
             reported_file['contexts'] = analysis.data.contexts_by_lineno(
-                file_reporter.filename
+                analysis.filename,
             )
         if coverage_data.has_arcs():
             reported_file['summary'].update({

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -103,42 +103,51 @@ class JsonReportTest(UsingModulesMixin, CoverageTest):
         self._assert_expected_json_report(cov, expected_result)
 
     def test_context(self):
-        cov = coverage.Coverage(context="cool_test")
-        cov.config.json_show_contexts = True
-        expected_result = {
-            'meta': {
-                "version": coverage.__version__,
-                "branch_coverage": False,
-                "show_contexts": True,
-            },
-            'files': {
-                'a.py': {
-                    'executed_lines': [1, 2],
-                    'missing_lines': [3],
-                    'excluded_lines': [],
-                    "contexts": {
-                        "1": [
-                            "cool_test"
-                        ],
-                        "2": [
-                            "cool_test"
-                        ]
-                    },
-                    'summary': {
-                        'excluded_lines': 0,
-                        'missing_lines': 1,
-                        'covered_lines': 2,
-                        'num_statements': 3,
-                        'percent_covered': 66.66666666666667
+        for relative_files in [False, True]:
+            config_file = os.path.join(self.temp_dir, "config")
+            with open(config_file, 'w') as handle:
+                handle.write(
+                    "[run]\nrelative_files = {}".format(relative_files)
+                )
+            cov = coverage.Coverage(
+                context="cool_test",
+                config_file=config_file
+            )
+            cov.config.json_show_contexts = True
+            expected_result = {
+                'meta': {
+                    "version": coverage.__version__,
+                    "branch_coverage": False,
+                    "show_contexts": True,
+                },
+                'files': {
+                    'a.py': {
+                        'executed_lines': [1, 2],
+                        'missing_lines': [3],
+                        'excluded_lines': [],
+                        "contexts": {
+                            "1": [
+                                "cool_test"
+                            ],
+                            "2": [
+                                "cool_test"
+                            ]
+                        },
+                        'summary': {
+                            'excluded_lines': 0,
+                            'missing_lines': 1,
+                            'covered_lines': 2,
+                            'num_statements': 3,
+                            'percent_covered': 66.66666666666667
+                        }
                     }
+                },
+                'totals': {
+                    'excluded_lines': 0,
+                    'missing_lines': 1,
+                    'covered_lines': 2,
+                    'num_statements': 3,
+                    'percent_covered': 66.66666666666667
                 }
-            },
-            'totals': {
-                'excluded_lines': 0,
-                'missing_lines': 1,
-                'covered_lines': 2,
-                'num_statements': 3,
-                'percent_covered': 66.66666666666667
             }
-        }
-        self._assert_expected_json_report(cov, expected_result)
+            self._assert_expected_json_report(cov, expected_result)


### PR DESCRIPTION
fix reporting of contexts when `relative_files = True`

fixes #900