### PR TITLE
Improve a bit the performances of CoverageData.arcs()

### DIFF
--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -887,9 +887,10 @@ class CoverageData(SimpleReprMixin):
             if file_id is None:
                 return None
             else:
-                query = "select distinct fromno, tono from arc where file_id = ?"
                 data = [file_id]
+                query = "select fromno, tono from arc where file_id = ?"
                 if self._query_context_ids is not None:
+                    query = "select distinct fromno, tono from arc where file_id = ?"
                     ids_array = ', '.join('?' * len(self._query_context_ids))
                     query += " and context_id in (" + ids_array + ")"
                     data += self._query_context_ids

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -894,7 +894,7 @@ class CoverageData(SimpleReprMixin):
                     query += " and context_id in (" + ids_array + ")"
                     data += self._query_context_ids
                 arcs = con.execute(query, data)
-                return list(set(arcs))
+                return sorted(list(set(arcs))
 
     def contexts_by_lineno(self, filename):
         """Get the contexts for each line in a file.

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -894,7 +894,7 @@ class CoverageData(SimpleReprMixin):
                     query += " and context_id in (" + ids_array + ")"
                     data += self._query_context_ids
                 arcs = con.execute(query, data)
-                return sorted(list(set(arcs))
+                return sorted(list(set(arcs)))
 
     def contexts_by_lineno(self, filename):
         """Get the contexts for each line in a file.

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -887,15 +887,14 @@ class CoverageData(SimpleReprMixin):
             if file_id is None:
                 return None
             else:
-                data = [file_id]
                 query = "select fromno, tono from arc where file_id = ?"
+                data = [file_id]
                 if self._query_context_ids is not None:
-                    query = "select distinct fromno, tono from arc where file_id = ?"
                     ids_array = ', '.join('?' * len(self._query_context_ids))
                     query += " and context_id in (" + ids_array + ")"
                     data += self._query_context_ids
                 arcs = con.execute(query, data)
-                return list(arcs)
+                return list(set(arcs))
 
     def contexts_by_lineno(self, filename):
         """Get the contexts for each line in a file.


### PR DESCRIPTION
When there is no context id, there is no need
to use a `distinct` query, since there is already
a `distinct` constrain in the declaration on the table
involving fromno, tono, fileid and contextid, with
contextid being a constant in our case.

This simplifies the query, and improve a bit the performances:

```
sqlite> .explain
sqlite> explain select distinct fromno, tono from arc where file_id = 6;
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     14    0                    00  Start at 14
1     OpenEphemeral  1     0     0     k(2,B,B)       08  nColumn=0
2     OpenRead       2     12    0     k(5,,,,,)      02  root=12 iDb=0; sqlite_autoindex_arc_1
3     Integer        6     1     0                    00  r[1]=6
4     SeekGE         2     13    1     1              00  key=r[1]
5       IdxGT          2     13    1     1              00  key=r[1]
6       Column         2     2     2                    00  r[2]=arc.fromno
7       Column         2     3     3                    00  r[3]=arc.tono
8       Found          1     12    2     2              00  key=r[2..3]
9       MakeRecord     2     2     4                    00  r[4]=mkrec(r[2..3])
10      IdxInsert      1     4     2     2              10  key=r[4]
11      ResultRow      2     2     0                    00  output=r[2..3]
12    Next           2     5     0                    00
13    Halt           0     0     0                    00
14    Transaction    0     0     7     0              01  usesStmtJournal=0
15    Goto           0     1     0                    00
sqlite> explain select  fromno, tono from arc where file_id = 6;
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     10    0                    00  Start at 10
1     OpenRead       1     12    0     k(5,,,,,)      02  root=12 iDb=0; sqlite_autoindex_arc_1
2     Integer        6     1     0                    00  r[1]=6
3     SeekGE         1     9     1     1              00  key=r[1]
4       IdxGT          1     9     1     1              00  key=r[1]
5       Column         1     2     2                    00  r[2]=arc.fromno
6       Column         1     3     3                    00  r[3]=arc.tono
7       ResultRow      2     2     0                    00  output=r[2..3]
8     Next           1     4     0                    00
9     Halt           0     0     0                    00
10    Transaction    0     0     7     0              01  usesStmtJournal=0
11    Goto           0     1     0                    00
sqlite>
```