### PR TITLE
Support patterns in module names

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -242,6 +242,7 @@ class ModuleMatcher(object):
     """A matcher for modules in a tree."""
     def __init__(self, module_names):
         self.modules = list(module_names)
+        self.module_patterns = [re.compile(m) for m in self.modules]
 
     def __repr__(self):
         return "<ModuleMatcher %r>" % (self.modules)
@@ -262,6 +263,10 @@ class ModuleMatcher(object):
                 if module_name[len(m)] == '.':
                     # This is a module in the package
                     return True
+
+        for pattern in self.module_patterns:
+            if pattern.match(module_name):
+                return True
 
         return False
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -174,12 +174,15 @@ class MatcherTest(CoverageTest):
     def test_module_matcher(self):
         matches_to_try = [
             ('test', True),
+            ('te.*', True),
             ('trash', False),
+            ('tra.*', False),
             ('testing', False),
             ('test.x', True),
             ('test.x.y.z', True),
             ('py', False),
             ('py.t', False),
+            ('py.t.*', True),
             ('py.test', True),
             ('py.testing', False),
             ('py.test.buz', True),


### PR DESCRIPTION
This PR adds support for using patterns in the `source` module names. For example the following configuration will match both the `coverage`, as well as the `mycoverage` modules:
```
[run]
source = .*coverage
```