### PR TITLE
Include PID in the atexit log

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -545,7 +545,7 @@ class Coverage(object):
     def _atexit(self):
         """Clean up on process shutdown."""
         if self._debug.should("process"):
-            self._debug.write("atexit: {!r}".format(self))
+            self._debug.write("atexit: pid: {}, instance: {!r}".format(os.getpid(), self))
         if self._started:
             self.stop()
         if self._auto_save:


### PR DESCRIPTION
Hi,

While troubleshooting an issue with processes being forked, I added the `process` debug, which shows the process information, and later when the atexit has been called.

The process information already includes the PID:

```
New process: executable: '/home/kinow/Development/python/workspace/cylc-flow/venv/bin/python'
New process: cmd: ['/home/kinow/Development/python/workspace/cylc-flow/venv/bin/cylc-get-global-config', '--print-user-dir']
New process: pid: 11505, parent pid: 11504
```

However, the atexit contains only the object reference.

```
atexit: <coverage.control.Coverage object at 0x7f394457c3c8>
```

As I had multiple processes, I found it useful to quickly patch my local `coveragepy` to include the PID. Just to be sure that the process was being traced, and that the `_atexit` for the process was also invoked?

Would that be a good idea?

Cheers
Bruno