### PR TITLE
Escape backslashes in windows filepath in config docs

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -240,7 +240,7 @@ patterns to match against the paths of collected data, or they can be absolute
 or relative file paths on the current machine.
 
 In this example, data collected for "/jenkins/build/1234/src/module.py" will be
-combined with data for "c:\myproj\src\module.py", and will be reported against
+combined with data for "c:\\myproj\\src\\module.py", and will be reported against
 the source file found at "src/module.py".
 
 If you specify more than one list of paths, they will be considered in order.


### PR DESCRIPTION
[ReST uses backslashes for escaping](https://docutils.sourceforge.io/docs/user/rst/quickref.html#escaping). Using single backslashes in the windows filepath thus results in a minor rendering issue in the docs (path separator is missing). This PR fixes this.