### PR TITLE
htmlfiles: Handle localStorage not accessible

### DIFF
--- a/coverage/htmlfiles/coverage_html.js
+++ b/coverage/htmlfiles/coverage_html.js
@@ -172,7 +172,10 @@ coverage.index_ready = function ($) {
     // Look for a localStorage item containing previous sort settings:
     var sort_list = [];
     var storage_name = "COVERAGE_INDEX_SORT";
-    var stored_list = localStorage.getItem(storage_name);
+    var stored_list = undefined;
+    try {
+        stored_list = localStorage.getItem(storage_name);
+    } catch(err) {}
 
     if (stored_list) {
         sort_list = JSON.parse('[[' + stored_list + ']]');
@@ -222,7 +225,9 @@ coverage.index_ready = function ($) {
 
     // Watch for page unload events so we can save the final sort settings:
     $(window).unload(function () {
-        localStorage.setItem(storage_name, sort_list.toString())
+        try {
+            localStorage.setItem(storage_name, sort_list.toString())
+        } catch(err) {}
     });
 };
 


### PR DESCRIPTION
In some cases, if based on the browser's settings - localStorage
is not accessible, fallback and don't save the sort-columns into
localStorage.
While the UX is a little inconvenient, at least the page doesn't
break - sorting on columns is still possible, but not retained
between pages.

Resolves https://github.com/nedbat/coveragepy/issues/944