### PR TITLE
Extending jsonreport.py to also include all branch attributes

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -114,6 +114,7 @@ Rodrigue Cloutier
 Roger Hu
 Ross Lawley
 Roy Williams
+Salvatore Zagaria
 Sandra Martocchia
 Scott Belden
 Sigve Tjora

--- a/coverage/jsonreport.py
+++ b/coverage/jsonreport.py
@@ -60,6 +60,8 @@ class JsonReporter(object):
             self.report_data["totals"].update({
                 'num_branches': self.total.n_branches,
                 'num_partial_branches': self.total.n_partial_branches,
+                'covered_branches': self.total.n_executed_branches,
+                'missing_branches': self.total.n_missing_branches,
             })
 
         json.dump(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -65,7 +65,9 @@ class JsonReportTest(UsingModulesMixin, CoverageTest):
                 'num_branches': 2,
                 'excluded_lines': 0,
                 'num_partial_branches': 1,
-                'percent_covered': 60.0
+                'percent_covered': 60.0,
+                'covered_branches': 1,
+                'missing_branches': 1
             }
         }
         self._assert_expected_json_report(cov, expected_result)


### PR DESCRIPTION
The current `jsonreport` does not include the attributes for `covered_branches` and `missing_branches`.

This PR extends `jsonreport.py` such that it includes these attributes; it also updates `test_json.py` to account for these newly-dumped attributes.

Current test status:

```
  py27: commands succeeded
SKIPPED:  py35: InterpreterNotFound: python3.5
  py36: commands succeeded
SKIPPED:  py37: InterpreterNotFound: python3.7
SKIPPED:  py38: InterpreterNotFound: python3.8
SKIPPED:  py39: InterpreterNotFound: python3.9
SKIPPED:  pypy2: InterpreterNotFound: pypy2
SKIPPED:  pypy3: InterpreterNotFound: pypy3
```