### PR TITLE
message for fail-under

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -617,6 +617,7 @@ class CoverageScript(object):
             fail_under = self.coverage.get_option("report:fail_under")
             precision = self.coverage.get_option("report:precision")
             if should_fail_under(total, fail_under, precision):
+                print("fail-under has failed")
                 return FAIL_UNDER
 
         return OK

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1236,13 +1236,13 @@ class FailUnderTest(CoverageTest):
     def test_report_43_is_not_ok(self):
         st, out = self.run_command_status("coverage report --fail-under=44")
         self.assertEqual(st, 2)
-        self.assertEqual(self.last_line_squeezed(out), "forty_two_plus.py 7 4 43%")
+        self.assertEqual(self.last_line_squeezed(out), "fail-under has failed")
 
     def test_report_42p86_is_not_ok(self):
         self.make_file(".coveragerc", "[report]\nprecision = 2")
         st, out = self.run_command_status("coverage report --fail-under=42.88")
         self.assertEqual(st, 2)
-        self.assertEqual(self.last_line_squeezed(out), "forty_two_plus.py 7 4 42.86%")
+        self.assertEqual(self.last_line_squeezed(out), "fail-under has failed")
 
 
 class FailUnderNoFilesTest(CoverageTest):


### PR DESCRIPTION
[PR](https://github.com/nedbat/coveragepy/issues/904) printing the message when fail-under is True.