### PR TITLE
Add --precision option to report command

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -146,6 +146,13 @@ class Opts(object):
             "to be run as 'python -m' would run it."
         ),
     )
+    precision = optparse.make_option(
+        '', '--precision', action='store', metavar='N', type=int,
+        help=(
+            "Number of digits after the decimal point to display for "
+            "reported coverage percentages."
+        ),
+    )
     rcfile = optparse.make_option(
         '', '--rcfile', action='store',
         help=(
@@ -203,6 +210,7 @@ class CoverageOptionParser(optparse.OptionParser, object):
             omit=None,
             contexts=None,
             parallel_mode=None,
+            precision=None,
             pylib=None,
             rcfile=True,
             show_missing=None,
@@ -395,6 +403,7 @@ CMDS = {
             Opts.ignore_errors,
             Opts.include,
             Opts.omit,
+            Opts.precision,
             Opts.show_missing,
             Opts.skip_covered,
             Opts.skip_empty,
@@ -569,6 +578,7 @@ class CoverageScript(object):
             omit=omit,
             include=include,
             contexts=contexts,
+            precision=options.precision,
             )
 
         # We need to be able to import from the current directory, because

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -829,7 +829,7 @@ class Coverage(object):
     def report(
         self, morfs=None, show_missing=None, ignore_errors=None,
         file=None, omit=None, include=None, skip_covered=None,
-        contexts=None, skip_empty=None,
+        contexts=None, skip_empty=None, precision=None,
     ):
         """Write a textual summary report to `file`.
 
@@ -873,7 +873,7 @@ class Coverage(object):
             self,
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,
             show_missing=show_missing, skip_covered=skip_covered,
-            report_contexts=contexts, skip_empty=skip_empty,
+            report_contexts=contexts, skip_empty=skip_empty, precision=precision,
         ):
             reporter = SummaryReporter(self)
             return reporter.report(morfs, outfile=file)


### PR DESCRIPTION
This PR adds a `--precision <N>` CLI option to `coverage report`, so you don't have to write a `.coveragerc` file if you only want to adjust the precision.

Note: I did a few ad-hoc tests and those ran fine, but I couldn't get the test suite to pass. Since I didn't want to spend too much time on this I decided to submit the PR as-is. Hopefully you can fix the failing tests easily, but otherwise I won't be too embarrassed if this gets rejected.