### PR TITLE
tests/gold/html/Makefile: support more shells

### DIFF
--- a/tests/gold/html/Makefile
+++ b/tests/gold/html/Makefile
@@ -7,7 +7,7 @@ help:
 
 complete: 	## Copy support files into directories so the HTML can be viewed properly.
 	@for sub in *; do \
-		if [[ -f $$sub/index.html ]]; then \
+		if if [ -f "$$sub/index.html" ]; then \
 			echo Copying into $$sub ; \
 			cp -n support/* $$sub ; \
 		fi ; \

--- a/tests/gold/html/Makefile
+++ b/tests/gold/html/Makefile
@@ -7,7 +7,7 @@ help:
 
 complete: 	## Copy support files into directories so the HTML can be viewed properly.
 	@for sub in *; do \
-		if if [ -f "$$sub/index.html" ]; then \
+		if [ -f "$$sub/index.html" ]; then \
 			echo Copying into $$sub ; \
 			cp -n support/* $$sub ; \
 		fi ; \


### PR DESCRIPTION
Not all shells support the `[[` keywords. Among them are many `/bin/sh`.