### PR TITLE
Add better details on how to use `[coverage:run]` to exclude files

### DIFF
--- a/doc/source.rst
+++ b/doc/source.rst
@@ -26,7 +26,7 @@ When running your code, the ``coverage run`` command will by default measure
 all code, unless it is part of the Python standard library.
 
 You can specify source to measure with the ``--source`` command-line switch, or
-the ``[run] source`` configuration value.  The value is a comma- or
+the ``[coverage:run] source`` configuration value.  The value is a comma- or
 newline-separated list of directories or package names.  If specified, only
 source inside these directories or packages will be measured.  Specifying the
 source option also enables coverage.py to report on unexecuted files, since it
@@ -38,20 +38,20 @@ text editors). Files that do not end with ``.py`` or ``.pyo`` or ``.pyc``
 will also be skipped.
 
 You can further fine-tune coverage.py's attention with the ``--include`` and
-``--omit`` switches (or ``[run] include`` and ``[run] omit`` configuration
-values). ``--include`` is a list of file name patterns. If specified, only
-files matching those patterns will be measured. ``--omit`` is also a list of
-file name patterns, specifying files not to measure.  If both ``include`` and
-``omit`` are specified, first the set of files is reduced to only those that
-match the include patterns, then any files that match the omit pattern are
-removed from the set.
+``--omit`` switches (or ``[coverage:run] include`` and ``[coverage:run] omit``
+configuration values). ``--include`` is a list of file name patterns. If
+specified, only files matching those patterns will be measured. ``--omit``
+is also a list of file name patterns, specifying files not to measure.  If
+both ``include`` and ``omit`` are specified, first the set of files is
+reduced to only those that match the include patterns, then any files that
+match the omit pattern are removed from the set.
 
 The ``include`` and ``omit`` file name patterns follow typical shell syntax:
 ``*`` matches any number of characters and ``?`` matches a single character.
 Patterns that start with a wildcard character are used as-is, other patterns
 are interpreted relative to the current directory::
 
-    [run]
+    [coverage:run]
     omit =
         # omit anything in a .local directory anywhere
         */.local/*

--- a/doc/source.rst
+++ b/doc/source.rst
@@ -26,16 +26,17 @@ When running your code, the ``coverage run`` command will by default measure
 all code, unless it is part of the Python standard library.
 
 You can specify source to measure with the ``--source`` command-line switch, or
-the ``[coverage:run] source`` configuration value.  The value is a comma- or
-newline-separated list of directories or package names.  If specified, only
-source inside these directories or packages will be measured.  Specifying the
-source option also enables coverage.py to report on unexecuted files, since it
-can search the source tree for files that haven't been measured at all.  Only
-importable files (ones at the root of the tree, or in directories with a
-``__init__.py`` file) will be considered. Files with unusual punctuation in
-their names will be skipped (they are assumed to be scratch files written by
-text editors). Files that do not end with ``.py`` or ``.pyo`` or ``.pyc``
-will also be skipped.
+the ``[coverage:run] source`` configuration value.  To use this configuration
+value, you will need a configuration file, which is described in
+:ref:`setup.cfg`.  The value is a comma- or newline-separated list of
+directories or package names.  If specified, only source inside these directories
+or packages will be measured.  Specifying the source option also enables
+coverage.py to report on unexecuted files, since it can search the source tree
+for files that haven't been measured at all.  Only importable files (ones at the
+root of the tree, or in directories with a ``__init__.py`` file) will be
+considered. Files with unusual punctuation in their names will be skipped (they
+are assumed to be scratch files written by text editors). Files that do not end
+with ``.py`` or ``.pyo`` or ``.pyc`` will also be skipped.
 
 You can further fine-tune coverage.py's attention with the ``--include`` and
 ``--omit`` switches (or ``[coverage:run] include`` and ``[coverage:run] omit``


### PR DESCRIPTION
This PR updates the documentation for excluding files. I initially had trouble when setting it up, and after a bit of searching, I found the name of the file that `[coverage:run]` is specified in (`setup.cfg` or something else, as described in https://coverage.readthedocs.io/en/latest/config.html?highlight=setup.cfg#configuration-reference), and I realized I had to use `[coverage:run]` and not `[run]`.

Please feel free to contact me on this PR with any questions or comments.