### PR TITLE
allow serving the html content for coverage

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -170,6 +170,10 @@ class Opts(object):
             "'pyproject.toml' are tried. [env: COVERAGE_RCFILE]"
         ),
     )
+    serve = optparse.make_option(
+        '', '--serve', action='store_true', default=False,
+        help='Serve htmlcov directory to default webbrowser',
+    )
     source = optparse.make_option(
         '', '--source', action='store', metavar="SRC1,SRC2,...",
         help="A list of packages or directories of code to be measured.",
@@ -385,6 +389,7 @@ CMDS = {
             Opts.no_skip_covered,
             Opts.skip_empty,
             Opts.title,
+            Opts.serve,
             ] + GLOBAL_ARGS,
         usage="[options] [modules]",
         description=(
@@ -619,6 +624,7 @@ class CoverageScript(object):
         elif options.action == "html":
             total = self.coverage.html_report(
                 directory=options.directory,
+                serve=options.serve,
                 title=options.title,
                 skip_covered=options.skip_covered,
                 skip_empty=options.skip_empty,

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -21,7 +21,7 @@ from coverage.data import CoverageData, combine_parallel_data
 from coverage.debug import DebugControl, short_stack, write_formatted_info
 from coverage.disposition import disposition_debug_msg
 from coverage.files import PathAliases, abs_file, relative_filename, set_relative_directory
-from coverage.html import HtmlReporter
+from coverage.html import HtmlReporter, serve_htmldir
 from coverage.inorout import InOrOut
 from coverage.jsonreport import JsonReporter
 from coverage.misc import CoverageException, bool_or_none, join_regex
@@ -912,7 +912,7 @@ class Coverage(object):
         self, morfs=None, directory=None, ignore_errors=None,
         omit=None, include=None, extra_css=None, title=None,
         skip_covered=None, show_contexts=None, contexts=None,
-        skip_empty=None, precision=None,
+        skip_empty=None, precision=None, serve=False,
     ):
         """Generate an HTML report.
 
@@ -944,7 +944,10 @@ class Coverage(object):
             skip_empty=skip_empty, precision=precision,
         ):
             reporter = HtmlReporter(self)
-            return reporter.report(morfs)
+            total = reporter.report(morfs)
+        if serve is True:
+            serve_htmldir(directory)
+        return total
 
     def xml_report(
         self, morfs=None, outfile=None, ignore_errors=None,


### PR DESCRIPTION
Hi!

I have been playing with this for as a tool for local stuff, and I was wondering if there was any interest in it being added to coveragepy, and I would spend the time to make it compatible for python2.

What it does is start a simple html server in a thread, and then use the port that is sent back by the simple http server, and then use the built webbrowser module to open the directory in the browser for viewing.

Let me know if yall are interested, if not, that is ok too.

Thanks!
Daniel