### PR TITLE
if source looks like a package add it to source_pkgs

### DIFF
--- a/coverage/inorout.py
+++ b/coverage/inorout.py
@@ -111,7 +111,7 @@ def module_has_file(mod):
 
 
 _IS_PKG_RE = re.compile(
-    r"\A(((?!keywords){tokenize.Name})\.?)+\Z".format(
+    r"\A(((?!{keywords}){tokenize.Name})\.?)+\Z".format(
         tokenize=tokenize,
         keywords="|".join(re.escape(kw) for kw in keyword.kwlist),
     )


### PR DESCRIPTION
an alternative to https://github.com/nedbat/coveragepy/pull/1026 in which ambiguous `source` definitions use the package and the dir 