### PR TITLE
Prevent plugin dependencies in "omit" from causing already-imported warnings

### DIFF
--- a/coverage/inorout.py
+++ b/coverage/inorout.py
@@ -384,6 +384,11 @@ class InOrOut(object):
                 if filename in warned:
                     continue
 
+                file_path = canonical_filename(filename)
+                if self.omit_match and self.omit_match.match(file_path):
+                    continue
+
+
                 disp = self.should_trace(filename)
                 if disp.trace:
                     msg = "Already imported a file that will be measured: {}".format(filename)

--- a/coverage/inorout.py
+++ b/coverage/inorout.py
@@ -385,8 +385,8 @@ class InOrOut(object):
                     continue
 
                 file_path = canonical_filename(filename)
-                # if self.omit_match and self.omit_match.match(file_path):
-                #     continue
+                if self.omit_match and self.omit_match.match(file_path):
+                    continue
 
                 disp = self.should_trace(filename)
                 if disp.trace:

--- a/coverage/inorout.py
+++ b/coverage/inorout.py
@@ -385,9 +385,8 @@ class InOrOut(object):
                     continue
 
                 file_path = canonical_filename(filename)
-                if self.omit_match and self.omit_match.match(file_path):
-                    continue
-
+                # if self.omit_match and self.omit_match.match(file_path):
+                #     continue
 
                 disp = self.should_trace(filename)
                 if disp.trace:


### PR DESCRIPTION
I came across the same bug noted [in this comment](https://github.com/nedbat/django_coverage_plugin/issues/71#issuecomment-678193581) when using django plugin  alongside both source/include _and_ omit would cause a bunch of already-imported warnings for the plugin's dependencies:

```
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/__init__.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/engine.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/base.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/context.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/exceptions.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/library.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/utils.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/defaulttags.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/defaultfilters.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/template/smartif.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/templatetags/__init__.py (already-imported)
Coverage.py warning: Already imported a file that will be measured: .../venv/lib/python3.7/site-packages/django/templatetags/i18n.py (already-imported)
```


I tried to fix this from the plugin side, but the only place the plugin gets an opinion is in the plugin's `file_tracer()` method, and we can't disable tracing for the core django templates, otherwise we can't trace the templates themselves. 

Every other `omit_match` check is used too late, after plugins have already imported their dependencies

