### PR TITLE
Fix the recording of arcs for non-Python files

### DIFF
--- a/coverage/ctracer/datastack.c
+++ b/coverage/ctracer/datastack.c
@@ -45,6 +45,9 @@ DataStack_grow(Stats *pstats, DataStack *pdata_stack)
 
         pdata_stack->stack = bigger_data_stack;
         pdata_stack->alloc = bigger;
+    } else {
+        /* Zero the entry, because it may have been previously used and can still contain data. */
+        memset(pdata_stack->stack + pdata_stack->depth, 0, sizeof(DataStackEntry));
     }
     return RET_OK;
 }

--- a/coverage/ctracer/datastack.h
+++ b/coverage/ctracer/datastack.h
@@ -22,7 +22,8 @@ typedef struct DataStackEntry {
     PyObject * file_tracer;
 
     /* The line number of the last line recorded, for tracing arcs.
-        -1 means there was no previous line, as when entering a code object.
+       0 means there was no previous line.
+       A negative number -N means we've just entered the code object which starts at line N.
     */
     int last_line;
 

--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -698,7 +698,6 @@ CTracer_handle_return(CTracer *self, PyFrameObject *frame)
     PyObject * pCode = NULL;
 
     STATS( self->stats.returns++; )
-    /* A near-copy of this code is above in the missing-return handler. */
     if (CTracer_set_pdata_stack(self) < 0) {
         goto error;
     }

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -981,7 +981,7 @@ class CoverageData(AutoReprMixin):
 
         Negative numbers have special meaning.  If the starting line number is
         -N, it represents an entry to the code object that starts at line N.
-        If the ending ling number is -N, it's an exit from the code object that
+        If the ending line number is -N, it's an exit from the code object that
         starts at line N.
 
         """


### PR DESCRIPTION
Hi,

While developing new coverage plugins I found that they received invalid arcs when branch coverage was turned on.

An example of an obviously invalid arc is one which contains a line number greater than the actual number of lines in the file. This can happen when the generated python code being executed is longer than the source code it was generated from.

This problem has two causes:

1. The tracer mixes mapped and unmapped line numbers. In other words, not all line numbers are passed through the tracer's `line_number_range` method before being recorded.
2. The `DataStackEntry` struct isn't cleared before being reused. Not clearing its `last_line` attribute results in bogus arcs being recorded.

My patch fixes both problems.

I don't often write C code, so please let me know if you see something that I could have done better.