### PR TITLE
🐛 Fix HTML report sorting order storage in jQuery unload event

### DIFF
--- a/coverage/htmlfiles/coverage_html.js
+++ b/coverage/htmlfiles/coverage_html.js
@@ -224,7 +224,7 @@ coverage.index_ready = function ($) {
     coverage.wire_up_filter();
 
     // Watch for page unload events so we can save the final sort settings:
-    $(window).unload(function () {
+    $(window).on("unload", function () {
         try {
             localStorage.setItem(storage_name, sort_list.toString())
         } catch(err) {}


### PR DESCRIPTION
🐛 Fix HTML report sorting order storage in jQuery unload event.

This is related to: https://github.com/nedbat/coveragepy/issues/986

I'm having a (probably) similar issue. In the generated HTML report, on the console, I'm seeing an error:

```
Uncaught TypeError: $(...).unload is not a function
    at HTMLDocument.coverage.index_ready (coverage_html.js:227)
    at mightThrow (jquery.min.js:2)
    at process (jquery.min.js:2)
```

Using `$().unload` was deprecated and [removed in jQuery 3](https://api.jquery.com/unload/#unload-handler). The recommendation is to use `$().on("unload", handler)`.

I see that it seems the included minified jQuery JS file says it has version 1.11: https://github.com/nedbat/coveragepy/blob/master/coverage/htmlfiles/jquery.min.js#L1

Nevertheless, when I generate an HTML report from scratch in a local project, the minified jQuery I get is indeed 3.x. I have no idea why.

Either way, the method with `$().on("unload", handler)` works with both versions.

For completeness, I'm on Chrome, on Ubuntu.