### PR TITLE
Retry in the case of failures. #1010

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,9 +27,14 @@ Unreleased
 - When using ``--source`` on a large source tree, v5.x was slower than previous
   versions.  This performance regression is now fixed, closing `issue 1037`_.
 
+- Mysterious SQLite errors can happen on PyPy, as reported in `issue 1010`_. An
+  immediate retry seems to fix the problem, although it is an unsatisfying
+  solution.
+
 - Continuous integration has moved from Travis and AppVeyor to GitHub Actions.
 
 .. _issue 1037: https://github.com/nedbat/coveragepy/issues/1037
+.. _issue 1010: https://github.com/nedbat/coveragepy/issues/1010
 
 
 .. _changes_53:

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -1056,7 +1056,13 @@ class SqliteDb(SimpleReprMixin):
             tail = " with {!r}".format(parameters) if parameters else ""
             self.debug.write("Executing {!r}{}".format(sql, tail))
         try:
-            return self.con.execute(sql, parameters)
+            try:
+                return self.con.execute(sql, parameters)
+            except Exception:
+                # In some cases, an error might happen that isn't really an
+                # error.  Try again immediately.
+                # https://github.com/nedbat/coveragepy/issues/1010
+                return self.con.execute(sql, parameters)
         except sqlite3.Error as exc:
             msg = str(exc)
             try:


### PR DESCRIPTION
PyPy seems prone to intermittent SQLite failures.  An immediate retry
avoids them.  Not great, but it works.