### PR TITLE
fix: combine aliases on windows base dirs (ie: ``X:\``) (fixes: #577)

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -359,17 +359,19 @@ class PathAliases(object):
         match an entire tree, and not just its root.
 
         """
+        pattern_sep = sep(pattern)
+
         if len(pattern) > 1:
             pattern = pattern.rstrip(r"\/")
 
         # The pattern can't end with a wildcard component.
         if pattern.endswith("*"):
             raise CoverageException("Pattern must not end with wildcards.")
-        pattern_sep = sep(pattern)
 
         # The pattern is meant to match a filepath.  Let's make it absolute
         # unless it already is, or is meant to match any prefix.
-        if not pattern.startswith('*') and not isabs_anywhere(pattern):
+        if not pattern.startswith('*') and not isabs_anywhere(pattern +
+                                                              pattern_sep):
             pattern = abs_file(pattern)
         if not pattern.endswith(pattern_sep):
             pattern += pattern_sep

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -349,6 +349,20 @@ class PathAliasesTest(CoverageTest):
             './django/foo/bar.py'
         )
 
+    def test_windows_root_paths(self):
+        aliases = PathAliases()
+        aliases.add('X:\\', '/tmp/src')
+        self.assert_mapped(
+            aliases,
+            "X:\\a\\file.py",
+            "/tmp/src/a/file.py"
+        )
+        self.assert_mapped(
+            aliases,
+            "X:\\file.py",
+            "/tmp/src/file.py"
+        )
+
     def test_leading_wildcard(self):
         aliases = PathAliases()
         aliases.add('*/d1', './mysrc1')


### PR DESCRIPTION
Illustrating a valid fix for my issue, that is still happening ;-)

I had a (very quick) look at running the tests, but unfortunately I had a lot of tests failing on the pristine source prior to any change. So I figured I missed a lot of dependencies or information to get this running properly. I'm afraid that I couldn't check that I didn't break anything properly before submitting that code change.

If you think this code change is definitively worth it, I'll take the time to add tests to your convenience if required.
