### PR TITLE
Prevent misbehaving dynamic context plugins from ruining coverage

### DIFF
--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -70,6 +70,7 @@ CREATE TABLE context (
     id integer primary key,
     context text,
     unique (context)
+    ON CONFLICT IGNORE
 );
 
 CREATE TABLE line_bits (

--- a/doc/dbschema.rst
+++ b/doc/dbschema.rst
@@ -72,6 +72,7 @@ TODO: explain more. Readers: what needs explaining?
         id integer primary key,
         context text,
         unique (context)
+        ON CONFLICT IGNORE
     );
 
     CREATE TABLE line_bits (


### PR DESCRIPTION
While working on a dynamic context plugin I encountered an issue where contexts are not unique(I think it's related to subprocess coverage, but I haven't been able to create a small enough example to show here).

While we can argue that the plugin itself should be fixed, this looks like an innocuous change to `coveragepy` which can prevent these misbehaving plugins from ruining most of the coverage data(not being covered).