### PR TITLE
skip_covered and skip_empty for HTML. #1090

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,12 +29,19 @@ Unreleased
   of the output easier.  Thanks, Judson Neer.  This had been requested a number
   of times (`issue 1086`_, `issue 922`_, `issue 732`_).
 
+- The ``skip_covered`` and ``skip_empty`` settings in the configuration file
+  can now be specified in the ``[html]`` section, so that text reports and HTML
+  reports can use separate settings.  The HTML report will still use the
+  ``[report]`` settings if there isn't a value in the ``[html]`` section.
+  Closes `issue 1090`_.
+
 - Update to support Python 3.10 alphas in progress, including `PEP 626: Precise
   line numbers for debugging and other tools <pep626_>`_.
 
-.. _issue 1086: https://github.com/nedbat/coveragepy/issues/1086
 .. _issue 732: https://github.com/nedbat/coveragepy/issues/732
 .. _issue 922: https://github.com/nedbat/coveragepy/issues/922
+.. _issue 1086: https://github.com/nedbat/coveragepy/issues/1086
+.. _issue 1090: https://github.com/nedbat/coveragepy/issues/1090
 
 .. _pep626: https://www.python.org/dev/peps/pep-0626/
 

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -217,6 +217,8 @@ class CoverageConfig(object):
         # Defaults for [html]
         self.extra_css = None
         self.html_dir = "htmlcov"
+        self.html_skip_covered = None
+        self.html_skip_empty = None
         self.html_title = "Coverage report"
         self.show_contexts = False
 
@@ -384,6 +386,8 @@ class CoverageConfig(object):
         # [html]
         ('extra_css', 'html:extra_css'),
         ('html_dir', 'html:directory'),
+        ('html_skip_covered', 'html:skip_covered', 'boolean'),
+        ('html_skip_empty', 'html:skip_empty', 'boolean'),
         ('html_title', 'html:title'),
         ('show_contexts', 'html:show_contexts', 'boolean'),
 

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -955,8 +955,8 @@ class Coverage(object):
         with override_config(self,
             ignore_errors=ignore_errors, report_omit=omit, report_include=include,
             html_dir=directory, extra_css=extra_css, html_title=title,
-            skip_covered=skip_covered, show_contexts=show_contexts, report_contexts=contexts,
-            skip_empty=skip_empty, precision=precision,
+            html_skip_covered=skip_covered, show_contexts=show_contexts, report_contexts=contexts,
+            html_skip_empty=skip_empty, precision=precision,
         ):
             reporter = HtmlReporter(self)
             return reporter.report(morfs)

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -173,6 +173,14 @@ class HtmlReporter(object):
         self.coverage = cov
         self.config = self.coverage.config
         self.directory = self.config.html_dir
+
+        self.skip_covered = self.config.html_skip_covered
+        if self.skip_covered is None:
+            self.skip_covered = self.config.skip_covered
+        self.skip_empty = self.config.html_skip_empty
+        if self.skip_empty is None:
+            self.skip_empty= self.config.skip_empty
+
         title = self.config.html_title
         if env.PY2:
             title = title.decode("utf8")
@@ -271,7 +279,7 @@ class HtmlReporter(object):
         nums = analysis.numbers
         self.all_files_nums.append(nums)
 
-        if self.config.skip_covered:
+        if self.skip_covered:
             # Don't report on 100% files.
             no_missing_lines = (nums.n_missing == 0)
             no_missing_branches = (nums.n_partial_branches == 0)
@@ -280,7 +288,7 @@ class HtmlReporter(object):
                 file_be_gone(html_path)
                 return
 
-        if self.config.skip_empty:
+        if self.skip_empty:
             # Don't report on empty files.
             if nums.n_statements == 0:
                 file_be_gone(html_path)

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -315,16 +315,6 @@ setting also affects the interpretation of the ``fail_under`` setting.
 ``show_missing`` (boolean, default False): when running a summary report, show
 missing lines.  See :ref:`cmd_report` for more information.
 
-.. _config_report_skip_covered:
-
-``skip_covered`` (boolean, default False): Don't include files in the report
-that are 100% covered files. See :ref:`cmd_report` for more information.
-
-.. _config_report_skip_empty:
-
-``skip_empty`` (boolean, default False): Don't include empty files (those that
-have 0 statements) in the report. See :ref:`cmd_report` for more information.
-
 .. _config_report_sort:
 
 ``sort`` (string, default "Name"): Sort the text report by the named column.
@@ -344,18 +334,30 @@ also apply to HTML output, where appropriate.
 ``directory`` (string, default "htmlcov"): where to write the HTML report
 files.
 
-.. _config_html_show_context:
-
-``show_contexts`` (boolean): should the HTML report include an indication on
-each line of which contexts executed the line.  See :ref:`dynamic_contexts` for
-details.
-
 .. _config_html_extra_css:
 
 ``extra_css`` (string): the path to a file of CSS to apply to the HTML report.
 The file will be copied into the HTML output directory.  Don't name it
 "style.css".  This CSS is in addition to the CSS normally used, though you can
 overwrite as many of the rules as you like.
+
+.. _config_html_show_context:
+
+``show_contexts`` (boolean): should the HTML report include an indication on
+each line of which contexts executed the line.  See :ref:`dynamic_contexts` for
+details.
+
+.. _config_html_skip_covered:
+
+``skip_covered`` (boolean, defaulted from ``[report] skip_covered``): Don't
+include files in the report that are 100% covered files. See :ref:`cmd_report`
+for more information.
+
+.. _config_html_skip_empty:
+
+``skip_empty`` (boolean, defaulted from ``[report] skip_empty``): Don't include
+empty files (those that have 0 statements) in the report. See :ref:`cmd_report`
+for more information.
 
 .. _config_html_title:
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -495,7 +495,8 @@ class HtmlTest(HtmlTestHelpers, CoverageTest):
         self.assert_exists("htmlcov/index.html")
         self.assert_exists("htmlcov/other_py.html")
 
-    def test_report_skip_covered_no_branches(self):
+    def make_main_and_not_covered(self):
+        """Helper to create files for skip_covered scenarios."""
         self.make_file("main_file.py", """
             import not_covered
 
@@ -507,7 +508,25 @@ class HtmlTest(HtmlTestHelpers, CoverageTest):
             def not_covered():
                 print("n")
         """)
+
+    def test_report_skip_covered(self):
+        self.make_main_and_not_covered()
         self.run_coverage(htmlargs=dict(skip_covered=True))
+        self.assert_exists("htmlcov/index.html")
+        self.assert_doesnt_exist("htmlcov/main_file_py.html")
+        self.assert_exists("htmlcov/not_covered_py.html")
+
+    def test_html_skip_covered(self):
+        self.make_main_and_not_covered()
+        self.make_file(".coveragerc", "[html]\nskip_covered = True")
+        self.run_coverage()
+        self.assert_exists("htmlcov/index.html")
+        self.assert_doesnt_exist("htmlcov/main_file_py.html")
+        self.assert_exists("htmlcov/not_covered_py.html")
+
+    def test_report_skip_covered_branches(self):
+        self.make_main_and_not_covered()
+        self.run_coverage(covargs=dict(branch=True), htmlargs=dict(skip_covered=True))
         self.assert_exists("htmlcov/index.html")
         self.assert_doesnt_exist("htmlcov/main_file_py.html")
         self.assert_exists("htmlcov/not_covered_py.html")
@@ -522,24 +541,8 @@ class HtmlTest(HtmlTestHelpers, CoverageTest):
         self.assertEqual(res, 100.0)
         self.assert_doesnt_exist("htmlcov/main_file_py.html")
 
-    def test_report_skip_covered_branches(self):
-        self.make_file("main_file.py", """
-            import not_covered
-
-            def normal():
-                print("z")
-            normal()
-        """)
-        self.make_file("not_covered.py", """
-            def not_covered():
-                print("n")
-        """)
-        self.run_coverage(covargs=dict(branch=True), htmlargs=dict(skip_covered=True))
-        self.assert_exists("htmlcov/index.html")
-        self.assert_doesnt_exist("htmlcov/main_file_py.html")
-        self.assert_exists("htmlcov/not_covered_py.html")
-
-    def test_report_skip_empty_files(self):
+    def make_init_and_main(self):
+        """Helper to create files for skip_empty scenarios."""
         self.make_file("submodule/__init__.py", "")
         self.make_file("main_file.py", """
             import submodule
@@ -548,7 +551,18 @@ class HtmlTest(HtmlTestHelpers, CoverageTest):
                 print("z")
             normal()
         """)
+
+    def test_report_skip_empty(self):
+        self.make_init_and_main()
         self.run_coverage(htmlargs=dict(skip_empty=True))
+        self.assert_exists("htmlcov/index.html")
+        self.assert_exists("htmlcov/main_file_py.html")
+        self.assert_doesnt_exist("htmlcov/submodule___init___py.html")
+
+    def test_html_skip_empty(self):
+        self.make_init_and_main()
+        self.make_file(".coveragerc", "[html]\nskip_empty = True")
+        self.run_coverage()
         self.assert_exists("htmlcov/index.html")
         self.assert_exists("htmlcov/main_file_py.html")
         self.assert_doesnt_exist("htmlcov/submodule___init___py.html")


### PR DESCRIPTION
The ``skip_covered`` and ``skip_empty`` settings in the configuration file
  can now be specified in the ``[html]`` section, so that text reports and HTML
  reports can use separate settings.  The HTML report will still use the
  ``[report]`` settings if there isn't a value in the ``[html]`` section.
