### PR TITLE
add command line option to show current configuration

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -114,6 +114,10 @@ class Opts(object):
         '--show-contexts', action='store_true',
         help="Show contexts for covered lines.",
     )
+    show_omit = optparse.make_option(
+        '--show-omit', action='store_true',
+        help="Show omit entries in coverage config files.",
+    )
     omit = optparse.make_option(
         '', '--omit', action='store',
         metavar="PAT1,PAT2,...",
@@ -212,6 +216,7 @@ class CoverageOptionParser(optparse.OptionParser, object):
             append=None,
             branch=None,
             concurrency=None,
+            config=None,
             context=None,
             debug=None,
             directory=None,
@@ -231,6 +236,7 @@ class CoverageOptionParser(optparse.OptionParser, object):
             skip_covered=None,
             skip_empty=None,
             show_contexts=None,
+            show_omit=None,
             sort=None,
             source=None,
             timid=None,
@@ -348,6 +354,20 @@ CMDS = {
             "arguments are data files or directories containing data files. "
             "If no paths are provided, data files in the default data file's "
             "directory are combined."
+        ),
+    ),
+
+    'config': CmdOptionParser(
+        "config",
+        [
+            Opts.show_omit,
+            Opts.output_json,
+        ] + GLOBAL_ARGS,
+        usage="[options] [modules]",
+        description=(
+            "Get current configuration. "
+            "Topics are: "
+                "'omit' to show configuration omit entries in list format; "
         ),
     ),
 
@@ -609,6 +629,18 @@ class CoverageScript(object):
         sys.path.insert(0, '')
 
         self.coverage.load()
+
+        if options.action == "config":
+            # Allows end user to see omit settings
+            # Useful since there are several configuration files in many different formats
+            # Which do environment variable expansion, etc
+            if options.show_omit:
+                if options.outfile == "json":
+                    print(self.coverage.config.run_omit)
+                else:
+                    joined_string = ",".join(self.coverage.config.run_omit)
+                    print(joined_string)
+            return OK
 
         total = None
         if options.action == "report":

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -34,6 +34,9 @@ class BaseCmdLineTest(CoverageTest):
         directory=None, ignore_errors=None, include=None, omit=None, morfs=[],
         contexts=None,
     )
+    _defaults.Coverage().config(
+        show_omit=None, json=None
+    )
     _defaults.Coverage().html_report(
         directory=None, ignore_errors=None, include=None, omit=None, morfs=[],
         skip_covered=None, show_contexts=None, title=None, contexts=None,
@@ -251,6 +254,11 @@ class CmdLineTest(BaseCmdLineTest):
     def test_debug(self):
         self.cmd_help("debug", "What information would you like: config, data, sys, premain?")
         self.cmd_help("debug foo", "Don't know what you mean by 'foo'")
+
+    def test_config(self):
+        self.command_line("config")
+        out = self.stdout()
+        assert "" in out
 
     def test_debug_sys(self):
         self.command_line("debug sys")


### PR DESCRIPTION
It's useful to be able to determine in advance of running an analysis what the current configuration is.
This adds support for exposing the end resulting configuration via cmd
ex.
`coverage config --show-omit -o json`

Signed-off-by: smcavallo <smcavallo@hotmail.com>