### PR TITLE
Fix documentation code comment formatting

### DIFF
--- a/doc/branch.rst
+++ b/doc/branch.rst
@@ -108,7 +108,7 @@ tell coverage.py that you don't want them flagged by marking them with a
 pragma::
 
     i = 0
-    while i < 999999999:    # pragma: no branch
+    while i < 999999999:  # pragma: no branch
         if eventually():
             break
 

--- a/doc/branch.rst
+++ b/doc/branch.rst
@@ -17,10 +17,10 @@ and flags lines that haven't visited all of their possible destinations.
 
 For example::
 
-    def my_partial_fn(x):       # line 1
-        if x:                   #      2
-            y = 10              #      3
-        return y                #      4
+    def my_partial_fn(x):
+        if x:
+            y = 10
+        return y
 
     my_partial_fn(1)
 

--- a/doc/branch.rst
+++ b/doc/branch.rst
@@ -78,7 +78,7 @@ as a branch if one of its choices is excluded::
         if x:
             blah1()
             blah2()
-        else:       # pragma: no cover
+        else:  # pragma: no cover
             # x is always true.
             blah3()
 

--- a/doc/cmd.rst
+++ b/doc/cmd.rst
@@ -517,7 +517,7 @@ For example::
 
     > def h(x):
           """Silly function."""
-    -     if 0:   #pragma: no cover
+    -     if 0:  # pragma: no cover
     -         pass
     >     if x == 1:
     !         a = 1

--- a/doc/excluding.rst
+++ b/doc/excluding.rst
@@ -17,7 +17,7 @@ Coverage.py will look for comments marking clauses for exclusion.  In this
 code, the "if debug" clause is excluded from reporting::
 
     a = my_function1()
-    if debug:   # pragma: no cover
+    if debug:  # pragma: no cover
         msg = "blah blah"
         log_message(msg, a)
     b = my_function2()
@@ -32,7 +32,7 @@ function is not reported as missing::
             blah1()
             blah2()
 
-        def __repr__(self): # pragma: no cover
+        def __repr__(self):  # pragma: no cover
             return "<MyObject>"
 
 Excluded code is executed as usual, and its execution is recorded in the

--- a/doc/excluding.rst
+++ b/doc/excluding.rst
@@ -50,7 +50,7 @@ counted as a branch if one of its choices is excluded::
         if x:
             blah1()
             blah2()
-        else:       # pragma: no cover
+        else:  # pragma: no cover
             # x is always true.
             blah3()
 


### PR DESCRIPTION
Hey!

I was going through [Excluding code from coverage.py](https://coverage.readthedocs.io/en/latest/excluding.html) and found formatting issues in the comments used in code examples. Fixed those and a couple more from other pages.

I tried to keep it inline with [PEP8](https://www.python.org/dev/peps/pep-0008/#inline-comments)

Depending on the type of change I made and their need, I have separated the changes into 3 commits.
With each commit message explaining the reasoning behind the change.