### PR TITLE
Use license_files instead of deprecated license_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ ignore = E265,E266,E123,E133,E226,E241,E242,E301,E401
 max-line-length = 100
 
 [metadata]
-license_file = LICENSE.txt
+license_files = LICENSE.txt


### PR DESCRIPTION
# master

Warns that `the 'license_file' option is deprecated, use 'license_files' instead`.

```console
$ make lint
tox -q -e lint
lists of files in version control and sdist match
warning: the 'license_file' option is deprecated, use 'license_files' instead
warning: no previously-included files found matching 'ci/*.token'
no previously-included directories found matching 'doc/_build'
no previously-included directories found matching 'doc/_spell'
no previously-included directories found matching 'tests/eggsrc/build'
warning: no previously-included files matching '*.py[co]' found anywhere in distribution
Checking dist/coverage-6.0a0-cp39-cp39-macosx_10_9_x86_64.whl: PASSED
Checking dist/coverage-6.0a0.tar.gz: PASSED
___________________________________________________ summary ____________________________________________________
  lint: commands succeeded
  congratulations :)
```

# PR

```console
$  make lint
tox -q -e lint
lists of files in version control and sdist match
warning: no previously-included files found matching 'ci/*.token'
no previously-included directories found matching 'doc/_build'
no previously-included directories found matching 'doc/_spell'
no previously-included directories found matching 'tests/eggsrc/build'
warning: no previously-included files matching '*.py[co]' found anywhere in distribution
Checking dist/coverage-6.0a0-cp39-cp39-macosx_10_9_x86_64.whl: PASSED
Checking dist/coverage-6.0a0.tar.gz: PASSED
___________________________________________________ summary ____________________________________________________
  lint: commands succeeded
  congratulations :)
```

# More info

* https://setuptools.readthedocs.io/en/latest/history.html#v56-0-0
* https://setuptools.readthedocs.io/en/latest/references/keywords.html?highlight=license_files#keywords

`license_file` was deprecated in setuptools v56.0.0, use `license_files` instead.

Also 

> If neither `license_file` nor `license_files` is specified, the `sdist` option will now auto-include files that match the following patterns: `LICEN[CS]E*`, `COPYING*`, `NOTICE*`, `AUTHORS*`. This matches the behavior of `bdist_wheel`.

So we could omit it altogether to simplify config a bit, what do you think?
