### PR TITLE
fix(python): handle source decoding errors

### DIFF
--- a/coverage/python.py
+++ b/coverage/python.py
@@ -63,7 +63,10 @@ def get_python_source(filename):
 
     # Replace \f because of http://bugs.python.org/issue19035
     source = source.replace(b'\f', b' ')
-    source = source.decode(source_encoding(source), "replace")
+    try:
+        source = source.decode(source_encoding(source), "replace")
+    except Exception as e:
+        raise NoSource("Cannot decode source '%s: %s" % (filename, e))
 
     # Python code should always end with a line with a newline.
     if source and source[-1] != '\n':


### PR DESCRIPTION
As described in #1160, occasionally some shared object paths make their way into the coverage report. When they get to `get_python_source` the call to `source_encoding` fails because the content of these files is binary. The change allows `get_python_source` to handle these cases gracefully while still reporting the issue.

Fixes #1160.