### PR TITLE
Support TOML v1.0.0 syntax in `pyproject.toml`

### DIFF
--- a/coverage/tomlconfig.py
+++ b/coverage/tomlconfig.py
@@ -12,9 +12,9 @@ from coverage.misc import substitute_variables
 
 # TOML support is an install-time extra option.
 try:
-    import toml
+    import tomli
 except ImportError:         # pragma: not covered
-    toml = None
+    tomli = None
 
 
 class TomlDecodeError(Exception):
@@ -44,12 +44,12 @@ class TomlConfigParser:
                 toml_text = fp.read()
         except OSError:
             return []
-        if toml:
+        if tomli is not None:
             toml_text = substitute_variables(toml_text, os.environ)
             try:
-                self.data = toml.loads(toml_text)
-            except toml.TomlDecodeError as err:
-                raise TomlDecodeError(*err.args)
+                self.data = tomli.loads(toml_text)
+            except tomli.TOMLDecodeError as err:
+                raise TomlDecodeError(str(err))
             return [filename]
         else:
             has_toml = re.search(r"^\[tool\.coverage\.", toml_text, flags=re.MULTILINE)

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup_args = dict(
 
     extras_require={
         # Enable pyproject.toml support.
-        'toml': ['toml'],
+        'toml': ['tomli'],
     },
 
     # We need to get HTML assets from our htmlfiles directory.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -242,7 +242,7 @@ def without_module(using_module, missing_module_name):
     Use this in a test function to make an optional module unavailable during
     the test::
 
-        with without_module(product.something, 'toml'):
+        with without_module(product.something, 'tomli'):
             use_toml_somehow()
 
     Arguments:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,31 +186,28 @@ class ConfigTest(CoverageTest):
             with pytest.raises(CoverageException, match=msg):
                 coverage.Coverage()
 
-    def test_toml_parse_errors(self):
+    @pytest.mark.parametrize("bad_config,msg", [
+        ("[tool.coverage.run]\ntimid = \"maybe?\"\n", r"maybe[?]"),
+        ("[tool.coverage.run\n", r"Key group"),
+        ('[tool.coverage.report]\nexclude_lines = ["foo("]\n',
+         r"Invalid \[tool.coverage.report\].exclude_lines value u?'foo\(': "
+         r"(unbalanced parenthesis|missing \))"),
+        ('[tool.coverage.report]\npartial_branches = ["foo["]\n',
+         r"Invalid \[tool.coverage.report\].partial_branches value u?'foo\[': "
+         r"(unexpected end of regular expression|unterminated character set)"),
+        ('[tool.coverage.report]\npartial_branches_always = ["foo***"]\n',
+         r"Invalid \[tool.coverage.report\].partial_branches_always value "
+         r"u?'foo\*\*\*': "
+         r"multiple repeat"),
+        ('[tool.coverage.run]\nconcurrency="foo"', "not a list"),
+        ("[tool.coverage.report]\nprecision=1.23", "not an integer"),
+        ('[tool.coverage.report]\nfail_under="s"', "not a float"),
+    ])
+    def test_toml_parse_errors(self, bad_config, msg):
         # Im-parsable values raise CoverageException, with details.
-        bad_configs_and_msgs = [
-            ("[tool.coverage.run]\ntimid = \"maybe?\"\n", r"maybe[?]"),
-            ("[tool.coverage.run\n", r"Key group"),
-            ('[tool.coverage.report]\nexclude_lines = ["foo("]\n',
-             r"Invalid \[tool.coverage.report\].exclude_lines value u?'foo\(': "
-             r"(unbalanced parenthesis|missing \))"),
-            ('[tool.coverage.report]\npartial_branches = ["foo["]\n',
-             r"Invalid \[tool.coverage.report\].partial_branches value u?'foo\[': "
-             r"(unexpected end of regular expression|unterminated character set)"),
-            ('[tool.coverage.report]\npartial_branches_always = ["foo***"]\n',
-             r"Invalid \[tool.coverage.report\].partial_branches_always value "
-             r"u?'foo\*\*\*': "
-             r"multiple repeat"),
-            ('[tool.coverage.run]\nconcurrency="foo"', "not a list"),
-            ("[tool.coverage.report]\nprecision=1.23", "not an integer"),
-            ('[tool.coverage.report]\nfail_under="s"', "not a float"),
-        ]
-
-        for bad_config, msg in bad_configs_and_msgs:
-            print("Trying %r" % bad_config)
-            self.make_file("pyproject.toml", bad_config)
-            with pytest.raises(CoverageException, match=msg):
-                coverage.Coverage()
+        self.make_file("pyproject.toml", bad_config)
+        with pytest.raises(CoverageException, match=msg):
+            coverage.Coverage()
 
     def test_environment_vars_in_config(self):
         # Config files can have $envvars in them.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -715,7 +715,7 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
 
     def test_no_toml_installed_no_toml(self):
         # Can't read a toml file that doesn't exist.
-        with without_module(coverage.tomlconfig, 'toml'):
+        with without_module(coverage.tomlconfig, 'tomli'):
             msg = "Couldn't read 'cov.toml' as a config file"
             with pytest.raises(CoverageException, match=msg):
                 coverage.Coverage(config_file="cov.toml")
@@ -723,7 +723,7 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
     def test_no_toml_installed_explicit_toml(self):
         # Can't specify a toml config file if toml isn't installed.
         self.make_file("cov.toml", "# A toml file!")
-        with without_module(coverage.tomlconfig, 'toml'):
+        with without_module(coverage.tomlconfig, 'tomli'):
             msg = "Can't read 'cov.toml' without TOML support"
             with pytest.raises(CoverageException, match=msg):
                 coverage.Coverage(config_file="cov.toml")
@@ -735,7 +735,7 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
             [tool.coverage.run]
             xyzzy = 17
             """)
-        with without_module(coverage.tomlconfig, 'toml'):
+        with without_module(coverage.tomlconfig, 'tomli'):
             msg = "Can't read 'pyproject.toml' without TOML support"
             with pytest.raises(CoverageException, match=msg):
                 coverage.Coverage()
@@ -747,7 +747,7 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
             [tool.something]
             xyzzy = 17
             """)
-        with without_module(coverage.tomlconfig, 'toml'):
+        with without_module(coverage.tomlconfig, 'tomli'):
             cov = coverage.Coverage()
             # We get default settings:
             assert not cov.config.timid

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -188,7 +188,7 @@ class ConfigTest(CoverageTest):
 
     @pytest.mark.parametrize("bad_config,msg", [
         ("[tool.coverage.run]\ntimid = \"maybe?\"\n", r"maybe[?]"),
-        ("[tool.coverage.run\n", r"Key group"),
+        ("[tool.coverage.run\n", None),
         ('[tool.coverage.report]\nexclude_lines = ["foo("]\n',
          r"Invalid \[tool.coverage.report\].exclude_lines value u?'foo\(': "
          r"(unbalanced parenthesis|missing \))"),

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -348,7 +348,7 @@ def _same_python_executable(e1, e2):
 
 def test_without_module():
     toml1 = tomlconfig.toml
-    with without_module(tomlconfig, 'toml'):
+    with without_module(tomlconfig, 'tomli'):
         toml2 = tomlconfig.toml
     toml3 = tomlconfig.toml
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -347,10 +347,10 @@ def _same_python_executable(e1, e2):
 
 
 def test_without_module():
-    toml1 = tomlconfig.toml
+    toml1 = tomlconfig.tomli
     with without_module(tomlconfig, 'tomli'):
-        toml2 = tomlconfig.toml
-    toml3 = tomlconfig.toml
+        toml2 = tomlconfig.tomli
+    toml3 = tomlconfig.tomli
 
     assert toml1 is toml3 is not None
     assert toml2 is None


### PR DESCRIPTION
fixes #1180 