### PR TITLE
feat: unrecognized options are now a warning rather than error. #1035

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,8 +24,14 @@ want to know what's different in 5.0 since 4.5.x, see :ref:`whatsnew5x`.
 Unreleased
 ----------
 
+- Unrecognized options in the configuration file are no longer errors. They are
+  now warnings, to ease the use of coverage across versions.  Fixes `issue
+  1035`_.
+
 - Fix another rarer instance of "Error binding parameter 0 - probably
   unsupported type." (`issue 1010`_).
+
+.. _issue 1035: https://github.com/nedbat/coveragepy/issues/1035
 
 
 .. _changes_60b1:

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -248,7 +248,7 @@ class CoverageConfig:
                 setattr(self, k, v)
 
     @contract(filename=str)
-    def from_file(self, filename, our_file):
+    def from_file(self, filename, warn, our_file):
         """Read configuration from a .rc file.
 
         `filename` is a file name to read.
@@ -297,7 +297,7 @@ class CoverageConfig:
             real_section = cp.has_section(section)
             if real_section:
                 for unknown in set(cp.options(section)) - options:
-                    raise CoverageException(
+                    warn(
                         "Unrecognized option '[{}] {}=' in config file {}".format(
                             real_section, unknown, filename
                         )
@@ -517,12 +517,13 @@ def config_files_to_try(config_file):
     return files_to_try
 
 
-def read_coverage_config(config_file, **kwargs):
+def read_coverage_config(config_file, warn, **kwargs):
     """Read the coverage.py configuration.
 
     Arguments:
         config_file: a boolean or string, see the `Coverage` class for the
             tricky details.
+        warn: a function to issue warnings.
         all others: keyword arguments from the `Coverage` class, used for
             setting values in the configuration.
 
@@ -541,7 +542,7 @@ def read_coverage_config(config_file, **kwargs):
         files_to_try = config_files_to_try(config_file)
 
         for fname, our_file, specified_file in files_to_try:
-            config_read = config.from_file(fname, our_file=our_file)
+            config_read = config.from_file(fname, warn, our_file=our_file)
             if config_read:
                 break
             if specified_file:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ import pytest
 
 import coverage
 from coverage.config import HandyConfigParser
-from coverage.exceptions import CoverageException
+from coverage.exceptions import CoverageException, CoverageWarning
 
 from tests.coveragetest import CoverageTest, UsingModulesMixin
 from tests.helpers import without_module
@@ -392,7 +392,7 @@ class ConfigTest(CoverageTest):
             xyzzy = 17
             """)
         msg = r"Unrecognized option '\[run\] xyzzy=' in config file .coveragerc"
-        with pytest.raises(CoverageException, match=msg):
+        with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 
     def test_unknown_option_toml(self):
@@ -401,7 +401,7 @@ class ConfigTest(CoverageTest):
             xyzzy = 17
             """)
         msg = r"Unrecognized option '\[tool.coverage.run\] xyzzy=' in config file pyproject.toml"
-        with pytest.raises(CoverageException, match=msg):
+        with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 
     def test_misplaced_option(self):
@@ -410,7 +410,7 @@ class ConfigTest(CoverageTest):
             branch = True
             """)
         msg = r"Unrecognized option '\[report\] branch=' in config file .coveragerc"
-        with pytest.raises(CoverageException, match=msg):
+        with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 
     def test_unknown_option_in_other_ini_file(self):
@@ -418,8 +418,8 @@ class ConfigTest(CoverageTest):
             [coverage:run]
             huh = what?
             """)
-        msg = (r"Unrecognized option '\[coverage:run\] huh=' in config file setup.cfg")
-        with pytest.raises(CoverageException, match=msg):
+        msg = r"Unrecognized option '\[coverage:run\] huh=' in config file setup.cfg"
+        with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 
     def test_exceptions_from_missing_things(self):


### PR DESCRIPTION
Because they are warnings issued while parsing the configuration file, it's not
possible to suppress them with the coverage configuration.