### PR TITLE
Fix an incompatibility with pyarmor

### DIFF
--- a/coverage/context.py
+++ b/coverage/context.py
@@ -48,7 +48,7 @@ def qualname_from_frame(frame):
     fname = co.co_name
     method = None
     if co.co_argcount and co.co_varnames[0] == "self":
-        self = frame.f_locals["self"]
+        self = frame.f_locals.get("self", None)
         method = getattr(self, fname, None)
 
     if method is None:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -5,6 +5,7 @@
 
 import inspect
 import os.path
+from unittest import mock
 
 import coverage
 from coverage.context import qualname_from_frame
@@ -275,3 +276,8 @@ class QualnameTest(CoverageTest):
         # A class with a name like a function shouldn't confuse qualname_from_frame.
         class test_something:               # pylint: disable=unused-variable
             assert get_qualname() is None
+
+    def test_bug_1210(self):
+        co = mock.Mock(co_name="a_co_name", co_argcount=1, co_varnames=["self"])
+        frame = mock.Mock(f_code = co, f_locals={})
+        assert qualname_from_frame(frame) == "unittest.mock.a_co_name"


### PR DESCRIPTION
Hi thanks for all your amazing and dedicated work on Coverage.py! I ran across a compatibility issue and wanted to propose a fix, feedback welcome :) 

I was running into an error that I traced to frames whose first argument is called `self` according to `frame.f_code.co_varnames`, but which have no `frame.f_locals["self"]`:

```
...
../../.pyenv/versions/3.9.6/lib/python3.9/site-packages/coverage/context.py:41: in should_start_context_test_function
    return qualname_from_frame(frame)
../../.pyenv/versions/3.9.6/lib/python3.9/site-packages/coverage/context.py:51: in qualname_from_frame
    self = frame.f_locals["self"]
E   KeyError: 'self'
```

Specifically, I can reproduce frames like this out of [pyarmor][1]ed code -- based on light research it seems there's nothing theoretically wrong with a frame like this, they just generally don't exist in practice.

These frames only trip up Coverage.py if  `dynamic_context = test_function` ("who tests what") is set, and if a function that starts with "test" and takes `self` as a first argument gets called.

I ran into this issue refactoring our pytest plugin that uses a class to sort tests, so was doing things like

```python
for test in sorter.tests_in_bucket(1):
```

inside pytest hooks, which set off this chain reaction 😄 

I've set up a simplistic reproduction example here: https://github.com/glacials/_coverage_error_repro

[1]: https://github.com/dashingsoft/pyarmor