### PR TITLE
Add link to coverage.py twitter account to project urls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ setup_args = dict(
             '?utm_source=pypi-coverage&utm_medium=referral&utm_campaign=pypi'
         ),
         'Issues': 'https://github.com/nedbat/coveragepy/issues',
+        'Twitter': 'https://twitter.com/coveragepy',
     },
     python_requires=">=3.6",
 )


### PR DESCRIPTION
pypi has supported twitter links [for a while now](https://github.com/pypa/warehouse/pull/878/files#diff-057bf4a747c150d9f3f76db209a6c8f689b023a8e7cd41d96fcc549492889da7R31) so it makes sense to link to coverage.py official twitter account from the pypi project page, similar to other projects, like [pytest](https://pypi.org/project/pytest/)
<img width="1030" alt="Screen Shot 2021-08-30 at 2 11 36 PM" src="https://user-images.githubusercontent.com/1268088/131406186-47a350e3-27aa-4689-a0d6-dff6abf16303.png">
