### PR TITLE
fix: Avoid a race condition in misc.ensure_dir

### DIFF
--- a/coverage/misc.py
+++ b/coverage/misc.py
@@ -156,8 +156,8 @@ def ensure_dir(directory):
 
     If `directory` is None or empty, do nothing.
     """
-    if directory and not os.path.isdir(directory):
-        os.makedirs(directory)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
 
 
 def ensure_dir_for_file(path):


### PR DESCRIPTION
* coverage/misc.py (ensure_dir): Pass exist_ok to os.makedirs, ensuring that if
two concurrent instances of coverage.py entering this function at the same time
won't fail with FileExistsError.

Sample backtrace:

    Traceback (most recent call last):
      File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/home/user/.local/lib/python3.8/site-packages/coverage/__main__.py", line 8, in <module>
        sys.exit(main())
      File "/home/user/.local/lib/python3.8/site-packages/coverage/cmdline.py", line 871, in main
        status = CoverageScript().command_line(argv)
      File "/home/user/.local/lib/python3.8/site-packages/coverage/cmdline.py", line 588, in command_line
        return self.do_run(options, args)
      File "/home/user/.local/lib/python3.8/site-packages/coverage/cmdline.py", line 743, in do_run
        self.coverage.start()
      File "/home/user/.local/lib/python3.8/site-packages/coverage/control.py", line 535, in start
        self._init_for_start()
      File "/home/user/.local/lib/python3.8/site-packages/coverage/control.py", line 474, in _init_for_start
        self._init_data(suffix)
      File "/home/user/.local/lib/python3.8/site-packages/coverage/control.py", line 512, in _init_data
        ensure_dir_for_file(self.config.data_file)
      File "/home/user/.local/lib/python3.8/site-packages/coverage/misc.py", line 165, in ensure_dir_for_file
        ensure_dir(os.path.dirname(path))
      File "/.local/lib/python3.8/site-packages/coverage/misc.py", line 160, in ensure_dir
        os.makedirs(directory)
      File "/usr/lib/python3.8/os.py", line 223, in makedirs
        mkdir(name, mode)