### PR TITLE
refactor: no need for specialized pyexpat code anymore

### DIFF
--- a/coverage/ctracer/stats.h
+++ b/coverage/ctracer/stats.h
@@ -17,10 +17,8 @@ typedef struct Stats {
 #if COLLECT_STATS
     unsigned int lines;
     unsigned int returns;
-    unsigned int exceptions;
     unsigned int others;
     unsigned int files;
-    unsigned int missed_returns;
     unsigned int stack_reallocs;
     unsigned int errors;
     unsigned int pycalls;

--- a/coverage/ctracer/tracer.h
+++ b/coverage/ctracer/tracer.h
@@ -60,10 +60,6 @@ typedef struct CTracer {
     /* The current file's data stack entry. */
     DataStackEntry * pcur_entry;
 
-    /* The parent frame for the last exception event, to fix missing returns. */
-    PyFrameObject * last_exc_back;
-    int last_exc_firstlineno;
-
     Stats stats;
 } CTracer;
 

--- a/coverage/inorout.py
+++ b/coverage/inorout.py
@@ -349,11 +349,6 @@ class InOrOut:
             # can't do anything with the data later anyway.
             return nope(disp, "not a real file name")
 
-        # pyexpat does a dumb thing, calling the trace function explicitly from
-        # C code with a C file name.
-        if re.search(r"[/\\]Modules[/\\]pyexpat.c", filename):
-            return nope(disp, "pyexpat lies about itself")
-
         # Jython reports the .class file to the tracer, use the source file.
         if filename.endswith("$py.class"):
             filename = filename[:-9] + ".py"

--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -55,8 +55,6 @@ class PyTracer:
         self.started_context = False
 
         self.data_stack = []
-        self.last_exc_back = None
-        self.last_exc_firstlineno = 0
         self.thread = None
         self.stopped = False
         self._activity = False
@@ -117,17 +115,6 @@ class PyTracer:
                 self.data_stack.pop()
             )
             return None
-
-        if self.last_exc_back:
-            if frame == self.last_exc_back:
-                # Someone forgot a return event.
-                if self.trace_arcs and self.cur_file_data:
-                    pair = (self.last_line, -self.last_exc_firstlineno)
-                    self.cur_file_data.add(pair)
-                self.cur_file_data, self.cur_file_name, self.last_line, self.started_context = (
-                    self.data_stack.pop()
-                )
-            self.last_exc_back = None
 
         # if event != 'call' and frame.f_code.co_filename != self.cur_file_name:
         #     self.log("---\n*", frame.f_code.co_filename, self.cur_file_name, frame.f_lineno)
@@ -204,9 +191,6 @@ class PyTracer:
             if self.started_context:
                 self.context = None
                 self.switch_context(None)
-        elif event == 'exception':
-            self.last_exc_back = frame.f_back
-            self.last_exc_firstlineno = frame.f_code.co_firstlineno
         return self._trace
 
     def start(self):


### PR DESCRIPTION
The pyexpat bug that plagued us was fixed in Python 3.4:
https://bugs.python.org/issue22462

We no longer need the code that adapted to it.  The test will remain, couldn't
hurt.