### PR TITLE
Default the required complexity attribute to N/A

### DIFF
--- a/coverage/xmlreport.py
+++ b/coverage/xmlreport.py
@@ -107,7 +107,7 @@ class XmlReporter:
             else:
                 branch_rate = "0"
             xpackage.setAttribute("branch-rate", branch_rate)
-            xpackage.setAttribute("complexity", "0")
+            xpackage.setAttribute("complexity", "N/A")
 
             lnum_tot += lnum
             lhits_tot += lhits


### PR DESCRIPTION
The Cobertura DTD for coverage.xml requires the complexity value to be set, and the current coverage.py sets it to 0.

0 is a misleading sentinel value, that could be misinterpreted by tools that parse it. Since the DTD requires the attribute complexity but dictates it is a string, setting it to a more explicit N/A could probably prevent some unwanted behavior downstreams