### PR TITLE
coverage run: add a -o option

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -384,7 +384,7 @@ CMDS = {
     ),
 
     'erase': CmdOptionParser(
-        "erase", GLOBAL_ARGS,
+        "erase", [Opts.input_coverage] + GLOBAL_ARGS,
         description="Erase previously collected coverage data.",
     ),
 

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -129,6 +129,12 @@ class Opts:
         metavar="OUTFILE",
         help="Write the recorded coverage information to this file. Defaults to '.coverage'"
     )
+    input_coverage = optparse.make_option(
+        '-c', '--input-coverage', action='store', dest="input_coverage",
+        metavar="INPUT",
+        help="Read coverage data for report generation from this file (needed if you have "
+             "specified -o previously). Defaults to '.coverage'"
+    )
     json_pretty_print = optparse.make_option(
         '', '--pretty-print', action='store_true',
         help="Format the JSON for human readers.",
@@ -326,6 +332,8 @@ GLOBAL_ARGS = [
     Opts.rcfile,
     ]
 
+REPORT_ARGS = [Opts.input_coverage]
+
 CMDS = {
     'annotate': CmdOptionParser(
         "annotate",
@@ -334,7 +342,7 @@ CMDS = {
             Opts.ignore_errors,
             Opts.include,
             Opts.omit,
-            ] + GLOBAL_ARGS,
+            ] + REPORT_ARGS + GLOBAL_ARGS,
         usage="[options] [modules]",
         description=(
             "Make annotated copies of the given files, marking statements that are executed " +
@@ -348,6 +356,7 @@ CMDS = {
             Opts.append,
             Opts.keep,
             Opts.quiet,
+            Opts.output_coverage
             ] + GLOBAL_ARGS,
         usage="[options] <path1> <path2> ... <pathN>",
         description=(
@@ -401,7 +410,7 @@ CMDS = {
             Opts.no_skip_covered,
             Opts.skip_empty,
             Opts.title,
-            ] + GLOBAL_ARGS,
+            ] + REPORT_ARGS + GLOBAL_ARGS,
         usage="[options] [modules]",
         description=(
             "Create an HTML report of the coverage of the files.  " +
@@ -422,7 +431,7 @@ CMDS = {
             Opts.json_pretty_print,
             Opts.quiet,
             Opts.show_contexts,
-            ] + GLOBAL_ARGS,
+            ] + REPORT_ARGS + GLOBAL_ARGS,
         usage="[options] [modules]",
         description="Generate a JSON report of coverage results."
     ),
@@ -441,7 +450,7 @@ CMDS = {
             Opts.skip_covered,
             Opts.no_skip_covered,
             Opts.skip_empty,
-            ] + GLOBAL_ARGS,
+            ] + REPORT_ARGS + GLOBAL_ARGS,
         usage="[options] [modules]",
         description="Report coverage statistics on modules."
     ),
@@ -476,7 +485,7 @@ CMDS = {
             Opts.output_xml,
             Opts.quiet,
             Opts.skip_empty,
-            ] + GLOBAL_ARGS,
+            ] + REPORT_ARGS + GLOBAL_ARGS,
         usage="[options] [modules]",
         description="Generate an XML report of coverage results."
     ),
@@ -579,8 +588,7 @@ class CoverageScript:
         else:
             concurrency = None
 
-        data_file = options.outfile if options.action in ["run", "combine"] \
-            else getattr(options, "input_coverage", None)
+        data_file = options.outfile if options.action == "run" else None
         # Do something.
         self.coverage = Coverage(
             data_file=data_file or DEFAULT_DATAFILE,

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -18,6 +18,7 @@ from coverage import Coverage
 from coverage import env
 from coverage.collector import CTracer
 from coverage.config import CoverageConfig
+from coverage.control import DEFAULT_DATAFILE
 from coverage.data import combinable_files, debug_data_file
 from coverage.debug import info_formatter, info_header, short_stack
 from coverage.exceptions import _BaseCoverageException, _ExceptionDuringRun, NoSource
@@ -122,6 +123,11 @@ class Opts:
         '-o', '', action='store', dest="outfile",
         metavar="OUTFILE",
         help="Write the JSON report to this file. Defaults to 'coverage.json'",
+    )
+    output_coverage = optparse.make_option(
+        '-o', '', action='store', dest="outfile",
+        metavar="OUTFILE",
+        help="Write the recorded coverage information to this file. Defaults to '.coverage'"
     )
     json_pretty_print = optparse.make_option(
         '', '--pretty-print', action='store_true',
@@ -450,6 +456,7 @@ CMDS = {
             Opts.include,
             Opts.module,
             Opts.omit,
+            Opts.output_coverage,
             Opts.pylib,
             Opts.parallel_mode,
             Opts.source,
@@ -572,8 +579,11 @@ class CoverageScript:
         else:
             concurrency = None
 
+        data_file = options.outfile if options.action in ["run", "combine"] \
+            else getattr(options, "input_coverage", None)
         # Do something.
         self.coverage = Coverage(
+            data_file=data_file or DEFAULT_DATAFILE,
             data_suffix=options.parallel_mode,
             cover_pylib=options.pylib,
             timid=options.timid,

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -125,7 +125,7 @@ class Opts:
         help="Write the JSON report to this file. Defaults to 'coverage.json'",
     )
     output_coverage = optparse.make_option(
-        '-o', '', action='store', dest="outfile",
+        '-o', '', action='store', dest="output_coverage",
         metavar="OUTFILE",
         help="Write the recorded coverage information to this file. Defaults to '.coverage'"
     )
@@ -588,7 +588,8 @@ class CoverageScript:
         else:
             concurrency = None
 
-        data_file = options.outfile if options.action == "run" else None
+        data_file = getattr(options, "output_coverage", None) \
+            or getattr(options, "input_coverage", None)
         # Do something.
         self.coverage = Coverage(
             data_file=data_file or DEFAULT_DATAFILE,

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -125,12 +125,12 @@ class Opts:
         help="Write the JSON report to this file. Defaults to 'coverage.json'",
     )
     output_coverage = optparse.make_option(
-        '-o', '', action='store', dest="output_coverage",
+        '', '--data-file', action='store', dest="output_coverage",
         metavar="OUTFILE",
         help="Write the recorded coverage information to this file. Defaults to '.coverage'"
     )
     input_coverage = optparse.make_option(
-        '-c', '--input-coverage', action='store', dest="input_coverage",
+        '', '--data-file', action='store', dest="input_coverage",
         metavar="INPUT",
         help="Read coverage data for report generation from this file (needed if you have "
              "specified -o previously). Defaults to '.coverage'"

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -60,7 +60,8 @@ def override_config(cov, **kwargs):
         cov.config = original_config
 
 
-_DEFAULT_DATAFILE = DefaultValue("MISSING")
+DEFAULT_DATAFILE = DefaultValue("MISSING")
+_DEFAULT_DATAFILE = DEFAULT_DATAFILE  # Just in case, for backwards compatibility
 
 class Coverage:
     """Programmatic access to coverage.py.
@@ -101,7 +102,7 @@ class Coverage:
             return None
 
     def __init__(
-        self, data_file=_DEFAULT_DATAFILE, data_suffix=None, cover_pylib=None,
+        self, data_file=DEFAULT_DATAFILE, data_suffix=None, cover_pylib=None,
         auto_data=False, timid=None, branch=None, config_file=True,
         source=None, source_pkgs=None, omit=None, include=None, debug=None,
         concurrency=None, check_preimported=False, context=None,
@@ -198,7 +199,7 @@ class Coverage:
         # data_file=None means no disk file at all. data_file missing means
         # use the value from the config file.
         self._no_disk = data_file is None
-        if data_file is _DEFAULT_DATAFILE:
+        if data_file is DEFAULT_DATAFILE:
             data_file = None
 
         self.config = None

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -307,6 +307,10 @@ class CmdLineTest(BaseCmdLineTest):
             cov = Coverage()
             cov.erase()
             """)
+        self.cmd_executes("erase -c foo.cov", """\
+            cov = Coverage(data_file="foo.cov")
+            cov.erase()
+            """)
 
     def test_version(self):
         # coverage --version

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -247,6 +247,11 @@ class CmdLineTest(BaseCmdLineTest):
             cov.combine(None, strict=True, keep=False)
             cov.save()
             """)
+        self.cmd_executes("combine -o foo.cov", """\
+            cov = Coverage(data_file="foo.cov")
+            cov.combine(None, strict=True, keep=False)
+            cov.save()
+            """)
 
     def test_combine_doesnt_confuse_options_with_args(self):
         # https://github.com/nedbat/coveragepy/issues/385
@@ -511,6 +516,11 @@ class CmdLineTest(BaseCmdLineTest):
             cov = Coverage()
             cov.load()
             cov.report(sort='-foo')
+            """)
+        self.cmd_executes("report -c foo.cov.2", """\
+            cov = Coverage(data_file="foo.cov.2")
+            cov.load()
+            cov.report(show_missing=None)
             """)
 
     def test_run(self):

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -14,6 +14,7 @@ import pytest
 import coverage
 import coverage.cmdline
 from coverage import env
+from coverage.control import DEFAULT_DATAFILE
 from coverage.config import CoverageConfig
 from coverage.exceptions import _ExceptionDuringRun
 from coverage.version import __url__
@@ -53,6 +54,7 @@ class BaseCmdLineTest(CoverageTest):
         contexts=None, pretty_print=None, show_contexts=None,
     )
     _defaults.Coverage(
+        data_file=DEFAULT_DATAFILE,
         cover_pylib=None, data_suffix=None, timid=None, branch=None,
         config_file=True, source=None, include=None, omit=None, debug=None,
         concurrency=None, check_preimported=True, context=None, messages=True,
@@ -629,6 +631,15 @@ class CmdLineTest(BaseCmdLineTest):
             """)
         self.cmd_executes("run --concurrency=gevent,thread foo.py", """\
             cov = Coverage(concurrency=['gevent', 'thread'])
+            runner = PyRunner(['foo.py'], as_module=False)
+            runner.prepare()
+            cov.start()
+            runner.run()
+            cov.stop()
+            cov.save()
+            """)
+        self.cmd_executes("run -o output.coverage foo.py", """\
+            cov = Coverage(data_file="output.coverage")
             runner = PyRunner(['foo.py'], as_module=False)
             runner.prepare()
             cov.start()

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -247,7 +247,7 @@ class CmdLineTest(BaseCmdLineTest):
             cov.combine(None, strict=True, keep=False)
             cov.save()
             """)
-        self.cmd_executes("combine -o foo.cov", """\
+        self.cmd_executes("combine --data-file=foo.cov", """\
             cov = Coverage(data_file="foo.cov")
             cov.combine(None, strict=True, keep=False)
             cov.save()
@@ -307,7 +307,7 @@ class CmdLineTest(BaseCmdLineTest):
             cov = Coverage()
             cov.erase()
             """)
-        self.cmd_executes("erase -c foo.cov", """\
+        self.cmd_executes("erase --data-file=foo.cov", """\
             cov = Coverage(data_file="foo.cov")
             cov.erase()
             """)
@@ -521,7 +521,7 @@ class CmdLineTest(BaseCmdLineTest):
             cov.load()
             cov.report(sort='-foo')
             """)
-        self.cmd_executes("report -c foo.cov.2", """\
+        self.cmd_executes("report --data-file=foo.cov.2", """\
             cov = Coverage(data_file="foo.cov.2")
             cov.load()
             cov.report(show_missing=None)
@@ -652,7 +652,7 @@ class CmdLineTest(BaseCmdLineTest):
             cov.stop()
             cov.save()
             """)
-        self.cmd_executes("run -o output.coverage foo.py", """\
+        self.cmd_executes("run --data-file=output.coverage foo.py", """\
             cov = Coverage(data_file="output.coverage")
             runner = PyRunner(['foo.py'], as_module=False)
             runner.prepare()


### PR DESCRIPTION
Add a way to specify the coverage filename manually for `coverage run` (option: `-o`) and correspondingly for the reporting commands and `combine` (`-c`, `--input-coverage`):

```shell
python3 -m coverage run -o output.coverage test.py
python3 -m coverage xml -c output.coverage -o -
```

Use case: I am writing an IDE plugin to integrate `coverage.py`, and I would like to use the python package unmodified. However, I'd like to avoid the creation of a `.coverage` file at the project root, and would instead like the coverage to be written to a file of my choosing (somewhere in the IDE's data directory).

This idea could (possibly) be taken further, if use cases are found (for my use case, the feature as implemented in this PR is sufficient), so I have not implement them here:
- `coverage erase` could take a list of coverage files instead of only one (with this PR: via `-c`)
- `input-coverage` for `coverage run`: allowing the coverage data of a previous run to be extended while writing to a new file (would require further core changes, introducing an `input_data_file` argument to the `Coverage` class)