### PR TITLE
Use precision argument on cmd

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -55,8 +55,8 @@ jobs:
         uses: "actions/setup-python@v2"
         with:
           python-version: "${{ matrix.python-version }}"
-          cache: pip
-          cache-dependency-path: 'requirements/*.pip'
+          #cache: pip
+          #cache-dependency-path: 'requirements/*.pip'
 
       - name: "Install dependencies"
         run: |

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -4,7 +4,7 @@
 """Command-line support for coverage.py."""
 
 import glob
-import optparse  # pylint: disable=deprecated-module
+import optparse    # pylint: disable=deprecated-module
 import os
 import os.path
 import shlex
@@ -13,13 +13,14 @@ import textwrap
 import traceback
 
 import coverage
-from coverage import Coverage, env
+from coverage import Coverage
+from coverage import env
 from coverage.collector import CTracer
 from coverage.config import CoverageConfig
 from coverage.control import DEFAULT_DATAFILE
 from coverage.data import combinable_files, debug_data_file
 from coverage.debug import info_formatter, info_header, short_stack
-from coverage.exceptions import NoSource, _BaseCoverageException, _ExceptionDuringRun
+from coverage.exceptions import _BaseCoverageException, _ExceptionDuringRun, NoSource
 from coverage.execfile import PyRunner
 from coverage.results import Numbers, should_fail_under
 
@@ -970,7 +971,7 @@ def main(argv=None):
 # $set_env.py: COVERAGE_PROFILE - Set to use ox_profile.
 _profile = os.environ.get("COVERAGE_PROFILE", "")
 if _profile:                                                # pragma: debugging
-    from ox_profile.core.launchers import SimpleLauncher  # pylint: disable=import-error
+    from ox_profile.core.launchers import SimpleLauncher    # pylint: disable=import-error
     original_main = main
 
     def main(argv=None):                                    # pylint: disable=function-redefined

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -4,7 +4,7 @@
 """Command-line support for coverage.py."""
 
 import glob
-import optparse     # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module
 import os
 import os.path
 import shlex
@@ -13,14 +13,13 @@ import textwrap
 import traceback
 
 import coverage
-from coverage import Coverage
-from coverage import env
+from coverage import Coverage, env
 from coverage.collector import CTracer
 from coverage.config import CoverageConfig
 from coverage.control import DEFAULT_DATAFILE
 from coverage.data import combinable_files, debug_data_file
 from coverage.debug import info_formatter, info_header, short_stack
-from coverage.exceptions import _BaseCoverageException, _ExceptionDuringRun, NoSource
+from coverage.exceptions import NoSource, _BaseCoverageException, _ExceptionDuringRun
 from coverage.execfile import PyRunner
 from coverage.results import Numbers, should_fail_under
 
@@ -731,6 +730,8 @@ class CoverageScript:
             # value, so we can get fail_under from the config file.
             if options.fail_under is not None:
                 self.coverage.set_option("report:fail_under", options.fail_under)
+            if options.precision is not None:
+                self.coverage.set_option("report:precision", options.precision)
 
             fail_under = self.coverage.get_option("report:fail_under")
             precision = self.coverage.get_option("report:precision")
@@ -969,7 +970,7 @@ def main(argv=None):
 # $set_env.py: COVERAGE_PROFILE - Set to use ox_profile.
 _profile = os.environ.get("COVERAGE_PROFILE", "")
 if _profile:                                                # pragma: debugging
-    from ox_profile.core.launchers import SimpleLauncher    # pylint: disable=import-error
+    from ox_profile.core.launchers import SimpleLauncher  # pylint: disable=import-error
     original_main = main
 
     def main(argv=None):                                    # pylint: disable=function-redefined

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -4,7 +4,7 @@
 """Command-line support for coverage.py."""
 
 import glob
-import optparse    # pylint: disable=deprecated-module
+import optparse     # pylint: disable=deprecated-module
 import os
 import os.path
 import shlex

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -7,19 +7,18 @@ import pprint
 import re
 import sys
 import textwrap
-
 from unittest import mock
+
 import pytest
 
 import coverage
 import coverage.cmdline
 from coverage import env
-from coverage.control import DEFAULT_DATAFILE
 from coverage.config import CoverageConfig
+from coverage.control import DEFAULT_DATAFILE
 from coverage.exceptions import _ExceptionDuringRun
 from coverage.version import __url__
-
-from tests.coveragetest import CoverageTest, OK, ERR, command_line
+from tests.coveragetest import ERR, OK, CoverageTest, command_line
 from tests.helpers import os_sep
 
 
@@ -1136,9 +1135,13 @@ class CoverageReportingFake:
     ((20, 30, 40, 50, 60), 61, "lcov", 2),
     # Command-line overrides configuration.
     ((20, 30, 40, 50, 60), 19, "report --fail-under=21", 2),
+    # Precision defined
+    ((20, 30, 40, 50, 60), None, "report --fail-under=20.1 --precision=1", 2),
+    ((20, 30, 40, 50, 60), None, "report --fail-under=19.9 --precision=1", 0),
 ])
 def test_fail_under(results, fail_under, cmd, ret):
     cov = CoverageReportingFake(*results)
+    print(cov.report_result)
     if fail_under is not None:
         cov.set_option("report:fail_under", fail_under)
     with mock.patch("coverage.cmdline.Coverage", lambda *a,**kw: cov):

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -7,18 +7,19 @@ import pprint
 import re
 import sys
 import textwrap
-from unittest import mock
 
+from unittest import mock
 import pytest
 
 import coverage
 import coverage.cmdline
 from coverage import env
-from coverage.config import CoverageConfig
 from coverage.control import DEFAULT_DATAFILE
+from coverage.config import CoverageConfig
 from coverage.exceptions import _ExceptionDuringRun
 from coverage.version import __url__
-from tests.coveragetest import ERR, OK, CoverageTest, command_line
+
+from tests.coveragetest import CoverageTest, OK, ERR, command_line
 from tests.helpers import os_sep
 
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1141,7 +1141,6 @@ class CoverageReportingFake:
 ])
 def test_fail_under(results, fail_under, cmd, ret):
     cov = CoverageReportingFake(*results)
-    print(cov.report_result)
     if fail_under is not None:
         cov.set_option("report:fail_under", fail_under)
     with mock.patch("coverage.cmdline.Coverage", lambda *a,**kw: cov):


### PR DESCRIPTION
Precision gets default to 0 when using as cmd argument.

I guess it's related to https://github.com/pytest-dev/pytest-cov/issues/403