### PR TITLE
build: MyFrame_lasti() uses PyObject_GetAttrString()

### DIFF
--- a/coverage/ctracer/util.h
+++ b/coverage/ctracer/util.h
@@ -12,19 +12,21 @@
 #undef COLLECT_STATS    /* Collect counters: stats are printed when tracer is stopped. */
 #undef DO_NOTHING       /* Define this to make the tracer do nothing. */
 
-#if PY_VERSION_HEX >= 0x030B00A0
-// 3.11 moved f_lasti into an internal structure. This is totally the wrong way
-// to make this work, but it's all I've got until https://bugs.python.org/issue40421
-// is resolved.
-#include <internal/pycore_frame.h>
-#define MyFrame_lasti(f)    ((f)->f_frame->f_lasti * 2)
-#elif PY_VERSION_HEX >= 0x030A00A7
-// The f_lasti field changed meaning in 3.10.0a7. It had been bytes, but
-// now is instructions, so we need to adjust it to use it as a byte index.
-#define MyFrame_lasti(f)    ((f)->f_lasti * 2)
-#else
-#define MyFrame_lasti(f)    ((f)->f_lasti)
-#endif
+static inline Py_ssize_t MyFrame_lasti(PyFrameObject *frame)
+{
+    PyObject *obj = PyObject_GetAttrString((PyObject*)frame, "f_lasti");
+    if (obj == NULL) {
+        PyErr_Clear();
+        return -1;
+    }
+    // f_lasti is an int, but using Py_ssize_t is more convenient in coverage
+    Py_ssize_t lasti = PyLong_AsSsize_t(obj);
+    if (lasti == -1 && PyErr_Occurred()) {
+        PyErr_Clear();
+        return -1;
+    }
+    return lasti;
+}
 
 // Access f_code should be done through a helper starting in 3.9.
 #if PY_VERSION_HEX >= 0x03090000

--- a/coverage/ctracer/util.h
+++ b/coverage/ctracer/util.h
@@ -5,6 +5,7 @@
 #define _COVERAGE_UTIL_H
 
 #include <Python.h>
+#include "frameobject.h"          // PyFrameObject
 
 /* Compile-time debugging helpers */
 #undef WHAT_LOG         /* Define to log the WHAT params in the trace function. */


### PR DESCRIPTION
Reimplement the MyFrame_lasti() function using
PyObject_GetAttrString(frame, "f_lasti") to avoid using the internal
C API on Python 3.11.

Add assertions in CTracer_handle_call() and CTracer_handle_return()
to ensure that f_lasti is the in expected bounds.