### PR TITLE
Add timestamp and version info in header and footer.

### DIFF
--- a/coverage/htmlfiles/index.html
+++ b/coverage/htmlfiles/index.html
@@ -48,6 +48,13 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+
+    <nav>
+        <p>
+            <a class="nav" href="{{__url__}}">coverage.py v{{__version__}}</a>,
+            created at {{ time_stamp }}
+        </p>
+    </nav>
 </header>
 
 <main id="index">
@@ -109,12 +116,12 @@
 </main>
 
 <footer>
-    <div class="content">
+    <nav>
         <p>
             <a class="nav" href="{{__url__}}">coverage.py v{{__version__}}</a>,
             created at {{ time_stamp }}
         </p>
-    </div>
+    </nav>
 </footer>
 
 </body>

--- a/coverage/htmlfiles/pyfile.html
+++ b/coverage/htmlfiles/pyfile.html
@@ -73,6 +73,13 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="{{__url__}}">coverage.py v{{__version__}}</a>,
+            created at {{ time_stamp }}
+        </p>
+    </nav>
 </header>
 
 <main id="source">
@@ -108,12 +115,12 @@
 </main>
 
 <footer>
-    <div class="content">
+    <nav>
         <p>
             <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="{{__url__}}">coverage.py v{{__version__}}</a>,
             created at {{ time_stamp }}
         </p>
-    </div>
+    </nav>
 </footer>
 
 </body>

--- a/coverage/htmlfiles/style.css
+++ b/coverage/htmlfiles/style.css
@@ -28,13 +28,15 @@ a.nav { text-decoration: none; color: inherit; }
 
 a.nav:hover { text-decoration: underline; color: inherit; }
 
-header { background: #f8f8f8; width: 100%; z-index: 2; border-bottom: 1px solid #ccc; }
+header { background: #f8f8f8; width: 100%; z-index: 2; border-bottom: 1px solid #ccc; padding: 1rem 1rem; }
 
 @media (prefers-color-scheme: dark) { header { background: black; } }
 
 @media (prefers-color-scheme: dark) { header { border-color: #333; } }
 
-header .content { padding: 1rem 3.5rem; }
+header .content { padding: 0 2.5rem; }
+
+header nav { margin-top: 1em; }
 
 header h2 { margin-top: .5em; font-size: 1em; }
 
@@ -52,13 +54,11 @@ header.sticky ~ #source { padding-top: 6.5em; }
 
 main { position: relative; z-index: 1; }
 
-.indexfile footer { margin: 1rem 3.5rem; }
+footer { margin: 1rem 1rem; }
 
-.pyfile footer { margin: 1rem 1rem; }
+nav { padding: 0; color: #666; font-style: italic; }
 
-footer .content { padding: 0; color: #666; font-style: italic; }
-
-@media (prefers-color-scheme: dark) { footer .content { color: #aaa; } }
+@media (prefers-color-scheme: dark) { nav { color: #aaa; } }
 
 #index { margin: 1rem 0 0 3.5rem; }
 

--- a/coverage/htmlfiles/style.scss
+++ b/coverage/htmlfiles/style.scss
@@ -164,9 +164,14 @@ header {
     z-index: 2;
     border-bottom: 1px solid $light-gray3;
     @include border-color-dark($dark-gray2);
+    padding: 1rem 1rem;
 
     .content {
-        padding: 1rem $left-gutter;
+        padding: 0 ($left-gutter - 1rem);
+    }
+
+    nav {
+        margin-top: 1em;
     }
 
     h2 {
@@ -208,15 +213,11 @@ main {
     z-index: 1;
 }
 
-.indexfile footer {
-    margin: 1rem $left-gutter;
-}
-
-.pyfile footer {
+footer {
     margin: 1rem 1rem;
 }
 
-footer .content {
+nav {
     padding: 0;
     color: $light-gray5;
     @include color-dark($dark-gray5);

--- a/tests/gold/html/a/a_py.html
+++ b/tests/gold/html/a/a_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:00 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">if</span> <span class="num">1</span> <span class="op">&lt;</span> <span class="num">2</span><span class="op">:</span>&nbsp;</span><span class="r"></span></p>
@@ -64,12 +70,12 @@
     <p class="mis show_mis"><span class="n"><a id="t5" href="#t5">5</a></span><span class="t">    <span class="nam">a</span> <span class="op">=</span> <span class="num">4</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:00 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/a/index.html
+++ b/tests/gold/html/a/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:01 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -71,12 +77,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:01 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/b_branch/b_py.html
+++ b/tests/gold/html/b_branch/b_py.html
@@ -57,6 +57,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">def</span> <span class="nam">one</span><span class="op">(</span><span class="nam">x</span><span class="op">)</span><span class="op">:</span>&nbsp;</span><span class="r"></span></p>
@@ -88,12 +94,12 @@
     <p class="run"><span class="n"><a id="t27" href="#t27">27</a></span><span class="t"><span class="nam">three</span><span class="op">(</span><span class="op">)</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/b_branch/index.html
+++ b/tests/gold/html/b_branch/index.html
@@ -37,6 +37,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -79,12 +85,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/bom/bom_py.html
+++ b/tests/gold/html/bom/bom_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="pln"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="com"># A Python source file in utf-8, with BOM.</span>&nbsp;</span><span class="r"></span></p>
@@ -70,12 +76,12 @@
     <p class="mis show_mis"><span class="n"><a id="t11" href="#t11">11</a></span><span class="t">    <span class="key">assert</span> <span class="nam">len</span><span class="op">(</span><span class="nam">math</span><span class="op">.</span><span class="nam">decode</span><span class="op">(</span><span class="str">'utf-8'</span><span class="op">)</span><span class="op">)</span> <span class="op">==</span> <span class="num">18</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/bom/index.html
+++ b/tests/gold/html/bom/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -71,12 +77,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/isolatin1/index.html
+++ b/tests/gold/html/isolatin1/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -71,12 +77,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/isolatin1/isolatin1_py.html
+++ b/tests/gold/html/isolatin1/isolatin1_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="pln"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="com"># -*- coding: iso8859-1 -*-</span>&nbsp;</span><span class="r"></span></p>
@@ -64,12 +70,12 @@
     <p class="run"><span class="n"><a id="t5" href="#t5">5</a></span><span class="t"><span class="key">assert</span> <span class="nam">len</span><span class="op">(</span><span class="nam">math</span><span class="op">)</span> <span class="op">==</span> <span class="num">18</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_1/index.html
+++ b/tests/gold/html/omit_1/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -92,12 +98,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_1/m1_py.html
+++ b/tests/gold/html/omit_1/m1_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m1a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m1b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_1/m2_py.html
+++ b/tests/gold/html/omit_1/m2_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m2a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m2b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_1/m3_py.html
+++ b/tests/gold/html/omit_1/m3_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m3a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m3b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_1/main_py.html
+++ b/tests/gold/html/omit_1/main_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">import</span> <span class="nam">m1</span>&nbsp;</span><span class="r"></span></p>
@@ -69,12 +75,12 @@
     <p class="run"><span class="n"><a id="t10" href="#t10">10</a></span><span class="t"><span class="key">assert</span> <span class="nam">m3</span><span class="op">.</span><span class="nam">m3a</span> <span class="op">==</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_2/index.html
+++ b/tests/gold/html/omit_2/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -85,12 +91,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_2/m2_py.html
+++ b/tests/gold/html/omit_2/m2_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m2a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m2b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_2/m3_py.html
+++ b/tests/gold/html/omit_2/m3_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m3a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m3b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_2/main_py.html
+++ b/tests/gold/html/omit_2/main_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">import</span> <span class="nam">m1</span>&nbsp;</span><span class="r"></span></p>
@@ -69,12 +75,12 @@
     <p class="run"><span class="n"><a id="t10" href="#t10">10</a></span><span class="t"><span class="key">assert</span> <span class="nam">m3</span><span class="op">.</span><span class="nam">m3a</span> <span class="op">==</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_3/index.html
+++ b/tests/gold/html/omit_3/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -78,12 +84,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_3/m3_py.html
+++ b/tests/gold/html/omit_3/m3_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m3a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m3b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_3/main_py.html
+++ b/tests/gold/html/omit_3/main_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">import</span> <span class="nam">m1</span>&nbsp;</span><span class="r"></span></p>
@@ -69,12 +75,12 @@
     <p class="run"><span class="n"><a id="t10" href="#t10">10</a></span><span class="t"><span class="key">assert</span> <span class="nam">m3</span><span class="op">.</span><span class="nam">m3a</span> <span class="op">==</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_4/index.html
+++ b/tests/gold/html/omit_4/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -85,12 +91,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_4/m1_py.html
+++ b/tests/gold/html/omit_4/m1_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m1a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m1b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_4/m3_py.html
+++ b/tests/gold/html/omit_4/m3_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m3a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m3b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_4/main_py.html
+++ b/tests/gold/html/omit_4/main_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">import</span> <span class="nam">m1</span>&nbsp;</span><span class="r"></span></p>
@@ -69,12 +75,12 @@
     <p class="run"><span class="n"><a id="t10" href="#t10">10</a></span><span class="t"><span class="key">assert</span> <span class="nam">m3</span><span class="op">.</span><span class="nam">m3a</span> <span class="op">==</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_5/index.html
+++ b/tests/gold/html/omit_5/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -78,12 +84,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_5/m1_py.html
+++ b/tests/gold/html/omit_5/m1_py.html
@@ -55,18 +55,24 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="nam">m1a</span> <span class="op">=</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
     <p class="run"><span class="n"><a id="t2" href="#t2">2</a></span><span class="t"><span class="nam">m1b</span> <span class="op">=</span> <span class="num">2</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/omit_5/main_py.html
+++ b/tests/gold/html/omit_5/main_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">import</span> <span class="nam">m1</span>&nbsp;</span><span class="r"></span></p>
@@ -69,12 +75,12 @@
     <p class="run"><span class="n"><a id="t10" href="#t10">10</a></span><span class="t"><span class="key">assert</span> <span class="nam">m3</span><span class="op">.</span><span class="nam">m3a</span> <span class="op">==</span> <span class="num">1</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/other/blah_blah_other_py.html
+++ b/tests/gold/html/other/blah_blah_other_py.html
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=emulateIE7" />
-    <title>Coverage for /private/var/folders/10/4sn2sk3j2mg5m116f08_367m0000gq/T/pytest-of-nedbatchelder/pytest-1363/popen-gw2/t48/othersrc/other.py: 100%</title>
+    <title>Coverage for TEST_TMPDIR/othersrc/other.py: 100%</title>
     <link rel="icon" sizes="32x32" href="favicon_32.png">
     <link rel="stylesheet" href="style.css" type="text/css">
     <script type="text/javascript" src="coverage_html.js" defer></script>
@@ -12,7 +12,7 @@
 <header>
     <div class="content">
         <h1>
-            <span class="text">Coverage for </span><b>/private/var/folders/10/4sn2sk3j2mg5m116f08_367m0000gq/T/pytest-of-nedbatchelder/pytest-1363/popen-gw2/t48/othersrc/other.py</b>:
+            <span class="text">Coverage for </span><b>TEST_TMPDIR/othersrc/other.py</b>:
             <span class="pc_cov">100%</span>
         </h1>
         <div id="help_panel_wrapper">
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="pln"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="com"># A file in another directory.  We're checking that it ends up in the</span>&nbsp;</span><span class="r"></span></p>
@@ -63,12 +69,12 @@
     <p class="run"><span class="n"><a id="t4" href="#t4">4</a></span><span class="t"><span class="nam">print</span><span class="op">(</span><span class="str">"This is the other src!"</span><span class="op">)</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/other/here_py.html
+++ b/tests/gold/html/other/here_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">import</span> <span class="nam">other</span>&nbsp;</span><span class="r"></span></p>
@@ -65,12 +71,12 @@
     <p class="mis show_mis"><span class="n"><a id="t6" href="#t6">6</a></span><span class="t">    <span class="nam">h</span> <span class="op">=</span> <span class="num">4</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/other/index.html
+++ b/tests/gold/html/other/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -49,7 +55,7 @@
         </thead>
         <tbody>
             <tr class="file">
-                <td class="name left"><a href="d_782ca3c126f2375a_other_py.html">/private/var/folders/10/4sn2sk3j2mg5m116f08_367m0000gq/T/pytest-of-nedbatchelder/pytest-964/popen-gw6/t104/othersrc/other.py</a></td>
+                <td class="name left"><a href="d_199d6e2ae336fe75_other_py.html">TEST_TMPDIR/othersrc/other.py</a></td>
                 <td>1</td>
                 <td>0</td>
                 <td>0</td>
@@ -78,12 +84,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/partial/index.html
+++ b/tests/gold/html/partial/index.html
@@ -37,6 +37,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -79,12 +85,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/partial/partial_py.html
+++ b/tests/gold/html/partial/partial_py.html
@@ -57,6 +57,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="pln"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="com"># partial branches and excluded lines</span>&nbsp;</span><span class="r"></span></p>
@@ -78,12 +84,12 @@
     <p class="exc show_exc"><span class="n"><a id="t17" href="#t17">17</a></span><span class="t">    <span class="key">raise</span> <span class="nam">ZeroDivisionError</span><span class="op">(</span><span class="str">"17"</span><span class="op">)</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/partial_626/index.html
+++ b/tests/gold/html/partial_626/index.html
@@ -37,6 +37,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
+            created at 2021-10-23 17:18 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -79,12 +85,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
             <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
             created at 2021-10-23 17:18 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/partial_626/partial_py.html
+++ b/tests/gold/html/partial_626/partial_py.html
@@ -57,6 +57,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
+            created at 2021-10-30 16:37 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="pln"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="com"># partial branches and excluded lines</span>&nbsp;</span><span class="r"></span></p>
@@ -78,12 +84,12 @@
     <p class="exc show_exc"><span class="n"><a id="t17" href="#t17">17</a></span><span class="t">    <span class="key">raise</span> <span class="nam">ZeroDivisionError</span><span class="op">(</span><span class="str">"17"</span><span class="op">)</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
             <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
             created at 2021-10-30 16:37 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/styled/a_py.html
+++ b/tests/gold/html/styled/a_py.html
@@ -56,6 +56,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="run"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="key">if</span> <span class="num">1</span> <span class="op">&lt;</span> <span class="num">2</span><span class="op">:</span>&nbsp;</span><span class="r"></span></p>
@@ -65,12 +71,12 @@
     <p class="mis show_mis"><span class="n"><a id="t5" href="#t5">5</a></span><span class="t">    <span class="nam">a</span> <span class="op">=</span> <span class="num">4</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/styled/index.html
+++ b/tests/gold/html/styled/index.html
@@ -36,6 +36,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -72,12 +78,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/styled/style.css
+++ b/tests/gold/html/styled/style.css
@@ -28,13 +28,15 @@ a.nav { text-decoration: none; color: inherit; }
 
 a.nav:hover { text-decoration: underline; color: inherit; }
 
-header { background: #f8f8f8; width: 100%; z-index: 2; border-bottom: 1px solid #ccc; }
+header { background: #f8f8f8; width: 100%; z-index: 2; border-bottom: 1px solid #ccc; padding: 1rem 1rem; }
 
 @media (prefers-color-scheme: dark) { header { background: black; } }
 
 @media (prefers-color-scheme: dark) { header { border-color: #333; } }
 
-header .content { padding: 1rem 3.5rem; }
+header .content { padding: 0 2.5rem; }
+
+header nav { margin-top: 1em; }
 
 header h2 { margin-top: .5em; font-size: 1em; }
 
@@ -52,13 +54,11 @@ header.sticky ~ #source { padding-top: 6.5em; }
 
 main { position: relative; z-index: 1; }
 
-.indexfile footer { margin: 1rem 3.5rem; }
+footer { margin: 1rem 1rem; }
 
-.pyfile footer { margin: 1rem 1rem; }
+nav { padding: 0; color: #666; font-style: italic; }
 
-footer .content { padding: 0; color: #666; font-style: italic; }
-
-@media (prefers-color-scheme: dark) { footer .content { color: #aaa; } }
+@media (prefers-color-scheme: dark) { nav { color: #aaa; } }
 
 #index { margin: 1rem 0 0 3.5rem; }
 

--- a/tests/gold/html/unicode/index.html
+++ b/tests/gold/html/unicode/index.html
@@ -35,6 +35,12 @@
             <input id="filter" type="text" value="" placeholder="filter..." />
         </form>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="index">
     <table class="index" data-sortable>
@@ -71,12 +77,12 @@
     </p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="https://coverage.readthedocs.io/en/6.1a0">coverage.py v6.1a0</a>,
-            created at 2021-10-23 08:16 -0400
+            <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>

--- a/tests/gold/html/unicode/unicode_py.html
+++ b/tests/gold/html/unicode/unicode_py.html
@@ -55,6 +55,12 @@
             <button type="button" class="button_first_chunk" data-shortcut="1">Goto first highlighted chunk</button>
         </div>
     </div>
+    <nav>
+        <p>
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
+        </p>
+    </nav>
 </header>
 <main id="source">
     <p class="pln"><span class="n"><a id="t1" href="#t1">1</a></span><span class="t"><span class="com"># -*- coding: utf-8 -*-</span>&nbsp;</span><span class="r"></span></p>
@@ -64,12 +70,12 @@
     <p class="run"><span class="n"><a id="t5" href="#t5">5</a></span><span class="t"><span class="nam">surrogate</span> <span class="op">=</span> <span class="str">"db40,dd00: x&#917760;"</span>&nbsp;</span><span class="r"></span></p>
 </main>
 <footer>
-    <div class="content">
+    <nav>
         <p>
-            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.1.1a0">coverage.py v6.1.1a0</a>,
-            created at 2021-10-30 16:07 -0400
+            <a class="nav" href="index.html">&#xab; index</a> &nbsp; &nbsp; <a class="nav" href="https://coverage.readthedocs.io/en/6.3.3a0">coverage.py v6.3.3a0</a>,
+            created at 2022-04-08 16:03 -0400
         </p>
-    </div>
+    </nav>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
This fixes #1351 by adding the timestamp and version info to both the header and footer. As mentioned in the issue, this is mostly useful for larger projects where long files push down this important info far down the page.

I also lined up the footer to be on the same place in both the index page and the file listing page.

| Page          | Before                                                                                                        | After                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
| Light (Index) | ![image](https://user-images.githubusercontent.com/773529/162531587-efb04239-3dc6-4ab0-8341-f4fb47ea4612.png) | ![image](https://user-images.githubusercontent.com/773529/162529515-6e4db01c-eb31-46cb-8a11-eddaa3ed32bc.png) |
| Dark (Index)  | ![image](https://user-images.githubusercontent.com/773529/162531736-538808dc-2131-4863-834d-2e928ea08183.png) | ![image](https://user-images.githubusercontent.com/773529/162530304-d3d7059b-3dc6-4626-b9e3-22dfeba0bc14.png) |
| Light (File)  | ![image](https://user-images.githubusercontent.com/773529/162531254-b7b95e36-9fd0-407d-9445-9fd4cf905fb0.png) | ![image](https://user-images.githubusercontent.com/773529/162530075-bdf960dd-c333-4daa-85e0-7fb531701999.png) |
| Dark (File)   | ![image](https://user-images.githubusercontent.com/773529/162531885-79631089-17e4-447a-a4d8-2448db984903.png) | ![image](https://user-images.githubusercontent.com/773529/162530228-fb652ab7-8943-4cd8-97f9-0b494bf10ea9.png) |
