### PR TITLE
Build and test tweaks to help with cross-compilation

### DIFF
--- a/igor.py
+++ b/igor.py
@@ -56,7 +56,7 @@ def do_show_env():
         print(f"  {env} = {os.environ[env]!r}")
 
 
-def do_remove_extension():
+def do_remove_extension(*args):
     """Remove the compiled C extension, no matter what its name."""
 
     so_patterns = """
@@ -66,8 +66,23 @@ def do_remove_extension():
         tracer.*.pyd
         """.split()
 
+    if "--from-install" in args:
+        # Get the install location using a subprocess to avoid
+        # locking the file we are about to delete
+        import subprocess
+        root = os.path.dirname(subprocess.check_output([
+            sys.executable,
+            "-Xutf8",
+            "-c",
+            "import coverage; print(coverage.__file__)"
+        ], encoding="utf-8").strip())
+    else:
+        root = "coverage"
+
     for pattern in so_patterns:
-        pattern = os.path.join("coverage", pattern)
+        pattern = os.path.join(root, pattern.strip())
+        if VERBOSITY:
+            print(f"Searching for {pattern}")
         for filename in glob.glob(pattern):
             if os.path.exists(filename):
                 if VERBOSITY:

--- a/igor.py
+++ b/igor.py
@@ -69,7 +69,6 @@ def do_remove_extension(*args):
     if "--from-install" in args:
         # Get the install location using a subprocess to avoid
         # locking the file we are about to delete
-        import subprocess
         root = os.path.dirname(subprocess.check_output([
             sys.executable,
             "-Xutf8",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import sys
 # Setuptools has to be imported before distutils, or things break.
 from setuptools import setup
 from distutils.core import Extension                # pylint: disable=wrong-import-order
-from distutils.command.build_ext import build_ext   # pylint: disable=wrong-import-order
+from setuptools.command.build_ext import build_ext  # pylint: disable=wrong-import-order
 from distutils import errors                        # pylint: disable=wrong-import-order
 import distutils.log                                # pylint: disable=wrong-import-order
 

--- a/tests/coveragetest.py
+++ b/tests/coveragetest.py
@@ -33,6 +33,11 @@ OK, ERR = 0, 1
 # The coverage/tests directory, for all sorts of finding test helping things.
 TESTS_DIR = os.path.dirname(__file__)
 
+# Install arguments to pass to pip when reinstalling ourselves.
+# Defaults to the top of the source tree, but can be overridden if we need
+# some help on certain platforms.
+COVERAGE_INSTALL_ARGS = os.getenv("COVERAGE_INSTALL_ARGS", nice_file(TESTS_DIR, ".."))
+
 
 class CoverageTest(
     StdStreamCapturingMixin,
@@ -415,7 +420,7 @@ class CoverageTest(
 
     def working_root(self):
         """Where is the root of the coverage.py working tree?"""
-        return os.path.dirname(nice_file(coverage.__file__, ".."))
+        return os.path.dirname(nice_file(__file__, ".."))
 
     def report_from_command(self, cmd):
         """Return the report from the `cmd`, with some convenience added."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -510,8 +510,9 @@ def test_ast_dump():
     # Run the AST_DUMP code to make sure it doesn't fail, with some light
     # assertions. Use parser.py as the test code since it is the longest file,
     # and fitting, since it's the AST_DUMP code.
+    import coverage.parser
     files = [
-        os.path.join(TESTS_DIR, "../coverage/parser.py"),
+        coverage.parser.__file__,
         os.path.join(TESTS_DIR, "stress_phystoken.tok"),
     ]
     for fname in files:

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -12,8 +12,8 @@ import pytest
 
 from coverage import env
 
-from tests.coveragetest import CoverageTest, TESTS_DIR, COVERAGE_INSTALL_ARGS
-from tests.helpers import change_dir, make_file, nice_file
+from tests.coveragetest import CoverageTest, COVERAGE_INSTALL_ARGS
+from tests.helpers import change_dir, make_file
 from tests.helpers import re_lines, run_command
 
 

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -12,7 +12,7 @@ import pytest
 
 from coverage import env
 
-from tests.coveragetest import CoverageTest, TESTS_DIR
+from tests.coveragetest import CoverageTest, TESTS_DIR, COVERAGE_INSTALL_ARGS
 from tests.helpers import change_dir, make_file, nice_file
 from tests.helpers import re_lines, run_command
 
@@ -138,13 +138,12 @@ def venv_world_fixture(tmp_path_factory):
             """)
 
         # Install everything.
-        coverage_src = nice_file(TESTS_DIR, "..")
         run_in_venv(
             "python -m pip install --no-index " +
             "./third_pkg " +
             "-e ./another_pkg " +
             "-e ./bug888/app -e ./bug888/plugin " +
-            coverage_src
+            COVERAGE_INSTALL_ARGS
         )
         shutil.rmtree("third_pkg")
 


### PR DESCRIPTION
For context, I've been testing whether a range of popular libraries are going to work on Windows ARM64. (This requires compiling on a regular x64 machine and then copying the wheel to an ARM64 one for testing.)

The good news is, coverage seems to be just fine without any changes. However, because of a few assumptions in the test suite about always testing an in-place build, I had to make some tweaks to be able to run tests. My proposed tweaks should be fine for current uses, but they also allow the following:

* support `SETUPTOOLS_EXT_SUFFIX` when building to override the pyd tag on Windows (used with `setup.py build_ext -L <path>` to point at [pythonarm64](https://www.nuget.org/packages/pythonarm64/) import libraries to do the cross-compile)
* allow `COVERAGE_INSTALL_ARGS` to override how the tests install coverage into a venv (allows to point at a wheel rather than rebuilding from the sources)
* allow `python igor.py remove_extension --from-install` to delete the extension module from `site-packages` rather than only the source tree
* other changes to allow removing the `coverage` directory from the source tree before tests so that the installed copy will be used instead.

I've tested these on my own Windows ARM64 machine, though unfortunately there aren't any available on CI services yet. If you wanted to start releasing (preview) wheels for win-arm64 you can, but there's no support (yet) in `cibuildwheel` or `build` to do it (because those tools don't really have a concept of cross-compilation for Windows at all... yet ;-) ).