### PR TITLE
Fix compilation errors on latest 3.11.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.5"
+          - "3.11.0-beta.1"
           - "pypy-3.7"
         exclude:
           # Windows PyPy doesn't seem to work?

--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -239,7 +239,7 @@ jobs:
         py:
           # PYVERSIONS. Available versions:
           # https://github.com/actions/python-versions/blob/main/versions-manifest.json
-          - "3.11.0-alpha.5"
+          - "3.11.0-beta.1"
       fail-fast: false
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,10 @@ development at the same time, such as 4.5.x and 5.0.
 Unreleased
 ----------
 
-Nothing yet.
+- Fix: Coverage.py now builds successfully on CPython 3.11 (3.11.0b1) again.
+  Closes `issue 1367`_.  Some results for generators may have changed.
+
+.. _issue 1367: https://github.com/nedbat/coveragepy/issues/1367
 
 
 .. _changes_632:

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Coverage.py runs on these versions of Python:
 
 .. PYVERSIONS
 
-* CPython 3.7 through 3.11.0a5.
+* CPython 3.7 through 3.11.0b1.
 * PyPy3 7.3.8.
 
 Documentation is on `Read the Docs`_.  Code repository and issue tracker are on

--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -119,6 +119,10 @@ CTracer_dealloc(CTracer *self)
 }
 
 #if TRACE_LOG
+/* Set debugging constants: a file substring and line number to start logging. */
+static const char * start_file = "badasync.py";
+static int start_line = 1;
+
 static const char *
 indent(int n)
 {
@@ -132,9 +136,6 @@ indent(int n)
 }
 
 static BOOL logging = FALSE;
-/* Set these constants to be a file substring and line number to start logging. */
-static const char * start_file = "nested.py";
-static int start_line = 1;
 
 static void
 CTracer_showlog(CTracer * self, int lineno, PyObject * filename, const char * msg)
@@ -787,11 +788,13 @@ CTracer_trace(CTracer *self, PyFrameObject *frame, int what, PyObject *arg_unuse
     #endif
 
     #if WHAT_LOG
+    const char * w = "XXX ";
     if (what <= (int)(sizeof(what_sym)/sizeof(const char *))) {
-        ascii = PyUnicode_AsASCIIString(MyFrame_GetCode(frame)->co_filename);
-        printf("%x trace: f:%x %s @ %s %d\n", (int)self, (int)frame, what_sym[what], PyBytes_AS_STRING(ascii), PyFrame_GetLineNumber(frame));
-        Py_DECREF(ascii);
+        w = what_sym[what];
     }
+    ascii = PyUnicode_AsASCIIString(MyFrame_GetCode(frame)->co_filename);
+    printf("%x trace: f:%x %s @ %s %d\n", (int)self, (int)frame, what_sym[what], PyBytes_AS_STRING(ascii), PyFrame_GetLineNumber(frame));
+    Py_DECREF(ascii);
     #endif
 
     #if TRACE_LOG

--- a/coverage/ctracer/util.h
+++ b/coverage/ctracer/util.h
@@ -17,13 +17,17 @@
 // to make this work, but it's all I've got until https://bugs.python.org/issue40421
 // is resolved.
 #include <internal/pycore_frame.h>
-#define MyFrame_lasti(f)    ((f)->f_frame->f_lasti * 2)
+#if PY_VERSION_HEX >= 0x030B00A7
+#define MyFrame_GetLasti(f)     (PyFrame_GetLasti(f))
+#else
+#define MyFrame_GetLasti(f)     ((f)->f_frame->f_lasti * 2)
+#endif
 #elif PY_VERSION_HEX >= 0x030A00A7
 // The f_lasti field changed meaning in 3.10.0a7. It had been bytes, but
 // now is instructions, so we need to adjust it to use it as a byte index.
-#define MyFrame_lasti(f)    ((f)->f_lasti * 2)
+#define MyFrame_GetLasti(f)     ((f)->f_lasti * 2)
 #else
-#define MyFrame_lasti(f)    ((f)->f_lasti)
+#define MyFrame_GetLasti(f)     ((f)->f_lasti)
 #endif
 
 // Access f_code should be done through a helper starting in 3.9.
@@ -31,6 +35,14 @@
 #define MyFrame_GetCode(f)      (PyFrame_GetCode(f))
 #else
 #define MyFrame_GetCode(f)      ((f)->f_code)
+#endif
+
+#if PY_VERSION_HEX >= 0x030B00A7
+#define MyCode_GetCode(co)      (PyObject_GetAttrString((PyObject *)(co), "co_code"))
+#define MyCode_FreeCode(code)   Py_XDECREF(code)
+#else
+#define MyCode_GetCode(co)      ((co)->co_code)
+#define MyCode_FreeCode(code)
 #endif
 
 /* The values returned to indicate ok or error. */

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,7 +18,7 @@ supported on:
 
 .. PYVERSIONS
 
-* Python versions 3.7 through 3.11.0a5.
+* Python versions 3.7 through 3.11.0b1.
 
 * PyPy3 7.3.8.
 

--- a/tests/test_arcs.py
+++ b/tests/test_arcs.py
@@ -13,6 +13,12 @@ from coverage import env
 from coverage.files import abs_file
 
 
+skip_cpython_92236 = pytest.mark.skipif(
+    env.PYVERSION >= (3, 11, 0, "beta"),
+    reason="Avoid a CPython bug: https://github.com/python/cpython/issues/92236",
+    # #92236 is fixed in https://github.com/python/cpython/pull/92722
+)
+
 class SimpleArcTest(CoverageTest):
     """Tests for coverage.py's arc measurement."""
 
@@ -605,6 +611,7 @@ class LoopArcTest(CoverageTest):
             arcz_missing="26 3. 6.",
         )
 
+    @skip_cpython_92236
     def test_generator_expression(self):
         # Generator expression:
         self.check_coverage("""\
@@ -617,6 +624,7 @@ class LoopArcTest(CoverageTest):
             arcz=".1 -22 2-2 12 23 34 45 53 3.",
         )
 
+    @skip_cpython_92236
     def test_generator_expression_another_way(self):
         # https://bugs.python.org/issue44450
         # Generator expression:
@@ -1169,6 +1177,7 @@ class ExceptionArcTest(CoverageTest):
 class YieldTest(CoverageTest):
     """Arc tests for generators."""
 
+    @skip_cpython_92236
     def test_yield_in_loop(self):
         self.check_coverage("""\
             def gen(inp):
@@ -1180,6 +1189,7 @@ class YieldTest(CoverageTest):
             arcz=".1 .2 23 2. 32 15 5.",
         )
 
+    @skip_cpython_92236
     def test_padded_yield_in_loop(self):
         self.check_coverage("""\
             def gen(inp):
@@ -1200,6 +1210,7 @@ class YieldTest(CoverageTest):
         env.PYVERSION[:5] == (3, 11, 0, 'alpha', 3),
         reason="avoid 3.11 bug: bpo46225",
     )
+    @skip_cpython_92236
     def test_bug_308(self):
         self.check_coverage("""\
             def run():
@@ -1234,6 +1245,7 @@ class YieldTest(CoverageTest):
             arcz=".1 14 45 54 4.  .2 2.  -22 2-2",
         )
 
+    @skip_cpython_92236
     def test_bug_324(self):
         # This code is tricky: the list() call pulls all the values from gen(),
         # but each of them is a generator itself that is never iterated.  As a
@@ -1252,6 +1264,7 @@ class YieldTest(CoverageTest):
             arcz_missing="-33 3-3",
         )
 
+    @skip_cpython_92236
     def test_coroutines(self):
         self.check_coverage("""\
             def double_inputs():
@@ -1271,6 +1284,7 @@ class YieldTest(CoverageTest):
         )
         assert self.stdout() == "20\n12\n"
 
+    @skip_cpython_92236
     def test_yield_from(self):
         self.check_coverage("""\
             def gen(inp):
@@ -1286,6 +1300,7 @@ class YieldTest(CoverageTest):
             arcz=".1 19 9.  .2 23 34 45 56 63 37 7.",
         )
 
+    @skip_cpython_92236
     def test_abandoned_yield(self):
         # https://github.com/nedbat/coveragepy/issues/440
         self.check_coverage("""\
@@ -1614,6 +1629,7 @@ class MiscArcTest(CoverageTest):
         self.check_coverage(code, arcs=[(-1, 1), (1, 2*n+4), (2*n+4, -1)])
         assert self.stdout() == f"{n}\n"
 
+    @skip_cpython_92236
     def test_partial_generators(self):
         # https://github.com/nedbat/coveragepy/issues/475
         # Line 2 is executed completely.
@@ -1830,6 +1846,7 @@ class AsyncTest(CoverageTest):
     """Tests of the new async and await keywords in Python 3.5"""
 
     @xfail_eventlet_670
+    @skip_cpython_92236
     def test_async(self):
         self.check_coverage("""\
             import asyncio
@@ -1857,6 +1874,7 @@ class AsyncTest(CoverageTest):
         assert self.stdout() == "Compute 1 + 2 ...\n1 + 2 = 3\n"
 
     @xfail_eventlet_670
+    @skip_cpython_92236
     def test_async_for(self):
         self.check_coverage("""\
             import asyncio
@@ -1932,6 +1950,7 @@ class AsyncTest(CoverageTest):
     # https://bugs.python.org/issue44621
     @pytest.mark.skipif(env.PYVERSION[:2] == (3, 9), reason="avoid a 3.9 bug: 44621")
     @pytest.mark.skipif(env.PYVERSION < (3, 7), reason="need asyncio.run")
+    @skip_cpython_92236
     def test_bug_1158(self):
         self.check_coverage("""\
             import asyncio
@@ -1962,6 +1981,7 @@ class AsyncTest(CoverageTest):
     )
     @xfail_eventlet_670
     @pytest.mark.skipif(env.PYVERSION < (3, 7), reason="need asyncio.run")
+    @skip_cpython_92236
     def test_bug_1176(self):
         self.check_coverage("""\
             import asyncio


### PR DESCRIPTION
Another attempt at 3.11.0-latest compatibility.  This fully compiles, but gets wrong answers for generators.