### PR TITLE
Use tomllib instead of tomli on Python 3.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,8 @@ development at the same time, such as 4.5.x and 5.0.
 Unreleased
 ----------
 
-Nothing yet.
+- The ``toml`` extra no longer installs ``tomli`` on Python 3.11 (``tomllib``
+  is used instead)
 
 
 .. _changes_633:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -11,6 +11,7 @@ Albertas Agejevas
 Aleksi Torhamo
 Alex Gaynor
 Alex Groce
+Alex Grönholm
 Alex Sandro
 Alexander Todorov
 Alexander Walters

--- a/coverage/tomlconfig.py
+++ b/coverage/tomlconfig.py
@@ -6,6 +6,7 @@
 import configparser
 import os
 import re
+import sys
 
 from coverage.exceptions import ConfigError
 from coverage.misc import import_third_party, substitute_variables
@@ -14,8 +15,11 @@ from coverage.misc import import_third_party, substitute_variables
 # import_third_party will unload any module that wasn't already imported.
 # tomli imports typing, and if we unload it, later it's imported again, and on
 # Python 3.6, this causes infinite recursion.)
-import typing   # pylint: disable=unused-import, wrong-import-order
-tomli = import_third_party("tomli")
+if sys.version_info >= (3, 11):
+    import tomllib as tomli
+else:
+    import typing   # pylint: disable=unused-import, wrong-import-order
+    tomli = import_third_party("tomli")
 
 
 class TomlDecodeError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup_args = dict(
 
     extras_require={
         # Enable pyproject.toml support.
-        'toml': ['tomli'],
+        'toml; python_version < "3.11"': ['tomli'],
     },
 
     # We need to get HTML assets from our htmlfiles directory.


### PR DESCRIPTION
The "toml" extra should not cause tomli to be installed on 3.11.