### PR TITLE
speed up python tracer with frame.f_trace_lines = False

### DIFF
--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -159,6 +159,8 @@ class PyTracer:
                 if tracename not in self.data:
                     self.data[tracename] = set()
                 self.cur_file_data = self.data[tracename]
+            else:
+                frame.f_trace_lines = False
             # The call event is really a "start frame" event, and happens for
             # function calls and re-entering generators.  The f_lasti field is
             # -1 for calls, and a real offset for generators.  Use <0 as the


### PR DESCRIPTION
This is a Python-only version of #791, in response to the extreme slowdowns of coverage on pypy reported in #1339.

the PR uses the python >= 3.7 feature of being able to disable line tracing by setting the frame attribute f_trace_lines to False. This can be used for the frames of functions that we aren't collecting coverage information for (eg those functions in the stdlib).

I tried to used the `perf/` code to look into the impact, but as @nedbat wrote on #1339, the code had bitrotted and even after fixing I couldn't really use it, since it doesn't *have* any code that shouldn't be traced. Instead, I used [pytest-html](https://github.com/pytest-dev/pytest-html) as a coverage benchmark (because somebody had reported extremely slow PyPy coverage runs there as well, see [#482](https://github.com/pytest-dev/pytest-html/issues/482)).

Running coverage of pytest-html with the python tracer gives the following numbers:


py3.10 timid:
before: 457.84s
after: 48.63s

pypy3.9-dev:
before: 290.38
after: 159.96

So quite a substantial improvement on both CPython and PyPy (I had to re-measure CPython a few times before I believed the speedup, but it was consistent for me).

This PR intentionally does not contain the equivalent change to the C tracer. I briefly tried this but it did not show a huge change in performance. So somebody might have to investigate that more carefully.