### PR TITLE
Pytracer improvements

### DIFF
--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -289,7 +289,8 @@ class PyTracer:
             dont_warn = (env.PYPY and env.PYPYVERSION >= (5, 4) and self.in_atexit and tf is None)
             if (not dont_warn) and tf != self._cached_bound_method_trace:   # pylint: disable=comparison-with-callable
                 self.warn(
-                    f"Trace function changed, data is likely wrong: {tf!r} != {self._cached_bound_method_trace!r}",
+                    f"Trace function changed, data is likely wrong: "
+                    f"{tf!r} != {self._cached_bound_method_trace!r}",
                     slug="trace-changed",
                 )
 


### PR DESCRIPTION
Here are two further improvements of the python tracer performance to help with #1339:
- cache the bound method of `_trace`
- use the observation that if we stay within the same file from one function to a called function, the decision whether we should trace or not does not change to save dictionary lookups

unfortunately I couldn't get the benchmark script to run (I fixed the hardcoded path, but even then tests stopped running after a run or two, didn't dig deeper). But here are some numbers for attrs and pytest-html:

| Implementation               | none | Coverage master timid | Coverage PR timid | Speedup |
|------------------------------|------|----------------------:|------------------:|---------|
| CPython 3.10 attrs           | 87s  |                  335s |              274s | 22%     |
| PyPy 3.9 nightly attrs       | 62s  |                  575s |              356s | 62%     |
| CPython 3.10 pytest-html     | 33s  |                   63s |               59s | 7%      |
| PyPy 3.9 nightly pytest-html | 45s  |                  185s |              156s | 19%     |

This change is a little bit more complex than the previous one, so I would understand if you don't deem it worth the extra complexity.