### PR TITLE
perf: cache the lookup of should_trace_cache

### DIFF
--- a/coverage/ctracer/stats.h
+++ b/coverage/ctracer/stats.h
@@ -22,6 +22,7 @@ typedef struct Stats {
     unsigned int stack_reallocs;
     unsigned int errors;
     unsigned int pycalls;
+    unsigned int filename_cache_hits;
     unsigned int start_context_calls;
 #endif
 } Stats;


### PR DESCRIPTION
Doesn't seem to improve performance by more than about .5%

| pyver | proj | without cache | with cache | compare |
|----|----|----|----|----|
| python3.11 | bug1339.py | 0.767 s | 0.819 s | 106.77% |
| python3.11 | bm_sudoku.py | 50.346 s | 50.142 s | 99.60% |
| python3.11 | bm_spectral_norm.py | 60.180 s | 59.727 s | 99.25% |