### PR TITLE
Fix paths when running coverage from root

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -26,7 +26,7 @@ def set_relative_directory():
 
     # The current directory
     abs_curdir = abs_file(os.curdir)
-    if abs_curdir != os.sep:
+    if not abs_curdir.endswith(os.sep):
         # Suffix with separator only if not at the system root
         abs_curdir = abs_curdir + os.sep
 

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -24,8 +24,14 @@ def set_relative_directory():
     """Set the directory that `relative_filename` will be relative to."""
     global RELATIVE_DIR, CANONICAL_FILENAME_CACHE
 
+    # The current directory
+    abs_curdir = abs_file(os.curdir)
+    if abs_curdir != os.sep:
+        # Suffix with separator only if not at the system root
+        abs_curdir = abs_curdir + os.sep
+
     # The absolute path to our current directory.
-    RELATIVE_DIR = os.path.normcase(abs_file(os.curdir) + os.sep)
+    RELATIVE_DIR = os.path.normcase(abs_curdir)
 
     # Cache of results of calling the canonical_filename() method, to
     # avoid duplicating work.

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -9,14 +9,10 @@ from unittest import mock
 
 import pytest
 
-from coverage import env
-from coverage import files
+from coverage import env, files
 from coverage.exceptions import ConfigError
-from coverage.files import (
-    TreeMatcher, FnmatchMatcher, ModuleMatcher, PathAliases,
-    find_python_files, abs_file, actual_path, flat_rootname, fnmatches_to_regex,
-)
-
+from coverage.files import (FnmatchMatcher, ModuleMatcher, PathAliases, TreeMatcher, abs_file,
+                            actual_path, find_python_files, flat_rootname, fnmatches_to_regex)
 from tests.coveragetest import CoverageTest
 
 
@@ -75,13 +71,11 @@ class FilesTest(CoverageTest):
         ]
     )
     def test_relative_dir_for_root(self, curdir, sep):
-        with (
-            mock.patch.object(files.os, 'curdir', new=curdir),
-            mock.patch.object(files.os, 'sep', new=sep),
-            mock.patch('coverage.files.os.path.normcase', return_value=curdir),
-        ):
-            files.set_relative_directory()
-            assert files.relative_directory() == curdir
+        with mock.patch.object(files.os, 'curdir', new=curdir):
+            with mock.patch.object(files.os, 'sep', new=sep):
+                with mock.patch('coverage.files.os.path.normcase', return_value=curdir):
+                    files.set_relative_directory()
+                    assert files.relative_directory() == curdir
 
 
 @pytest.mark.parametrize("original, flat", [

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -5,6 +5,7 @@
 
 import os
 import os.path
+from unittest import mock
 
 import pytest
 
@@ -66,6 +67,21 @@ class FilesTest(CoverageTest):
         # After the filename has been converted, it should be in the cache.
         assert 'sub/proj1/file1.py' in files.CANONICAL_FILENAME_CACHE
         assert files.canonical_filename('sub/proj1/file1.py') == self.abs_path('file1.py')
+
+    @pytest.mark.parametrize(
+        ["curdir", "sep"], [
+            ("/", "/"),
+            ("X:\\", "\\"),
+        ]
+    )
+    def test_relative_dir_for_root(self, curdir, sep):
+        with (
+            mock.patch.object(files.os, 'curdir', new=curdir),
+            mock.patch.object(files.os, 'sep', new=sep),
+            mock.patch('coverage.files.os.path.normcase', return_value=curdir),
+        ):
+            files.set_relative_directory()
+            assert files.relative_directory() == curdir
 
 
 @pytest.mark.parametrize("original, flat", [


### PR DESCRIPTION
I'm running coverage from a docker image where my source code is at `/`.
I couldn't figure out why the paths were all starting with `/` but not if I moved things in a subfolder (e.g. `/subfolder`).
With the current implementation, `RELATIVE_DIR` would be equal to `//` instead of `/` because we suffix no matter what.

I tested this change manually in my docker image with `python@3.10.4` and `coverage==6.0.2`.