### PR TITLE
Fix globbing of filenames that contain special glob characters

### DIFF
--- a/coverage/data.py
+++ b/coverage/data.py
@@ -70,7 +70,7 @@ def combinable_files(data_file, data_paths=None):
         if os.path.isfile(p):
             files_to_combine.append(os.path.abspath(p))
         elif os.path.isdir(p):
-            pattern = os.path.join(os.path.abspath(p), f"{glob.escape(local)}.*")
+            pattern = glob.escape(os.path.join(os.path.abspath(p), local)) +".*"
             files_to_combine.extend(glob.glob(pattern))
         else:
             raise NoDataError(f"Couldn't combine from non-existent path '{p}'")

--- a/coverage/data.py
+++ b/coverage/data.py
@@ -70,7 +70,7 @@ def combinable_files(data_file, data_paths=None):
         if os.path.isfile(p):
             files_to_combine.append(os.path.abspath(p))
         elif os.path.isdir(p):
-            pattern = os.path.join(os.path.abspath(p), f"{local}.*")
+            pattern = os.path.join(os.path.abspath(p), f"{glob.escape(local)}.*")
             files_to_combine.extend(glob.glob(pattern))
         else:
             raise NoDataError(f"Couldn't combine from non-existent path '{p}'")

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -774,8 +774,8 @@ class CoverageData(SimpleReprMixin):
         file_be_gone(self._filename)
         if parallel:
             data_dir, local = os.path.split(self._filename)
-            localdot = glob.escape(local) + ".*"
-            pattern = os.path.join(os.path.abspath(data_dir), localdot)
+            local_abs_path = os.path.join(os.path.abspath(data_dir), local)
+            pattern = glob.escape(local_abs_path) + ".*"
             for filename in glob.glob(pattern):
                 if self._debug.should("dataio"):
                     self._debug.write(f"Erasing parallel data file {filename!r}")

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -774,7 +774,7 @@ class CoverageData(SimpleReprMixin):
         file_be_gone(self._filename)
         if parallel:
             data_dir, local = os.path.split(self._filename)
-            localdot = local + ".*"
+            localdot = glob.escape(local) + ".*"
             pattern = os.path.join(os.path.abspath(data_dir), localdot)
             for filename in glob.glob(pattern):
                 if self._debug.should("dataio"):


### PR DESCRIPTION
When specifying a coverage filename using the `COVERAGE_FILE` environment variable, special characters are not handled correctly. I use that facility to set the name of the coverage file to match the name of the test that I am running in pytest, so that I can associate the coverage with the specific test that generated that coverage. Some test names contain brackets, so the name of the test might be `exampletest[b-a]`, and I transform that name into `.coverage.exampletest[b-a]` and then run
```
COVERAGE_FILE=.coverage.exampletest[b-a] pytest --cov "exampletest[b-a]"
```
Which results in the error:
```
re.error: bad character range b-a at position 5
```
Any special characters in a filename specified for creating a new file should be escaped before globbing for similar filenames.