### PR TITLE
force / in actual_path() on Windows

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -133,7 +133,7 @@ if env.WINDOWS:
                     tail = f
                     break
             actpath = os.path.join(head, tail)
-        actpath.replace("\\", "/")
+        actpath = actpath.replace("\\", "/")
         _ACTUAL_PATH_CACHE[path] = actpath
         return actpath
 

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -343,6 +343,7 @@ class PathAliases:
         match an entire tree, and not just its root.
 
         """
+        pattern = pattern.replace("\\", "/")
         pattern_sep = sep(pattern)
 
         if len(pattern) > 1:

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -133,7 +133,6 @@ if env.WINDOWS:
                     tail = f
                     break
             actpath = os.path.join(head, tail)
-        actpath = actpath.replace("\\", "/")
         _ACTUAL_PATH_CACHE[path] = actpath
         return actpath
 

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -133,6 +133,7 @@ if env.WINDOWS:
                     tail = f
                     break
             actpath = os.path.join(head, tail)
+        actpath.replace("\\", "/")
         _ACTUAL_PATH_CACHE[path] = actpath
         return actpath
 

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -384,6 +384,7 @@ class CoverageData(SimpleReprMixin):
         If filename is not in the database yet, add it if `add` is True.
         If `add` is not True, return None.
         """
+        filename = filename.replace("\\", "/")
         if filename not in self._file_map:
             if add:
                 with self._connect() as con:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -428,4 +428,4 @@ class WindowsFileTest(CoverageTest):
     run_in_temp_dir = False
 
     def test_actual_path(self):
-        assert actual_path(r'c:\Windows') == actual_path(r'C:\wINDOWS')
+        assert actual_path(r'c:/Windows') == actual_path(r'C:\wINDOWS')


### PR DESCRIPTION
This is intended to make relative paths generated on Windows usable in Linux and macOS.

https://github.com/nedbat/coveragepy/issues/991

Draft for:
- [ ] Tests
- [ ] Discussion around better solutions or other places that should be addressed.