### PR TITLE
fix(html): trigger filter on page load

### DIFF
--- a/coverage/htmlfiles/coverage_html.js
+++ b/coverage/htmlfiles/coverage_html.js
@@ -166,7 +166,7 @@ coverage.wire_up_filter = function () {
 
     // Trigger change event on setup, to force filter on page refresh
     // (filter value may still be present).
-    document.getElementById("filter").dispatchEvent(new Event("change"));
+    document.getElementById("filter").dispatchEvent(new Event("input"));
 };
 
 coverage.INDEX_SORT_STORAGE = "COVERAGE_INDEX_SORT_2";


### PR DESCRIPTION
In the HTML report, if the "filter" input contains a value when the page loads (e.g. when refreshing the page), it is ignored.  This happens even though an event is actually created on start-up to trigger the refresh.

I believe this is a regression introduced in 9a1954a224c7c0f578513d8f4ca5f821fcf2cf5a, when the observed events changed from "keyup change" to "input".

Therefore this PR changes the type of the fired event to match the type of the observed events.