### PR TITLE
build: remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 # For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
 
 [build-system]
-requires = ['setuptools', 'wheel']
+requires = ['setuptools']
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a