### PR TITLE
🐛 Fix the branch protection gate check @ GHA

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -91,13 +91,19 @@ jobs:
              exit 1
           fi
 
-  # A final step to give a simple name for required status checks.
-  # https://github.com/orgs/community/discussions/33579
-  success:
-    needs: tests
-    runs-on: ubuntu-latest
+  # https://github.com/marketplace/actions/alls-green#why
+  success:  # This job does nothing and is only used for the branch protection
     name: Tests successful
+
+    if: always()
+
+    needs:
+    - tests
+
+    runs-on: ubuntu-latest
+
     steps:
-      - name: "Success"
-        run: |
-          echo Tests successful
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This adds a GHA job that reliably determines if all the required dependencies have succeeded or not.

It is now in use in aiohttp (and other aio-libs projects), CherryPy, some of the Ansible repositories, pip-tools, all of the jaraco's projects (like `setuptools`, `importlib_metadata`), some of hynek's projects, some PyCQA, PyCA, PyPA and pytest projects, a few AWS Labs projects (to my surprise).

The story behind this is explained in more detail at https://github.com/marketplace/actions/alls-green#why.