### PR TITLE
PythonFileReporter: do not expect files without a filename extension to contain Python code

### DIFF
--- a/coverage/python.py
+++ b/coverage/python.py
@@ -244,9 +244,6 @@ class PythonFileReporter(FileReporter):
         # Anything named *.py* should be Python.
         if ext.startswith(".py"):
             return True
-        # Jinja templates are evaluated using Python.
-        if ext.startswith('.jinja'):
-            return True
         # Everything else is probably not Python.
         return False
 

--- a/coverage/python.py
+++ b/coverage/python.py
@@ -244,9 +244,6 @@ class PythonFileReporter(FileReporter):
         # Anything named *.py* should be Python.
         if ext.startswith(".py"):
             return True
-        # A file with no extension should be Python.
-        if not ext:
-            return True
         # Everything else is probably not Python.
         return False
 

--- a/coverage/python.py
+++ b/coverage/python.py
@@ -244,6 +244,9 @@ class PythonFileReporter(FileReporter):
         # Anything named *.py* should be Python.
         if ext.startswith(".py"):
             return True
+        # Jinja templates are evaluated using Python.
+        if ext.startswith('.jinja'):
+            return True
         # Everything else is probably not Python.
         return False
 

--- a/tests/test_filereporter.py
+++ b/tests/test_filereporter.py
@@ -102,3 +102,10 @@ class FileReporterTest(UsingModulesMixin, CoverageTest):
         z1z1 = PythonFileReporter(zip1.zip1)
         assert z1.source() == ""
         assert "# My zip file!" in z1z1.source().splitlines()
+
+    def test_python_extensions(self):
+        f1 = PythonFileReporter("afile.py")
+        f2 = PythonFileReporter("Makefile")
+
+        assert f1.should_be_python()
+        assert not f2.should_be_python()

--- a/tests/test_filereporter.py
+++ b/tests/test_filereporter.py
@@ -103,7 +103,7 @@ class FileReporterTest(UsingModulesMixin, CoverageTest):
         assert z1.source() == ""
         assert "# My zip file!" in z1z1.source().splitlines()
 
-    def test_python_extensions(self):
+    def test_python_extensions(self) -> None:
         f1 = PythonFileReporter("afile.py")
         f2 = PythonFileReporter("Makefile")
         f3 = PythonFileReporter("template.jinja")

--- a/tests/test_filereporter.py
+++ b/tests/test_filereporter.py
@@ -106,8 +106,6 @@ class FileReporterTest(UsingModulesMixin, CoverageTest):
     def test_python_extensions(self) -> None:
         f1 = PythonFileReporter("afile.py")
         f2 = PythonFileReporter("Makefile")
-        f3 = PythonFileReporter("template.jinja")
 
         assert f1.should_be_python()
         assert not f2.should_be_python()
-        assert f3.should_be_python()

--- a/tests/test_filereporter.py
+++ b/tests/test_filereporter.py
@@ -106,6 +106,8 @@ class FileReporterTest(UsingModulesMixin, CoverageTest):
     def test_python_extensions(self):
         f1 = PythonFileReporter("afile.py")
         f2 = PythonFileReporter("Makefile")
+        f3 = PythonFileReporter("template.jinja")
 
         assert f1.should_be_python()
         assert not f2.should_be_python()
+        assert f3.should_be_python()


### PR DESCRIPTION
Possible fixup; could resolve #1488 (if that's confirmed to be a bug worth addressing).