### PR TITLE
Only rerun the failed tests in CI

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -74,23 +74,14 @@ jobs:
           # python -c "import urllib.request as r; exec(r.urlopen('https://bit.ly/pydoctor').read())"
 
       - name: "Run tox for ${{ matrix.python-version }}"
-        continue-on-error: true
-        id: tox1
         run: |
           python -m tox -- -rfsEX
 
       - name: "Retry tox for ${{ matrix.python-version }}"
-        id: tox2
-        if: steps.tox1.outcome == 'failure'
-        run: |
-          python -m tox -- -rfsEX
-
-      - name: "Set status"
-        if: always()
-        run: |
-          if ${{ steps.tox1.outcome != 'success' && steps.tox2.outcome != 'success' }}; then
-             exit 1
-          fi
+        if: failure()
+        run: >-  # `exit 1` makes sure that the job remains red with flaky runs
+          python -m tox -- -rfsEX --lf -vvvvv
+          && exit 1
 
   # This job aggregates test results. It's the required check for branch protection.
   # https://github.com/marketplace/actions/alls-green#why


### PR DESCRIPTION
This patch simplifies attempting to execute the tests again on failures in CI. It also limits the scope of the tests being rerun to include only those that failed on the first try. Additionally, it enables the maximum verbosity so that the retry is more useful for troubleshooting.