### PR TITLE
fix: Handle ast.Match not defined in Python 3.10.0-alpha.1

### DIFF
--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -1079,7 +1079,7 @@ class AstArcAnalyzer:
         exits |= self.add_body_arcs(node.orelse, from_start=from_start)
         return exits
 
-    if sys.version_info > (3, 10, 0, 'alpha', 1):
+    if hasattr(ast, "Match"):  # Python 3.10 and more recent
         def _handle__Match(self, node: ast.Match) -> Set[ArcStart]:
             start = self.line_for_node(node)
             last_start = start

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -9,7 +9,6 @@ import ast
 import collections
 import os
 import re
-import sys
 import token
 import tokenize
 

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -1079,7 +1079,7 @@ class AstArcAnalyzer:
         exits |= self.add_body_arcs(node.orelse, from_start=from_start)
         return exits
 
-    if sys.version_info >= (3, 10):
+    if sys.version_info > (3, 10, 0, 'alpha', 1):
         def _handle__Match(self, node: ast.Match) -> Set[ArcStart]:
             start = self.line_for_node(node)
             last_start = start

--- a/coverage/phystokens.py
+++ b/coverage/phystokens.py
@@ -82,7 +82,7 @@ class MatchCaseFinder(ast.NodeVisitor):
         self.match_case_lines: Set[TLineNo] = set()
         self.visit(ast.parse(source))
 
-    if sys.version_info >= (3, 10):
+    if sys.version_info > (3, 10, 0, 'alpha', 1):
         def visit_Match(self, node: ast.Match) -> None:
             """Invoked by ast.NodeVisitor.visit"""
             self.match_case_lines.add(node.lineno)

--- a/coverage/phystokens.py
+++ b/coverage/phystokens.py
@@ -82,7 +82,7 @@ class MatchCaseFinder(ast.NodeVisitor):
         self.match_case_lines: Set[TLineNo] = set()
         self.visit(ast.parse(source))
 
-    if sys.version_info > (3, 10, 0, 'alpha', 1):
+    if hasattr(ast, "Match"):  # Python 3.10 and more recent
         def visit_Match(self, node: ast.Match) -> None:
             """Invoked by ast.NodeVisitor.visit"""
             self.match_case_lines.add(node.lineno)


### PR DESCRIPTION
Coverage 7.0.2 introduced some logic relying on ast.Match which a check that the Python version is 3.10 or more (see https://github.com/nedbat/coveragepy/commit/cceadff1d3d33c046042b606d40e01f41e23ec5d )

Unfortunately, on version 3.10.0-alpha.1, ast.Match does not seem to be defined, leading to uncaught exception:
  AttributeError: module 'ast' has no attribute 'Match'

More details can be found on https://github.com/SylvainDe/DidYouMean-Python/issues/59 .

The quickfix is to perform a more precise check on the Python version (another option could be to try to
access ast.Match and catch the exception).