### PR TITLE
Add safety for empty stack on shutdown.

### DIFF
--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -142,7 +142,12 @@ class PyTracer(TTracer):
                     self.data_stack.pop()
                 )
             except IndexError:
-                self.log("Empty stack!", frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name)
+                self.log(
+                    "Empty stack!",
+                    frame.f_code.co_filename,
+                    frame.f_lineno,
+                    frame.f_code.co_name
+                )
             return None
 
         # if event != 'call' and frame.f_code.co_filename != self.cur_file_name:

--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -137,9 +137,12 @@ class PyTracer(TTracer):
                     self.log(">", f.f_code.co_filename, f.f_lineno, f.f_code.co_name, f.f_trace)
                     f = f.f_back
             sys.settrace(None)
-            self.cur_file_data, self.cur_file_name, self.last_line, self.started_context = (
-                self.data_stack.pop()
-            )
+            try:
+                self.cur_file_data, self.cur_file_name, self.last_line, self.started_context = (
+                    self.data_stack.pop()
+                )
+            except IndexError:
+                self.log("Empty stack!", frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name)
             return None
 
         # if event != 'call' and frame.f_code.co_filename != self.cur_file_name:


### PR DESCRIPTION
Fixes #1542.

When stopping a thread, catch the possible situation of an empty data stack for a thread.

I haven't added test for this case - mostly because I'm not sure how I could manufacture the situation without introducing a very complex test setup. If having a test case is a blocker, I'm open to suggestions on what would constitute a meaningful test.