### PR TITLE
Add purge_files method to CoverageData + unit tests for it

### DIFF
--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -617,29 +617,29 @@ class CoverageData(AutoReprMixin):
 
     def purge_files(self, filenames, context=None):
         """Purge any existing coverage data for the given `filenames`.
-    
+
         If `context` is given, purge only data associated with that measurement context.
         """
-    
+
         if self._debug.should("dataop"):
             self._debug.write(f"Purging {filenames!r} for context {context}")
         self._start_using()
         with self._connect() as con:
-    
+
             if context is not None:
                 context_id = self._context_id(context)
                 if context_id is None:
                     raise DataError("Unknown context {context}")
             else:
                 context_id = None
-    
+
             if self._has_lines:
                 table = 'line_bits'
             elif self._has_arcs:
                 table = 'arcs'
             else:
                 return
-    
+
             for filename in filenames:
                 file_id = self._file_id(filename, add=False)
                 if file_id is None:

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -615,7 +615,7 @@ class CoverageData(AutoReprMixin):
                     # Set the tracer for this file
                     self.add_file_tracers({filename: plugin_name})
 
-    def purge_files(self, filenames, context=None):
+    def purge_files(self, filenames: Iterable[str], context: Optional[str] = None) -> None:
         """Purge any existing coverage data for the given `filenames`.
 
         If `context` is given, purge only data associated with that measurement context.

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -615,6 +615,42 @@ class CoverageData(AutoReprMixin):
                     # Set the tracer for this file
                     self.add_file_tracers({filename: plugin_name})
 
+    def purge_files(self, filenames, context=None):
+        """Purge any existing coverage data for the given `filenames`.
+    
+        If `context` is given, purge only data associated with that measurement context.
+        """
+    
+        if self._debug.should("dataop"):
+            self._debug.write(f"Purging {filenames!r} for context {context}")
+        self._start_using()
+        with self._connect() as con:
+    
+            if context is not None:
+                context_id = self._context_id(context)
+                if context_id is None:
+                    raise DataError("Unknown context {context}")
+            else:
+                context_id = None
+    
+            if self._has_lines:
+                table = 'line_bits'
+            elif self._has_arcs:
+                table = 'arcs'
+            else:
+                return
+    
+            for filename in filenames:
+                file_id = self._file_id(filename, add=False)
+                if file_id is None:
+                    continue
+                self._file_map.pop(filename, None)
+                if context_id is None:
+                    q = f'delete from {table} where file_id={file_id}'
+                else:
+                    q = f'delete from {table} where file_id={file_id} and context_id={context_id}'
+                con.execute(q)
+
     def update(self, other_data: CoverageData, aliases: Optional[PathAliases] = None) -> None:
         """Update this data with data from several other :class:`CoverageData` instances.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -829,7 +829,7 @@ class ApiTest(CoverageTest):
         except coverage.sqldata.DataError:
             pass
         else:
-            assert(0, "exception expected")
+            assert 0, "exception expected"
         assert len(data.measured_files()) == 3
         assert [1, 2] == sorted_lines(data, fn1)
         assert [1,] == sorted_lines(data, fn2)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -755,7 +755,7 @@ class ApiTest(CoverageTest):
         assert cast(str, d['data_file']).endswith(".coverage")
 
     def test_purge_filenames(self) -> None:
-        
+
         fn1 = self.make_file("mymain.py", """\
             import mymod
             a = 1
@@ -771,7 +771,7 @@ class ApiTest(CoverageTest):
         self.start_import_stop(cov, "mymain")
 
         data = cov.get_data()
-        
+
         # Initial measurement was for two files
         assert len(data.measured_files()) == 2
         assert [1, 2] == sorted_lines(data, fn1)
@@ -788,9 +788,9 @@ class ApiTest(CoverageTest):
         assert len(data.measured_files()) == 0
         assert [] == sorted_lines(data, fn1)
         assert [] == sorted_lines(data, fn2)
-        
+
     def test_purge_filenames_context(self) -> None:
-        
+
         fn1 = self.make_file("mymain.py", """\
             import mymod
             a = 1
@@ -804,7 +804,7 @@ class ApiTest(CoverageTest):
 
         def dummy_function():
             unused = 42
-            
+
         # Start/stop since otherwise cantext
         cov = coverage.Coverage()
         cov.start()
@@ -815,7 +815,7 @@ class ApiTest(CoverageTest):
         self.start_import_stop(cov, "mymain")
 
         data = cov.get_data()
-        
+
         # Initial measurement was for three files and two contexts
         assert len(data.measured_files()) == 3
         assert [1, 2] == sorted_lines(data, fn1)
@@ -851,7 +851,7 @@ class ApiTest(CoverageTest):
         assert [1,] == sorted_lines(data, fn2)
         assert len(sorted_lines(data, __file__)) == 0
         assert len(data.measured_contexts()) == 2
-        
+
         # Remove last file specifying correct context
         data.purge_files([fn2], 'testcontext')
         assert len(data.measured_files()) == 0
@@ -859,7 +859,7 @@ class ApiTest(CoverageTest):
         assert [] == sorted_lines(data, fn2)
         assert len(sorted_lines(data, __file__)) == 0
         assert len(data.measured_contexts()) == 2
- 
+
 
 class CurrentInstanceTest(CoverageTest):
     """Tests of Coverage.current()."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -802,7 +802,7 @@ class ApiTest(CoverageTest):
             """)
         fn2 = os.path.join(self.temp_dir, fn2)
 
-        def dummy_function():
+        def dummy_function() -> None:
             unused = 42
 
         # Start/stop since otherwise cantext


### PR DESCRIPTION
This new method makes it possible for users to selectively remove coverage data, and then optionally update it via the existing add_lines and add_arcs methods.

My motivation for this change:  I'm using it in an IDE to track coverage data across edits, in order to invalidate unit test results based on which code was edited.  It produces a pretty good approximation of tests that need to be re-run, useful in applications with massive test suites that take days or longer to run.  Eventually you have to rerun all tests, of course, but this helps catch errors earlier in the development process.  Obviously, there is way more to the implementation of that feature in an IDE, but this method is needed to make it possible.  I'm currently monkey-patching it in, but would prefer it to be part of the CoverageData API.

Of course this new method may also have other uses I'm not thinking of.