### PR TITLE
(🎁) add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup_args = dict(
         'coverage': [
             'htmlfiles/*.*',
             'fullcoverage/*.*',
+            'py.typed',
         ]
     },
 


### PR DESCRIPTION
Type checkers look for this file to determine if type annotations should be used or not. It's required for downstream projects to have access to coverage's type annotations.