### PR TITLE
fix failing `pragma journal_mode=off` execution and subsequent crash

### DIFF
--- a/coverage/data.py
+++ b/coverage/data.py
@@ -145,11 +145,20 @@ def combine_parallel_data(
             # we print the original value of f instead of its relative path
             rel_file_name = f
 
-        with open(f, "rb") as fobj:
-            hasher = hashlib.new("sha3_256")
-            hasher.update(fobj.read())
-            sha = hasher.digest()
-            combine_this_one = sha not in file_hashes
+        try:
+            fobj = open(f, "rb")
+        except FileNotFoundError as exc:
+            if data._warn:
+                data._warn(str(exc))
+            if message:
+                message(f"Couldn't combine data file {rel_file_name}: {exc}")
+            combine_this_one = False
+        else:
+            with fobj:
+                hasher = hashlib.new("sha3_256")
+                hasher.update(fobj.read())
+                sha = hasher.digest()
+                combine_this_one = sha not in file_hashes
 
         delete_this_one = not keep
         if combine_this_one:

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -1133,6 +1133,11 @@ class SqliteDb(AutoReprMixin):
         # PyPy needs the .close() calls here, or sqlite gets twisted up:
         # https://bitbucket.org/pypy/pypy/issues/2872/default-isolation-mode-is-different-on
         self.execute_void("pragma journal_mode=off")
+        if self.execute_one("pragma journal_mode") != ("off",):
+            # Some instances of Sqlite refuse to disable journal mode.
+            # Switching to memory mode prevents journal files from being written,
+            # even though we lose performance with unecessary rollback protection.
+            self.execute_void("pragma journal_mode=memory")
         # This pragma makes writing faster.
         self.execute_void("pragma synchronous=off")
 


### PR DESCRIPTION
I recently encountered an issue that would *sometimes* cause coverage to crash despite no changes to the code it was testing/running against. Apparently some builds of Python+SQLite refuse to apply `pragma journal_mode=off` (they allow it to "execute" but actually silently ignore it), and that can results in short-lived `*-journal` files appearing on the filesystem since the default `pragma journal_mode=delete` is still in effect. When coverage runs in multi/parallel mode and attempts to combine results from its separate files, *sometimes* (presumably depending on OS/filesystem sync timing) some of the `*-journal` files may still briefly exist, and this can cause coverage to crash.

Real-world example of coverage crashing at the end of testing a project I was recently working on:

```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/_pytest/main.py", line 270, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/_pytest/main.py", line 324, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/pluggy/_hooks.py", line 265, in __call__
INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/pluggy/_manager.py", line 80, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/pluggy/_callers.py", line 55, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/pytest_cov/plugin.py", line 294, in pytest_runtestloop
INTERNALERROR>     self.cov_controller.finish()
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/pytest_cov/engine.py", line 44, in ensure_topdir_wrapper
INTERNALERROR>     return meth(self, *args, **kwargs)
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/pytest_cov/engine.py", line 326, in finish
INTERNALERROR>     self.cov.stop()
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/coverage/control.py", line 790, in combine
INTERNALERROR>     combine_parallel_data(
INTERNALERROR>   File "/Users/brasmith/Library/Caches/pypoetry/virtualenvs/quipucords-A54Z8Zh8-py3.9/lib/python3.9/site-packages/coverage/data.py", line 153, in combine_parallel_data
INTERNALERROR>     with open(f, "rb") as fobj:
INTERNALERROR> FileNotFoundError: [Errno 2] No such file or directory: '/Users/brasmith/projects/quipucords/.coverage.brasmith-shadowbook.lan.80545.469681-journal'
```

It was difficult to isolate a reproducible example with coverage itself running against another project, but I was able to at least verify independently that, yes, some builds of Python+SQLite refuse or ignore `pragma journal_mode=off`. See: https://github.com/infinitewarp/test-python-sqlite-journal_mode. The TLDR is that the default macOS 13.2.1 build and pyenv-installed builds fail, but homebrew-installed builds and Linux builds inside various Docker images work as expected.

Since I would like coverage to work reliably in my pyenv-installed environments, I'm proposing two changes with this PR, but I'm happy to drop one in favor of the other or to consider alternate implementations:

1. Check if the `pragma journal_mode=off` actually succeeded. _If it didn't_, execute `pragma journal_mode=memory` so the filesystem should never be dirtied with `*-journal` files. Based on my local testing and understanding of the SQLite documentation, the `memory` mode should still be available even when `off` is not. This might impact memory use or performance, but I suspect the effect would be negligible and a worthwhile tradeoff for stability.
2. Wrap the file-reading context in `combine_parallel_data` with a `try`, and handle the `FileNotFoundError` exception. This would help in the case where the `-journal` file exists when `combinable_files` is called but has been deleted by the time `combine_parallel_data` tries to read it. Weird as it sounds, that *does* appear to happen sometimes. This handling shouldn't be necessary if 1 succeeded in setting `pragma journal_mode=memory`, and I considered dropping this part from the PR, but I thought it might not hurt to have some extra checking there.

Please let me know what you think. 🙂 This problem took a while to figure out since the behavior was so inconsistent between runs and environments, and I'm happy to revise this PR or consider alternate ideas if you have them. I feel like neither 1 nor 2 is _ideal_, but given the fact that some Python+SQLite builds are misbehaving, I couldn't think of a better solution.