### PR TITLE
fix: generate xml report packages correctly on windows

### DIFF
--- a/coverage/xmlreport.py
+++ b/coverage/xmlreport.py
@@ -182,7 +182,7 @@ class XmlReporter:
                 rel_name = filename[len(source_path)+1:]
                 break
         else:
-            rel_name = fr.relative_filename()
+            rel_name = fr.relative_filename().replace("\\", "/")
             self.source_paths.add(fr.filename[:-len(rel_name)].rstrip(r"\/"))
 
         dirname = os.path.dirname(rel_name) or "."

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -319,7 +319,10 @@ class XmlReportTest(XmlTestHelpers, CoverageTest):
         }
 
     def test_no_duplicate_packages(self) -> None:
-        self.make_file("namespace/package/__init__.py", "from . import sample; from . import test; from .subpackage import test")
+        self.make_file(
+            "namespace/package/__init__.py", 
+            "from . import sample; from . import test; from .subpackage import test"
+        )
         self.make_file("namespace/package/sample.py", "print('package.sample')")
         self.make_file("namespace/package/test.py", "print('package.test')")
         self.make_file("namespace/package/subpackage/test.py", "print('package.subpackage.test')")


### PR DESCRIPTION
This will fix the problem of duplicate package elements with the same name in the xml report generated on windows.

Closes #1573 