### PR TITLE
Fix lcov summary coverage reporting

### DIFF
--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -81,8 +81,8 @@ class LcovReporter:
             hashed = base64.b64encode(md5(line).digest()).decode().rstrip("=")
             outfile.write(f"DA:{missed},0,{hashed}\n")
 
-        outfile.write(f"LF:{len(analysis.statements)}\n")
-        outfile.write(f"LH:{len(analysis.executed)}\n")
+        outfile.write(f"LF:{analysis.numbers.n_statements}\n")
+        outfile.write(f"LH:{analysis.numbers.n_executed}\n")
 
         # More information dense branch coverage data.
         missing_arcs = analysis.missing_branch_arcs()

--- a/tests/test_lcov.py
+++ b/tests/test_lcov.py
@@ -286,7 +286,7 @@ class LcovTest(CoverageTest):
                 SF:__init__.py
                 DA:1,1,1B2M2Y8AsgTpgAmY7PhCfg
                 LF:0
-                LH:1
+                LH:0
                 BRF:0
                 BRH:0
                 end_of_record


### PR DESCRIPTION
Using an lcov display tool, I found it displayed an incorrect coverage % when consuming an lcov file generated by `coverage lcov`. This is a snippet from the output of `coverage lcov`:

```
TN:
SF:project/core/types.py
DA:1,1,Q79QNYSUr7l/H6QbUTIbnQ
DA:2,1,ux0VOXuozR4u9iPOuXevGQ
DA:4,1,1Lx3z5HXY+kl9IQ6OARx8Q
DA:6,1,bqdoEo/iolQ7++YdNQhW9w
DA:8,1,UjDZl/ceZYYsCkFKBHJNug
DA:11,1,wQ3lbrGSqimUtHT/JTAbNw
DA:12,1,FoJS1jyk8SqNwzpvvgQbeQ
DA:13,1,IVBPmf2okaGhnhyTf2Uw5w
DA:15,1,1CevO4qnIVBVuhhXOfIEaw
DA:18,1,jpD1iWjBSxIaXY1rWyoUVw
DA:20,1,KzuZhvPiACkp2UaKWv69fQ
DA:22,1,+Zdhl8oX5ermx6jQRu4LVw
DA:27,1,/6yJxkh7yAHIDBy/cthfrw
DA:28,1,Q+/s5+skYAEH0S7cCAszFA
DA:29,1,M1PxRBbO5YFINBVhUbMlsg
DA:30,1,oAGvqi16mvSqeECZoCrQlA
DA:33,1,XzUkDZyD0yX41pZ/dwgH0Q
DA:34,1,CBRBHDDHPBrv8OxO7t+WCw
DA:35,1,/ZvqiDY7XVzMiSFdpC6ZCg
DA:16,0,rNSBT+zRP2ZHZLQ+Rxql5w
LF:18 <----
LH:19 <----
end_of_record
```
You see that LH (lines hit) is > LF (lines found), which is incorrect.

Using `coverage json` or simply `coverage report` displays the correct coverage info:

```
...
            "summary": {
                "covered_lines": 17,       <---
                "num_statements": 18,   <---
                "percent_covered": 94.44444444444444,
                "percent_covered_display": "94",
                "missing_lines": 1,
                "excluded_lines": 0
            },
...
```
```
Name                                                   Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------
project/core/types.py                                   18      1    94%   16
```