### PR TITLE
build: Migrate pytest configuration to pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,32 @@ exclude = """(?x)(
     | ^tests/balance_xdist_plugin\\.py$         # not part of our test suite.
     )"""
 
+[tool.pytest.ini_options]
+addopts = "-q -n auto -p no:legacypath --strict-markers --no-flaky-report -rfEX --failed-first"
+python_classes = "*Test"
+markers = [
+    "expensive: too slow to run during \"make smoke\"",
+]
+
+# How come these warnings are suppressed successfully here, but not in conftest.py??
+filterwarnings = [
+    "ignore:the imp module is deprecated in favour of importlib:DeprecationWarning",
+    "ignore:distutils Version classes are deprecated:DeprecationWarning",
+    "ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning",
+]
+
+# xfail tests that pass should fail the test suite
+xfail_strict = true
+
+balanced_clumps = [
+    # Because of expensive session-scoped fixture:
+    "VirtualenvTest",
+    # Because of shared-file manipulations (~/tests/actual/testing):
+    "CompareTest",
+    # No idea why this one fails if run on separate workers:
+    "GetZipBytesTest",
+]
+
 [tool.scriv]
 # Changelog management: https://pypi.org/project/scriv/
 format = "rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,28 +1,5 @@
 # Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
 # For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
 
-[tool:pytest]
-addopts = -q -n auto -p no:legacypath --strict-markers --no-flaky-report -rfEX --failed-first
-python_classes = *Test
-markers =
-    expensive: too slow to run during "make smoke"
-
-# How come these warnings are suppressed successfully here, but not in conftest.py??
-filterwarnings =
-    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
-    ignore:distutils Version classes are deprecated:DeprecationWarning
-    ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning
-
-# xfail tests that pass should fail the test suite
-xfail_strict = true
-
-balanced_clumps =
-    ; Because of expensive session-scoped fixture:
-    VirtualenvTest
-    ; Because of shared-file manipulations (~/tests/actual/testing):
-    CompareTest
-    ; No idea why this one fails if run on separate workers:
-    GetZipBytesTest
-
 [metadata]
 license_files = LICENSE.txt


### PR DESCRIPTION
This works locally for me, but not all of the tox suite would run since the `.pip` files won't reliably install (yet).

However, the pytest suite runs locally on 3.9 just fine, so pushing this to see if it runs the CI test suite OK.