### PR TITLE
Fix bug where coverage data is not saved on SIGTERM

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -653,7 +653,7 @@ class Coverage(TConfigurable):
             self._debug.write(f"{event}: pid: {os.getpid()}, instance: {self!r}")
         if self._started:
             self.stop()
-        if self._auto_save:
+        if self._auto_save or event == "sigterm":
             self.save()
 
     def _on_sigterm(self, signum_unused: int, frame_unused: Optional[FrameType]) -> None:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -768,7 +768,10 @@ class SigtermTest(CoverageTest):
             sigterm = true
             """)
         out = self.run_command("coverage run handler.py")
-        assert out == "START\nSIGTERM\nTerminated\n"
+        if env.LINUX:
+            assert out == "START\nSIGTERM\nTerminated\n"
+        else:
+            assert out == "START\nSIGTERM\n"
         out = self.run_command("coverage report -m")
         expected = "handler.py 5 1 80% 6"
         assert self.squeezed_lines(out)[2] == expected

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -705,7 +705,7 @@ class SigtermTest(CoverageTest):
     """Tests of our handling of SIGTERM."""
 
     @pytest.mark.parametrize("sigterm", [False, True])
-    def test_sigterm_saves_data(self, sigterm: bool) -> None:
+    def test_sigterm_multiprocessing_saves_data(self, sigterm: bool) -> None:
         # A terminated process should save its coverage data.
         self.make_file("clobbered.py", """\
             import multiprocessing
@@ -749,6 +749,28 @@ class SigtermTest(CoverageTest):
             expected = "clobbered.py 17 1 94% 6"
         else:
             expected = "clobbered.py 17 5 71% 5-10"
+        assert self.squeezed_lines(out)[2] == expected
+
+    def test_sigterm_threading_saves_data(self) -> None:
+        # A terminated process should save its coverage data.
+        self.make_file("handler.py", """\
+            import os, signal
+
+            print("START", flush=True)
+            print("SIGTERM", flush=True)
+            os.kill(os.getpid(), signal.SIGTERM)
+            print("NOT HERE", flush=True)
+            """)
+        self.make_file(".coveragerc", """\
+            [run]
+            # The default concurrency option.
+            concurrency = thread
+            sigterm = true
+            """)
+        out = self.run_command("coverage run handler.py")
+        assert out == "START\nSIGTERM\nTerminated\n"
+        out = self.run_command("coverage report -m")
+        expected = "handler.py 5 1 80% 6"
         assert self.squeezed_lines(out)[2] == expected
 
     def test_sigterm_still_runs(self) -> None:


### PR DESCRIPTION
Fixes https://github.com/nedbat/coveragepy/issues/1599

Failing test prior to the fix:
```
$python -m pytest tests/test_concurrency.py -k Sigterm
bringing up nodes...
...                                                                                                                            [100%] [100%]F [100%]
============================================================== FAILURES ==============================================================
___________________________________________ SigtermTest.test_sigterm_threading_saves_data ____________________________________________
[gw2] linux -- Python 3.8.10 /mnt/c/Users/legaul/repos/coveragepy/venv/bin/python

self = <tests.test_concurrency.SigtermTest object at 0x7f7ffc8f75e0>

    def test_sigterm_threading_saves_data(self) -> None:
        # A terminated process should save its coverage data.
        self.make_file("handler.py", """\
            import os, signal

            print("START", flush=True)
            print("SIGTERM", flush=True)
            os.kill(os.getpid(), signal.SIGTERM)
            print("NOT HERE", flush=True)
            """)
        self.make_file(".coveragerc", """\
            [run]
            # The default concurrency option.
            concurrency = thread
            sigterm = true
            """)
        out = self.run_command("coverage run handler.py")
        assert out == "START\nSIGTERM\nTerminated\n"
        out = self.run_command("coverage report -m")
        expected = "handler.py 5 1 80% 6"
>       assert self.squeezed_lines(out)[2] == expected
E       IndexError: list index out of range

/mnt/c/Users/legaul/repos/coveragepy/tests/test_concurrency.py:774: IndexError
-------------------------------------------------------- Captured stdout call --------------------------------------------------------
START
SIGTERM
Terminated

No data to report.

-------------------------------------------------------- Captured stdout call --------------------------------------------------------
START
SIGTERM
Terminated

No data to report.

-------------------------------------------------------- Captured stdout call --------------------------------------------------------
START
SIGTERM
Terminated

No data to report.

====================================================== short test summary info =======================================================
FAILED tests/test_concurrency.py::SigtermTest::test_sigterm_threading_saves_data - IndexError: list index out of range
1 failed, 3 passed in 3.17s
```