### PR TITLE
fix: Source paths with trailing slashes causing inconsistent sources in XML report with relative_paths

### DIFF
--- a/coverage/xmlreport.py
+++ b/coverage/xmlreport.py
@@ -69,6 +69,8 @@ class XmlReporter:
                 if os.path.exists(src):
                     if not self.config.relative_files:
                         src = files.canonical_filename(src)
+                    else:
+                        src = src.rstrip(r"\/")
                     self.source_paths.add(src)
         self.packages: Dict[str, PackageData] = {}
         self.xml_out: xml.dom.minidom.Document

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -320,7 +320,7 @@ class XmlReportTest(XmlTestHelpers, CoverageTest):
 
     def test_no_duplicate_packages(self) -> None:
         self.make_file(
-            "namespace/package/__init__.py", 
+            "namespace/package/__init__.py",
             "from . import sample; from . import test; from .subpackage import test"
         )
         self.make_file("namespace/package/sample.py", "print('package.sample')")
@@ -479,6 +479,19 @@ class XmlPackageStructureTest(XmlTestHelpers, CoverageTest):
     def test_relative_source(self) -> None:
         self.make_file("src/mod.py", "print(17)")
         cov = coverage.Coverage(source=["src"])
+        cov.set_option("run:relative_files", True)
+        self.start_import_stop(cov, "mod", modfile="src/mod.py")
+        cov.xml_report()
+
+        with open("coverage.xml") as x:
+            print(x.read())
+        dom = ElementTree.parse("coverage.xml")
+        elts = dom.findall(".//sources/source")
+        assert [elt.text for elt in elts] == ["src"]
+
+    def test_relative_source_trailing_slash(self) -> None:
+        self.make_file("src/mod.py", "print(17)")
+        cov = coverage.Coverage(source=["src/"])
         cov.set_option("run:relative_files", True)
         self.start_import_stop(cov, "mod", modfile="src/mod.py")
         cov.xml_report()


### PR DESCRIPTION
This is related to two bugs:

* Fixes https://github.com/nedbat/coveragepy/issues/1541
* Potentially unreported: `<sources>` would include an empty `<source>` if the source contained a trailing slash when using `relative_paths=True`.

The fix strips out the trailing slash in source directories when `relative_paths=True` is used. This does not need to be applied for `relative_path=False`, because `canonical_filename` will automatically strip trailing slashes through its use of `os.path.join`.

This fix returns the behaviour to that present prior to https://github.com/nedbat/coveragepy/commit/45cf7936ee605cfe06f7f5967a72a73198960120 where the `<source>` reported would never end in a trailing slash.