### PR TITLE
Set tox lint `basepython` to 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,8 @@ commands =
     - sphinx-build -b html -b linkcheck -aEnQW doc doc/_build/html
 
 [testenv:lint]
+# PYVERSIONS
+basepython = python3.7
 deps =
     -r requirements/lint.pip
 


### PR DESCRIPTION
3.7 is the lowest common denominator of supported versions. Linting on more recent versions introduces new error messages.

Fixes #1607 