### PR TITLE
Revert "Map also empty dictionaries to file"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,14 @@ development at the same time, such as 4.5.x and 5.0.
 Unreleased
 ----------
 
-Nothing yet.
+- Fix: reverted a `change from 6.4.3 <pull 1347_>`_ that helped Cython, but
+  also increased the size of data files when using dynamic contexts, as
+  described in the now-fixed `issue 1586`_. The problem is now avoided due to a
+  recent change (`issue 1538`_).  Thanks to `Anders Kaseorg <pull 1629_>`_
+  and David Szotten for persisting with problem reports and detailed diagnoses.
+
+.. _issue 1586: https://github.com/nedbat/coveragepy/issues/1586
+.. _pull 1629: https://github.com/nedbat/coveragepy/pull/1629
 
 
 .. scriv-start-here

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -16,6 +16,7 @@ Alexander Todorov
 Alexander Walters
 Alpha Chen
 Ammar Askar
+Anders Kaseorg
 Andrew Hoos
 Anthony Sottile
 Arcadiy Ivanov

--- a/coverage/collector.py
+++ b/coverage/collector.py
@@ -456,7 +456,7 @@ class Collector:
             assert isinstance(runtime_err, Exception)
             raise runtime_err
 
-        return {self.cached_mapped_file(k): v for k, v in items}
+        return {self.cached_mapped_file(k): v for k, v in items if v}
 
     def plugin_was_disabled(self, plugin: CoveragePlugin) -> None:
         """Record that `plugin` was disabled during the run."""


### PR DESCRIPTION
This reverts commit f54428fb8dfe98aacecc0b66e3c1ca2071ce1834 (#1347), which was a big regression in performance and file sizes when using `dynamic_context`, and is no longer needed for #972 as of 4cc32922685c6971275f522304b3754ad1a233c1 (#1538).

Fixes #1586.

We’ve been using this revert in Zulip without problems (zulip/zulip#25634), having previously been stuck on 6.4.2 for this regression.