### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+title: "Coverage.py: The code coverage tool for Python"
+message: >-
+  If you use this software, please cite it using the metadata from this file.
+type: software
+authors:
+  - name: "Contributors to Coverage.py"
+repository-code: "https://github.com/nedbat/coveragepy"
+url: "https://coverage.readthedocs.io/"
+abstract: >-
+  Coverage.py is a tool for measuring code coverage of Python programs. It monitors your program,
+  noting which parts of the code have been executed, then analyzes the source to identify code
+  that could have been executed but was not.
+  Coverage measurement is typically used to gauge the effectiveness of tests. It can show which
+  parts of your code are being exercised by tests, and which are not.
+license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,9 @@ message: >-
   If you use this software, please cite it using the metadata from this file.
 type: software
 authors:
+  - family-names: Batchelder
+    given-names: Ned
+    orcid: https://orcid.org/0009-0006-2659-884X
   - name: "Contributors to Coverage.py"
 repository-code: "https://github.com/nedbat/coveragepy"
 url: "https://coverage.readthedocs.io/"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@
 # .tar.gz source distribution would give you everything needed to continue
 # developing the project.  "pip install" will not install many of these files.
 
+include CITATION.cff
 include CONTRIBUTORS.txt
 include CHANGES.rst
 include LICENSE.txt


### PR DESCRIPTION
This pull request adds a CITATION.cff file to the root of the repository. If merged, it resolves #1639.

Some items suggested for further consideration:

- Are there changes you would like to make to the "author" field? We could add a few notable individuals followed by "Contributors to Coverage.py"
- Would you like to include a date? Perhaps the year of first release?
- A version number can be included, but that would require continued maintenance of the file. It is fairly common to leave this off since it adds friction.

Thank you for considering this pull request, and please let me know of any changes you would like to see.

-Ken