### PR TITLE
Build wheel for PyPy 3.8-3.10

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -234,7 +234,7 @@ jobs:
         run: |
           # One wheel works for all PyPy versions. PYVERSIONS
           # yes, this is weird syntax: https://github.com/pypa/build/issues/202
-          pypy3 -m build -w -C="--global-option=--python-tag" -C="--global-option=pp38.pp39"
+          pypy3 -m build -w -C="--global-option=--python-tag" -C="--global-option=pp38.pp39.pp310"
 
       - name: "List wheels"
         run: |


### PR DESCRIPTION
I see that CI has been updated to run tests on PyPy 3.10 but the workflow that builds the wheels hasn't been updated yet.

(Thanks for maintaining coverage.py, btw 😄)