### PR TITLE
🐛 Fix trailing single asterisk matching subdirs

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -316,7 +316,7 @@ G2RX_TOKENS = [(re.compile(rx), sub) for rx, sub in [
     (r"\*\*+[^/]+", None),          # Can't have **x
     (r"\*\*/\*\*", None),           # Can't have **/**
     (r"^\*+/", r"(.*[/\\\\])?"),    # ^*/ matches any prefix-slash, or nothing.
-    (r"/\*+$", r"[/\\\\].*"),       # /*$ matches any slash-suffix.
+    (r"/\*\*+$", r"[/\\\\].*"),       # /**$ matches any slash-suffix.
     (r"\*\*/", r"(.*[/\\\\])?"),    # **/ matches any subdirs, including none
     (r"/", r"[/\\\\]"),             # / matches either slash or backslash
     (r"\*", r"[^/\\\\]*"),          # * matches any number of non slash-likes

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -348,11 +348,14 @@ class MatcherTest(CoverageTest):
             (self.make_file("sub/file1.py"), True),
             (self.make_file("sub/file2.c"), False),
             (self.make_file("sub2/file3.h"), True),
+            (self.make_file("sub2/sub/file3.h"), False),
             (self.make_file("sub3/file4.py"), True),
             (self.make_file("sub3/file5.c"), False),
+            (self.make_file("sub4/file3.h"), True),
+            (self.make_file("sub4/sub/file3.h"), True),
         ]
-        fnm = GlobMatcher(["*.py", "*/sub2/*"])
-        assert fnm.info() == ["*.py", "*/sub2/*"]
+        fnm = GlobMatcher(["*.py", "*/sub2/*", "*/sub4/**"])
+        assert fnm.info() == ["*.py", "*/sub2/*", "*/sub4/**"]
         for filepath, matches in matches_to_try:
             self.assertMatches(fnm, filepath, matches)
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -107,7 +107,7 @@ class SummaryTest(UsingModulesMixin, CoverageTest):
         self.make_mycode()
         cov = coverage.Coverage()
         self.start_import_stop(cov, "mycode")
-        report = self.get_report(cov, omit=[f"{TESTS_DIR}/*", "*/site-packages/*"])
+        report = self.get_report(cov, omit=[f"{TESTS_DIR}/**", "*/site-packages/**"])
 
         # Name        Stmts   Miss  Cover
         # -------------------------------


### PR DESCRIPTION
This patch demonstrates a corner case in the path glob matcher.
Specifically, it documents how a single trailing asterisk is supposed
to be treated as opposed to a double asterisk.
With [[1]], a trailing `/*` is interpreted as an equivalent of `/**`.
The commit adds a case that shows that `/*` shouldn't be greedy as
described in the docs [[2]][[3]].

It then goes on to prevent path patterns ending with `/*` from being
greedy and interpreted the same as `/**`. After applying it, that
trailing asterisk only matches one file or directory but not nested
ones.

See also the observations in the bug report ticket [[4]].

[1]: https://github.com/nedbat/coveragepy/commit/ec6205a8de972af6a09453235d02a7ebea6aea8e
[2]: https://coverage.rtfd.io/en/stable/source.html#file-patterns
[3]: https://coverage.rtfd.io/en/7.2.7/migrating.html#migrating-to-coverage-py-7-x
[4]: https://github.com/nedbat/coveragepy/issues/1407#issuecomment-1631085209