### PR TITLE
🎨🧪 Wire linters into the main CI workflow

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -4,12 +4,7 @@
 name: "Quality"
 
 on:
-  push:
-    branches:
-      - master
-      - nedbat/*
-  pull_request:
-  workflow_dispatch:
+  workflow_call:
 
 defaults:
   run:
@@ -20,10 +15,6 @@ env:
 
 permissions:
   contents: read
-
-concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -28,6 +28,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  linters:
+    name: Quality
+    # Don't run linters if the branch name includes "-notests"
+    if: "!contains(github.ref, '-notests')"
+    uses: ./.github/workflows/reusable-quality.yml
+
   tests:
     name: "${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}-latest"
@@ -94,6 +100,7 @@ jobs:
     # The tests didn't run if the branch name includes "-notests"
     if: "!contains(github.ref, '-notests')"
     needs:
+      - linters
       - tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This patch makes the quality workflow definition into reusable. It doesn't need to track the same triggers and conditions as the main one. Additionally, the `alls-green` check can now take into account the outcome of linting making it possible to only have one job in the branch protection.