### PR TITLE
Add some typing changes required by Mypyc

### DIFF
--- a/coverage/config.py
+++ b/coverage/config.py
@@ -13,7 +13,7 @@ import os.path
 import re
 
 from typing import (
-    Any, Callable, Dict, Iterable, List, Optional, Tuple, Union,
+    Any, Callable, Dict, Final, Iterable, List, Optional, Set, Tuple, Union,
 )
 
 from coverage.exceptions import ConfigError
@@ -358,7 +358,7 @@ class CoverageConfig(TConfigurable, TPluginConfig):
         """Return a copy of the configuration."""
         return copy.deepcopy(self)
 
-    CONCURRENCY_CHOICES = {"thread", "gevent", "greenlet", "eventlet", "multiprocessing"}
+    CONCURRENCY_CHOICES: Final[Set[str]] = {"thread", "gevent", "greenlet", "eventlet", "multiprocessing"}
 
     CONFIG_FILE_OPTIONS = [
         # These are *args for _set_attr_from_config_option:

--- a/coverage/debug.py
+++ b/coverage/debug.py
@@ -21,7 +21,7 @@ import _thread
 
 from typing import (
     cast,
-    Any, Callable, IO, Iterable, Iterator, Mapping, Optional, List, Tuple,
+    Any, Callable, Final, IO, Iterable, Iterator, Mapping, Optional, List, Tuple,
 )
 
 from coverage.misc import human_sorted_items, isolate_module
@@ -376,8 +376,8 @@ class DebugOutputFile:
     # a process-wide singleton. So stash it in sys.modules instead of
     # on a class attribute. Yes, this is aggressively gross.
 
-    SYS_MOD_NAME = "$coverage.debug.DebugOutputFile.the_one"
-    SINGLETON_ATTR = "the_one_and_is_interim"
+    SYS_MOD_NAME: Final[str] = "$coverage.debug.DebugOutputFile.the_one"
+    SINGLETON_ATTR: Final[str] = "the_one_and_is_interim"
 
     @classmethod
     def _set_singleton_data(cls, the_one: DebugOutputFile, interim: bool) -> None:

--- a/coverage/env.py
+++ b/coverage/env.py
@@ -9,7 +9,7 @@ import os
 import platform
 import sys
 
-from typing import Any, Iterable, Tuple
+from typing import Any, Final, Iterable, Tuple
 
 # debug_info() at the bottom wants to show all the globals, but not imports.
 # Grab the global names here to know which names to not show. Nothing defined
@@ -40,78 +40,76 @@ class PYBEHAVIOR:
 
     # Does Python conform to PEP626, Precise line numbers for debugging and other tools.
     # https://www.python.org/dev/peps/pep-0626
-    pep626 = (PYVERSION > (3, 10, 0, "alpha", 4))
+    pep626: Final[bool] = (PYVERSION > (3, 10, 0, "alpha", 4))
 
     # Is "if __debug__" optimized away?
-    optimize_if_debug = not pep626
+    optimize_if_debug: Final[bool] = not pep626
 
     # Is "if not __debug__" optimized away? The exact details have changed
     # across versions.
-    if pep626:
-        optimize_if_not_debug = 1
-    elif PYPY:
-        if PYVERSION >= (3, 9):
-            optimize_if_not_debug = 2
-        else:
-            optimize_if_not_debug = 3
-    else:
-        optimize_if_not_debug = 2
+    optimize_if_not_debug: Final[int] = (
+        1 if pep626
+        else
+        3 if PYPY and PYVERSION < (3, 8)
+        else
+        2
+    )
 
     # 3.7 changed how functions with only docstrings are numbered.
-    docstring_only_function = (not PYPY) and ((3, 7, 0, "beta", 5) <= PYVERSION <= (3, 10))
+    docstring_only_function: Final[bool] = (not PYPY) and ((3, 7, 0, "beta", 5) <= PYVERSION <= (3, 10))
 
     # When a break/continue/return statement in a try block jumps to a finally
     # block, does the finally block do the break/continue/return (pre-3.8), or
     # does the finally jump back to the break/continue/return (3.8) to do the
     # work?
-    finally_jumps_back = ((3, 8) <= PYVERSION < (3, 10))
+    finally_jumps_back: Final[bool] = ((3, 8) <= PYVERSION < (3, 10))
 
     # CPython 3.11 now jumps to the decorator line again while executing
     # the decorator.
-    trace_decorator_line_again = (CPYTHON and PYVERSION > (3, 11, 0, "alpha", 3, 0))
+    trace_decorator_line_again: Final[bool] = (CPYTHON and PYVERSION > (3, 11, 0, "alpha", 3, 0))
 
     # CPython 3.9a1 made sys.argv[0] and other reported files absolute paths.
-    report_absolute_files = (
+    report_absolute_files: Final[bool] = (
         (CPYTHON or (PYPY and PYPYVERSION >= (7, 3, 10)))
         and PYVERSION >= (3, 9)
     )
 
     # Lines after break/continue/return/raise are no longer compiled into the
     # bytecode.  They used to be marked as missing, now they aren't executable.
-    omit_after_jump = (
+    omit_after_jump: Final[bool] = (
         pep626
         or (PYPY and PYVERSION >= (3, 9) and PYPYVERSION >= (7, 3, 12))
     )
 
     # PyPy has always omitted statements after return.
-    omit_after_return = omit_after_jump or PYPY
+    omit_after_return: Final[bool] = omit_after_jump or PYPY
 
     # Optimize away unreachable try-else clauses.
-    optimize_unreachable_try_else = pep626
+    optimize_unreachable_try_else: Final[bool] = pep626
 
     # Modules used to have firstlineno equal to the line number of the first
     # real line of code.  Now they always start at 1.
-    module_firstline_1 = pep626
+    module_firstline_1: Final[bool] = pep626
 
     # Are "if 0:" lines (and similar) kept in the compiled code?
-    keep_constant_test = pep626
+    keep_constant_test: Final[bool] = pep626
 
     # When leaving a with-block, do we visit the with-line again for the exit?
-    exit_through_with = (PYVERSION >= (3, 10, 0, "beta"))
+    exit_through_with: Final[bool] = (PYVERSION >= (3, 10, 0, "beta"))
 
     # Match-case construct.
-    match_case = (PYVERSION >= (3, 10))
+    match_case: Final[bool] = (PYVERSION >= (3, 10))
 
     # Some words are keywords in some places, identifiers in other places.
-    soft_keywords = (PYVERSION >= (3, 10))
+    soft_keywords: Final[bool] = (PYVERSION >= (3, 10))
 
     # Modules start with a line numbered zero. This means empty modules have
     # only a 0-number line, which is ignored, giving a truly empty module.
-    empty_is_empty = (PYVERSION >= (3, 11, 0, "beta", 4))
+    empty_is_empty: Final[bool] = (PYVERSION >= (3, 11, 0, "beta", 4))
 
     # Are comprehensions inlined (new) or compiled as called functions (old)?
     # Changed in https://github.com/python/cpython/pull/101441
-    comprehensions_are_functions = (PYVERSION <= (3, 12, 0, "alpha", 7, 0))
+    comprehensions_are_functions: Final[bool] = (PYVERSION <= (3, 12, 0, "alpha", 7, 0))
 
 # Coverage.py specifics.
 

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -131,7 +131,7 @@ class PythonParser:
         excluding = False
         excluding_decorators = False
         prev_toktype = token.INDENT
-        first_line = None
+        first_line: Optional[TLineNo] = None
         empty = True
         first_on_line = True
         nesting = 0
@@ -182,11 +182,11 @@ class PythonParser:
                 # http://stackoverflow.com/questions/1769332/x/1769794#1769794
                 self.raw_docstrings.update(range(slineno, elineno+1))
             elif toktype == token.NEWLINE:
-                if first_line is not None and elineno != first_line:    # type: ignore[unreachable]
+                if first_line is not None and elineno != first_line:
                     # We're at the end of a line, and we've ended on a
                     # different line than the first line of the statement,
                     # so record a multi-line range.
-                    for l in range(first_line, elineno+1):              # type: ignore[unreachable]
+                    for l in range(first_line, elineno+1):
                         self._multiline[l] = first_line
                 first_line = None
                 first_on_line = True
@@ -416,7 +416,7 @@ class ByteParser:
             byte_increments = self.code.co_lnotab[0::2]
             line_increments = self.code.co_lnotab[1::2]
 
-            last_line_num = None
+            last_line_num: Optional[TLineNo] = None
             line_num = self.code.co_firstlineno
             byte_num = 0
             for byte_incr, line_incr in zip(byte_increments, line_increments):

--- a/coverage/results.py
+++ b/coverage/results.py
@@ -308,7 +308,7 @@ def _line_ranges(
     lines = sorted(lines)
 
     pairs = []
-    start = None
+    start: Optional[TLineNo] = None
     lidx = 0
     for stmt in statements:
         if lidx >= len(lines):


### PR DESCRIPTION
I tried compiling Coverage with Mypyc, the compiler that comes with Mypy. Mypyc is pretty stringent about what it expects, and addressing some of its objections will require some design thought. But these changes are pretty straightforward.