### PR TITLE
Add some typing changes required by Mypyc

### DIFF
--- a/coverage/config.py
+++ b/coverage/config.py
@@ -13,7 +13,7 @@ import os.path
 import re
 
 from typing import (
-    Any, Callable, Union,
+    Any, Callable, Final, Union,
 )
 from collections.abc import Iterable
 
@@ -360,7 +360,8 @@ class CoverageConfig(TConfigurable, TPluginConfig):
         """Return a copy of the configuration."""
         return copy.deepcopy(self)
 
-    CONCURRENCY_CHOICES = {"thread", "gevent", "greenlet", "eventlet", "multiprocessing"}
+    CONCURRENCY_CHOICES: Final[set[str]] = {
+        "thread", "gevent", "greenlet", "eventlet", "multiprocessing"}
 
     CONFIG_FILE_OPTIONS = [
         # These are *args for _set_attr_from_config_option:

--- a/coverage/debug.py
+++ b/coverage/debug.py
@@ -21,7 +21,7 @@ import _thread
 
 from typing import (
     overload,
-    Any, Callable, IO,
+    Any, Callable, Final, IO,
 )
 from collections.abc import Iterable, Iterator, Mapping
 
@@ -467,8 +467,8 @@ class DebugOutputFile:
     # a process-wide singleton. So stash it in sys.modules instead of
     # on a class attribute. Yes, this is aggressively gross.
 
-    SYS_MOD_NAME = "$coverage.debug.DebugOutputFile.the_one"
-    SINGLETON_ATTR = "the_one_and_is_interim"
+    SYS_MOD_NAME: Final[str] = "$coverage.debug.DebugOutputFile.the_one"
+    SINGLETON_ATTR: Final[str] = "the_one_and_is_interim"
 
     @classmethod
     def _set_singleton_data(cls, the_one: DebugOutputFile, interim: bool) -> None:

--- a/coverage/env.py
+++ b/coverage/env.py
@@ -53,10 +53,7 @@ class PYBEHAVIOR:
 
     # Is "if not __debug__" optimized away? The exact details have changed
     # across versions.
-    if pep626:
-        optimize_if_not_debug = 1
-    else:
-        optimize_if_not_debug = 2
+    optimize_if_not_debug = 1 if pep626 else 2
 
     # 3.7 changed how functions with only docstrings are numbered.
     docstring_only_function = (not PYPY) and (PYVERSION <= (3, 10))

--- a/coverage/env.py
+++ b/coverage/env.py
@@ -9,7 +9,7 @@ import os
 import platform
 import sys
 
-from typing import Any
+from typing import Any, Final
 from collections.abc import Iterable
 
 # debug_info() at the bottom wants to show all the globals, but not imports.
@@ -148,7 +148,7 @@ class PYBEHAVIOR:
     soft_keywords = (PYVERSION >= (3, 10))
 
     # PEP669 Low Impact Monitoring: https://peps.python.org/pep-0669/
-    pep669 = bool(getattr(sys, "monitoring", None))
+    pep669: Final[bool] = bool(getattr(sys, "monitoring", None))
 
     # Where does frame.f_lasti point when yielding from a generator?
     # It used to point at the YIELD, in 3.13 it points at the RESUME,

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -466,7 +466,7 @@ class ByteParser:
             byte_increments = self.code.co_lnotab[0::2]
             line_increments = self.code.co_lnotab[1::2]
 
-            last_line_num = None
+            last_line_num: TLineNo | None = None
             line_num = self.code.co_firstlineno
             byte_num = 0
             for byte_incr, line_incr in zip(byte_increments, line_increments):

--- a/coverage/results.py
+++ b/coverage/results.py
@@ -343,7 +343,7 @@ def _line_ranges(
     lines = sorted(lines)
 
     pairs = []
-    start = None
+    start: TLineNo | None = None
     lidx = 0
     for stmt in statements:
         if lidx >= len(lines):


### PR DESCRIPTION
I tried compiling Coverage with Mypyc, the compiler that comes with Mypy. Mypyc is pretty stringent about what it expects, and addressing some of its objections will require some design thought. But these changes are pretty straightforward.
