### PR TITLE
Add missing MacOS ARM64 wheel for Python 3.12 to build matrix

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -117,6 +117,7 @@ jobs:
           - {"os": "macos", "py": "cp39", "arch": "arm64"}
           - {"os": "macos", "py": "cp310", "arch": "arm64"}
           - {"os": "macos", "py": "cp311", "arch": "arm64"}
+          - {"os": "macos", "py": "cp312", "arch": "arm64"}
           - {"os": "macos", "py": "cp38", "arch": "x86_64"}
           - {"os": "macos", "py": "cp39", "arch": "x86_64"}
           - {"os": "macos", "py": "cp310", "arch": "x86_64"}


### PR DESCRIPTION
Tested locally with

```shell
export CIBW_BUILD=cp312-*
export CIBW_ARCHS=arm64
export CIBW_ENVIRONMENT=PIP_DISABLE_PIP_VERSION_CHECK=1
export CIBW_PRERELEASE_PYTHONS=True
python -m cibuildwheel --output-dir wheelhouse --platform macos
```
