### PR TITLE
Fix handling of multi-line function declarations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,11 +20,18 @@ development at the same time, such as 4.5.x and 5.0.
 Unreleased
 ----------
 
+- Fix: function definitions with multi-line signatures can now be excluded by
+  matching any of the lines, closing `issue 684`_.  Thanks, `Jan Rusak and
+  others <pull 1705_>`_.
+
 - Added new :ref:`debug options <cmd_run_debug>`:
 
   - ``pytest`` writes the pytest test name into the debug output.
 
   - ``dataop2`` writes the full data being added to CoverageData objects.
+
+.. _issue 684: https://github.com/nedbat/coveragepy/issues/684
+.. _pull 1705: https://github.com/nedbat/coveragepy/pull/1705
 
 
 .. scriv-start-here

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -101,6 +101,7 @@ J. M. F. Tsang
 JT Olds
 Jacqueline Lee
 Jakub Wilk
+Jan Rusak
 Janakarajan Natarajan
 Jerin Peter George
 Jessamyn Smith

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -191,11 +191,11 @@ class PythonParser:
                     for l in range(first_line, elineno+1):              # type: ignore[unreachable]
                         self._multiline[l] = first_line
                     # Check if multi-line was before a suite (trigger by the colon token).
-                    statement_multilines = set(range(first_line, elineno + 1))
-                    if (statement_multilines & set(self.raw_excluded) and prev_toktype == token.OP
-                        and prev_ttext == ":" and nesting == 0):
-                        exclude_indent = indent
-                        excluding = True
+                    if nesting == 0 and prev_toktype == token.OP and prev_ttext == ":":
+                        statement_multilines = set(range(first_line, elineno + 1))
+                        if statement_multilines & set(self.raw_excluded):
+                            exclude_indent = indent
+                            excluding = True
                 first_line = None
                 first_on_line = True
 

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -136,6 +136,7 @@ class PythonParser:
         empty = True
         first_on_line = True
         nesting = 0
+        prev_ttext = None
 
         assert self.text is not None
         tokgen = generate_tokens(self.text)
@@ -189,6 +190,12 @@ class PythonParser:
                     # so record a multi-line range.
                     for l in range(first_line, elineno+1):              # type: ignore[unreachable]
                         self._multiline[l] = first_line
+                    # Check if multi-line was before a suite (trigger by the colon token).
+                    statement_multilines = set(range(first_line, elineno + 1))
+                    if (statement_multilines & set(self.raw_excluded) and prev_toktype == token.OP
+                        and prev_ttext == ":" and nesting == 0):
+                        exclude_indent = indent
+                        excluding = True
                 first_line = None
                 first_on_line = True
 
@@ -206,6 +213,7 @@ class PythonParser:
                     first_on_line = False
 
             prev_toktype = toktype
+            prev_ttext = ttext
 
         # Find the starts of the executable statements.
         if not empty:

--- a/tests/coveragetest.py
+++ b/tests/coveragetest.py
@@ -193,7 +193,7 @@ class CoverageTest(
         # Get the analysis results, and check that they are right.
         analysis = cov._analyze(mod)
         statements = sorted(analysis.statements)
-        if lines is not None:
+        if lines is not None and len(lines) != 0:
             if isinstance(lines[0], int):
                 # lines is just a list of numbers, it must match the statements
                 # found in the code.

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1405,6 +1405,14 @@ class ExcludeTest(CoverageTest):
             assert a == 1
             """,
             [1,7], "", excludes=['#pragma: NO COVER'])
+        self.check_coverage("""\
+            a = 0
+            def very_long_function_to_exclude_name(very_long_argument1,
+            very_long_argument2):
+                pass
+            assert a == 0
+            """,
+            [1,5], "", excludes=['function_to_exclude'])
 
     def test_excluding_for_else(self) -> None:
         self.check_coverage("""\

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1590,6 +1590,56 @@ class ExcludeTest(CoverageTest):
             """,
             [1,5], "5", excludes=['my_func_2'])
 
+        self.check_coverage("""\
+            def my_func       (
+                super_long_input_argument_0=0,
+                super_long_input_argument_1=1,
+                super_long_input_argument_2=2):
+                pass
+
+            def my_func_2    (super_long_input_argument_0=0, super_long_input_argument_1=1, super_long_input_argument_2=2):
+                pass
+            """,
+            [1,5], "5", excludes=['my_func_2'])
+
+        self.check_coverage("""\
+            def my_func       (
+                super_long_input_argument_0=0,
+                super_long_input_argument_1=1,
+                super_long_input_argument_2=2):
+                pass
+
+            def my_func_2    (super_long_input_argument_0=0, super_long_input_argument_1=1, super_long_input_argument_2=2):
+                pass
+            """,
+            [], "5", excludes=['my_func'])
+
+        self.check_coverage("""\
+            def my_func \
+                (
+                super_long_input_argument_0=0,
+                super_long_input_argument_1=1
+                ):
+                pass
+
+            def my_func_2(super_long_input_argument_0=0, super_long_input_argument_1=1, super_long_input_argument_2=2):
+                pass
+            """,
+            [1,5], "5", excludes=['my_func_2'])
+
+        self.check_coverage("""\
+            def my_func \
+                (
+                super_long_input_argument_0=0,
+                super_long_input_argument_1=1
+                ):
+                pass
+
+            def my_func_2(super_long_input_argument_0=0, super_long_input_argument_1=1, super_long_input_argument_2=2):
+                pass
+            """,
+            [], "5", excludes=['my_func'])
+
     def test_excluding_method(self) -> None:
         self.check_coverage("""\
             class Fooey:

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1405,14 +1405,6 @@ class ExcludeTest(CoverageTest):
             assert a == 1
             """,
             [1,7], "", excludes=['#pragma: NO COVER'])
-        self.check_coverage("""\
-            a = 0
-            def very_long_function_to_exclude_name(very_long_argument1,
-            very_long_argument2):
-                pass
-            assert a == 0
-            """,
-            [1,5], "", excludes=['function_to_exclude'])
 
     def test_excluding_for_else(self) -> None:
         self.check_coverage("""\
@@ -1554,6 +1546,50 @@ class ExcludeTest(CoverageTest):
             """,
             [6,7], "", excludes=['#pragma: NO COVER'])
 
+        self.check_coverage("""\
+            a = 0
+            def very_long_function_to_exclude_name(very_long_argument1,
+            very_long_argument2):
+                pass
+            assert a == 0
+            """,
+            [1,5], "", excludes=['function_to_exclude'])
+
+        self.check_coverage("""\
+            a = 0
+            def very_long_function_to_exclude_name(
+                very_long_argument1,
+                very_long_argument2
+            ):
+                pass
+            assert a == 0
+            """,
+            [1,7], "", excludes=['function_to_exclude'])
+
+        self.check_coverage("""\
+            def my_func(
+                super_long_input_argument_0=0,
+                super_long_input_argument_1=1,
+                super_long_input_argument_2=2):
+                pass
+
+            def my_func_2(super_long_input_argument_0=0, super_long_input_argument_1=1, super_long_input_argument_2=2):
+                pass
+            """,
+            [], "", excludes=['my_func'])
+
+        self.check_coverage("""\
+            def my_func(
+                super_long_input_argument_0=0,
+                super_long_input_argument_1=1,
+                super_long_input_argument_2=2):
+                pass
+
+            def my_func_2(super_long_input_argument_0=0, super_long_input_argument_1=1, super_long_input_argument_2=2):
+                pass
+            """,
+            [1,5], "5", excludes=['my_func_2'])
+
     def test_excluding_method(self) -> None:
         self.check_coverage("""\
             class Fooey:
@@ -1567,6 +1603,22 @@ class ExcludeTest(CoverageTest):
             assert x.a == 1
             """,
             [1,2,3,8,9], "", excludes=['#pragma: NO COVER'])
+
+        self.check_coverage("""\
+            class Fooey:
+                def __init__(self):
+                    self.a = 1
+
+                def very_long_method_to_exclude_name(
+                    very_long_argument1,
+                    very_long_argument2
+                ):
+                    pass
+
+            x = Fooey()
+            assert x.a == 1
+            """,
+            [1,2,3,11,12], "", excludes=['method_to_exclude'])
 
     def test_excluding_class(self) -> None:
         self.check_coverage("""\


### PR DESCRIPTION
Resolves #684
  
The cause of this problem is the method of checking whether a particular clause should be excluded. In a file `parser.py` in function `_raw_parse` (line 161) only the line that ends with `:` is checked for excluded expressions, not all the lines in a statement that ends with a colon. The solution is to add checking if at least one line in the multi-line statement ended with `:` has to be excluded and if that is the case - to exclude that clause. Multi-line statements are added after a token `\n`, so after checking for excluded clauses in one-line statements. Because of that, checking if a clause after multi-line statement should be excluded was added starting from the line 193.
Tests with different use cases were added.