### PR TITLE
Make so line number not copied

### DIFF
--- a/coverage/htmlfiles/style.css
+++ b/coverage/htmlfiles/style.css
@@ -148,7 +148,7 @@ kbd { border: 1px solid black; border-color: #888 #333 #333 #888; padding: .1em 
 
 #source p * { box-sizing: border-box; }
 
-#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; }
+#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; user-select: none; }
 
 @media (prefers-color-scheme: dark) { #source p .n { color: #777; } }
 

--- a/coverage/htmlfiles/style.scss
+++ b/coverage/htmlfiles/style.scss
@@ -418,6 +418,7 @@ $border-indicator-width: .2em;
             margin-left: -$left-gutter;
             padding-right: 1em;
             color: $light-gray4;
+            user-select: none;
             @include color-dark($dark-gray4);
 
             &.highlight {

--- a/doc/sample_html/style.css
+++ b/doc/sample_html/style.css
@@ -148,7 +148,7 @@ kbd { border: 1px solid black; border-color: #888 #333 #333 #888; padding: .1em 
 
 #source p * { box-sizing: border-box; }
 
-#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; }
+#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; user-select: none; }
 
 @media (prefers-color-scheme: dark) { #source p .n { color: #777; } }
 

--- a/tests/gold/html/styled/style.css
+++ b/tests/gold/html/styled/style.css
@@ -148,7 +148,7 @@ kbd { border: 1px solid black; border-color: #888 #333 #333 #888; padding: .1em 
 
 #source p * { box-sizing: border-box; }
 
-#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; }
+#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; user-select: none; }
 
 @media (prefers-color-scheme: dark) { #source p .n { color: #777; } }
 

--- a/tests/gold/html/support/style.css
+++ b/tests/gold/html/support/style.css
@@ -148,7 +148,7 @@ kbd { border: 1px solid black; border-color: #888 #333 #333 #888; padding: .1em 
 
 #source p * { box-sizing: border-box; }
 
-#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; }
+#source p .n { float: left; text-align: right; width: 3.5rem; box-sizing: border-box; margin-left: -3.5rem; padding-right: 1em; color: #999; user-select: none; }
 
 @media (prefers-color-scheme: dark) { #source p .n { color: #777; } }
 


### PR DESCRIPTION
Within the htmlcov output, there are line numbers for the code. This update makes so when you highlight the code the line numbers are not included.

![image](https://github.com/nedbat/coveragepy/assets/30379153/72a935c2-4ef6-4a0d-a7e6-7871f25e6afd)

becomes

![image](https://github.com/nedbat/coveragepy/assets/30379153/bce8651d-2b5b-4276-bdf6-613b86f77864)