### PR TITLE
Remove redundant code for EOL Python 3.7

### DIFF
--- a/coverage/env.py
+++ b/coverage/env.py
@@ -60,13 +60,12 @@ class PYBEHAVIOR:
         optimize_if_not_debug = 2
 
     # 3.7 changed how functions with only docstrings are numbered.
-    docstring_only_function = (not PYPY) and ((3, 7, 0, "beta", 5) <= PYVERSION <= (3, 10))
+    docstring_only_function = (not PYPY) and (PYVERSION <= (3, 10))
 
     # When a break/continue/return statement in a try block jumps to a finally
-    # block, does the finally block do the break/continue/return (pre-3.8), or
-    # does the finally jump back to the break/continue/return (3.8) to do the
-    # work?
-    finally_jumps_back = ((3, 8) <= PYVERSION < (3, 10))
+    # block, does the finally jump back to the break/continue/return (pre-3.10)
+    # to do the work?
+    finally_jumps_back = (PYVERSION < (3, 10))
 
     # CPython 3.11 now jumps to the decorator line again while executing
     # the decorator.

--- a/lab/show_pyc.py
+++ b/lab/show_pyc.py
@@ -23,17 +23,15 @@ def show_pyc_file(fname):
     magic = f.read(4)
     print("magic %s" % (binascii.hexlify(magic)))
     read_date_and_size = True
-    if sys.version_info >= (3, 7):
-        # 3.7 added a flags word
-        flags = struct.unpack('<L', f.read(4))[0]
-        hash_based = bool(flags & 0x01)
-        check_source = bool(flags & 0x02)
-        print(f"flags {flags:#08x}")
-        if hash_based:
-            source_hash = f.read(8)
-            read_date_and_size = False
-            print(f"hash {binascii.hexlify(source_hash)}")
-            print(f"check_source {check_source}")
+    flags = struct.unpack('<L', f.read(4))[0]
+    hash_based = bool(flags & 0x01)
+    check_source = bool(flags & 0x02)
+    print(f"flags {flags:#08x}")
+    if hash_based:
+        source_hash = f.read(8)
+        read_date_and_size = False
+        print(f"hash {binascii.hexlify(source_hash)}")
+        print(f"check_source {check_source}")
     if read_date_and_size:
         moddate = f.read(4)
         modtime = time.asctime(time.localtime(struct.unpack('<L', moddate)[0]))
@@ -147,7 +145,7 @@ def lnotab_interpreted(code):
                 yield (byte_num, line_num)
                 last_line_num = line_num
             byte_num += byte_incr
-        if sys.version_info >= (3, 6) and line_incr >= 0x80:
+        if line_incr >= 0x80:
             line_incr -= 0x100
         line_num += line_incr
     if line_num != last_line_num:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -986,8 +986,8 @@ class AliasedCommandTest(CoverageTest):
 
     def test_wrong_alias_doesnt_work(self) -> None:
         # "coverage2" doesn't work on py3
-        assert sys.version_info[0] in [2, 3]    # Let us know when Python 4 is out...
-        badcmd = "coverage%d" % (5 - sys.version_info[0])
+        assert sys.version_info[0] == 3    # Let us know when Python 4 is out...
+        badcmd = "coverage2"
         out = self.run_command(badcmd)
         assert "Code coverage for Python" not in out
 


### PR DESCRIPTION
Python 3.7 support was dropped in August 2023 in https://github.com/nedbat/coveragepy/releases/tag/7.3.0 so we can remove some old compatibility checks.