### PR TITLE
CI: Only run dependency review for upstream

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: github.repository_owner == 'nedbat'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'


### PR DESCRIPTION
This workflow fails when running on forks, which by default have it disabled.

> Run actions/dependency-review-action@v3
Error: Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled along with GitHub Advanced Security on private repositories, see https://github.com/hugovk/coveragepy/settings/security_analysis

https://github.com/hugovk/coveragepy/actions/runs/7418996024