### PR TITLE
CI: Set PYTHON_COLORS=0 to disable coloured CPython tracebacks

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -19,6 +19,7 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   COVERAGE_IGOR_VERBOSE: 1
   FORCE_COLOR: 1    # Get colored pytest output
+  PYTHON_COLORS: 0  # But not colored CPython output
 
 permissions:
   contents: read

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -19,7 +19,6 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   COVERAGE_IGOR_VERBOSE: 1
   FORCE_COLOR: 1    # Get colored pytest output
-  PYTHON_COLORS: 0  # But not colored CPython output
 
 permissions:
   contents: read

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -397,8 +397,3 @@ class DebugControlString(DebugControl):
     def get_output(self) -> str:
         """Get the output text from the `DebugControl`."""
         return self.io.getvalue()
-
-
-def without_color(text: str) -> str:
-    """Remove ANSI color-setting escape sequences."""
-    return re.sub(r"\033\[[\d;]+m", "", text)

--- a/tests/test_execfile.py
+++ b/tests/test_execfile.py
@@ -23,7 +23,6 @@ from coverage.execfile import run_python_file, run_python_module
 from coverage.files import python_reported_file
 
 from tests.coveragetest import CoverageTest, TESTS_DIR, UsingModulesMixin
-from tests.helpers import without_color
 
 TRY_EXECFILE = os.path.join(TESTS_DIR, "modules/process_test/try_execfile.py")
 
@@ -189,7 +188,7 @@ class RunFileTest(CoverageTest):
             run_python_file(["excepthook_throw.py"])
         # The _ExceptionDuringRun exception has the RuntimeError as its argument.
         assert exc_info.value.args[1].args[0] == "Error Outside"
-        stderr = without_color(self.stderr())
+        stderr = self.stderr()
         assert "in excepthook\n" in stderr
         assert "Error in sys.excepthook:\n" in stderr
         assert "RuntimeError: Error Inside" in stderr

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -27,7 +27,7 @@ from coverage.files import abs_file, python_reported_file
 
 from tests import testenv
 from tests.coveragetest import CoverageTest, TESTS_DIR
-from tests.helpers import re_line, re_lines, re_lines_text, without_color
+from tests.helpers import re_line, re_lines, re_lines_text
 
 
 class ProcessTest(CoverageTest):
@@ -318,7 +318,6 @@ class ProcessTest(CoverageTest):
         assert out == out2
 
         # But also make sure that the output is what we expect.
-        out = without_color(out)
         path = python_reported_file('throw.py')
         msg = f'File "{re.escape(path)}", line 8, in f2'
         assert re.search(msg, out)
@@ -970,11 +969,8 @@ class ExcepthookTest(CoverageTest):
         py_st, py_out = self.run_command_status("python excepthook_throw.py")
         assert cov_st == py_st
         assert cov_st == 1
-        assert "in excepthook" in without_color(py_out)
-        # Don't know why: the Python output shows "Error in sys.excepthook" and
-        # "Original exception" in color.  The coverage output has the first in
-        # color and "Original" without color? Strip all the color.
-        assert without_color(cov_out) == without_color(py_out)
+        assert "in excepthook" in py_out
+        assert cov_out == py_out
 
 
 class AliasedCommandTest(CoverageTest):
@@ -1181,7 +1177,6 @@ class YankedDirectoryTest(CoverageTest):
     def test_removing_directory_with_error(self) -> None:
         self.make_file("bug806.py", self.BUG_806)
         out = self.run_command("coverage run bug806.py")
-        out = without_color(out)
         path = python_reported_file('bug806.py')
         # Python 3.11 adds an extra line to the traceback.
         # Check that the lines we expect are there.

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -24,7 +24,7 @@ from tests.coveragetest import CoverageTest
 from tests.helpers import (
     CheckUniqueFilenames, FailingProxy,
     arcs_to_arcz_repr, arcz_to_arcs, assert_count_equal, assert_coverage_warnings,
-    re_lines, re_lines_text, re_line, without_color,
+    re_lines, re_lines_text, re_line,
 )
 
 
@@ -472,15 +472,3 @@ def test_failing_proxy() -> None:
         proxy.add(3, 4)
     # then add starts working
     assert proxy.add(5, 6) == 11
-
-
-@pytest.mark.parametrize("text, result", [
-    ("", ""),
-    ("Nothing to see here", "Nothing to see here"),
-    ("Oh no! \x1b[1;35mRuntimeError\x1b[0m. Fix it.", "Oh no! RuntimeError. Fix it."),
-    ("Fancy: \x1b[48;5;95mBkgd\x1b[38;2;100;200;25mRGB\x1b[0m", "Fancy: BkgdRGB"),
-    # Other escape sequences are unaffected.
-    ("X\x1b[2J\x1b[1mBold\x1b[22m\x1b[=3hZ", "X\x1b[2JBold\x1b[=3hZ"),
-])
-def test_without_color(text: str, result: str) -> None:
-    assert without_color(text) == result

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ setenv =
     PYTHONPYCACHEPREFIX=
     # If we ever need a stronger way to suppress warnings:
     #PYTHONWARNINGS=ignore:removed in Python 3.14; use ast.Constant:DeprecationWarning
+    # Disable CPython's color output
+    PYTHON_COLORS=0
 
 # $set_env.py: COVERAGE_PIP_ARGS - Extra arguments for `pip install`
 # `--no-build-isolation` will let tox work with no network.


### PR DESCRIPTION
Possible alternative to https://github.com/nedbat/coveragepy/commit/75b22f0e24559446ff551acb6ddbaa92bce8add3.

Instead of stripping colour escape sequences from the Python 3.13 tracebacks, set `PYTHON_COLORS=0` to disable only the CPython colour output on the CI.

https://docs.python.org/3.13/using/cmdline.html#envvar-PYTHON_COLORS
