### PR TITLE
Only use "sysmon" core when available (Python 3.12+)

### DIFF
--- a/coverage/collector.py
+++ b/coverage/collector.py
@@ -150,6 +150,10 @@ class Collector:
             core = "pytrace"
         else:
             core = os.getenv("COVERAGE_CORE")
+
+            if core == "sysmon" and not env.PYBEHAVIOR.pep669:
+                core = None
+
             if not core:
                 # Once we're comfortable with sysmon as a default:
                 # if env.PYBEHAVIOR.pep669 and self.should_start_context is None:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1122,7 +1122,6 @@ class CoverageCoreTest(CoverageTest):
         core = re_line(r" core:", out).strip()
         assert core == "core: PyTracer"
 
-    @pytest.mark.skipif(not env.PYBEHAVIOR.pep669, reason="No sys.monitoring to request")
     def test_core_request_sysmon(self) -> None:
         self.del_environ("COVERAGE_TEST_CORES")
         self.set_environ("COVERAGE_CORE", "sysmon")
@@ -1130,7 +1129,10 @@ class CoverageCoreTest(CoverageTest):
         out = self.run_command("coverage run --debug=sys numbers.py")
         assert out.endswith("123 456\n")
         core = re_line(r" core:", out).strip()
-        assert core == "core: SysMonitor"
+        if env.PYBEHAVIOR.pep669:
+            assert core == "core: SysMonitor"
+        else:
+            assert core in ("core: CTracer", "core: PyTracer")
 
 
 class FailUnderNoFilesTest(CoverageTest):


### PR DESCRIPTION
If `COVERAGE_CORE=sysmon`, but we don't have [PEP 669](https://peps.python.org/pep-0669/)'s `sys.monitoring` available (i.e. Python 3.11 or older), then don't use sysmon, but use the other defaults as if it hadn't been set.

This allows easily setting a global environment variable on a CI to benefit from the performance improvement where available, and 3.11 and older won't error like this:

```pytb
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pytest/__main__.py", line 5, in <module>
    raise SystemExit(pytest.console_main())
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 197, in console_main
    code = main()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 155, in main
    config = _prepareconfig(args, plugins)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 337, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/helpconfig.py", line 104, in pytest_cmdline_parse
    config = yield
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1094, in pytest_cmdline_parse
    self.parse(args)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1446, in parse
    self._preparse(args, addopts=addopts)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1346, in _preparse
    self.hook.pytest_load_initial_conftests(
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/warnings.py", line 148, in pytest_load_initial_conftests
    return (yield)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/_pytest/capture.py", line 151, in pytest_load_initial_conftests
    yield
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pytest_cov/plugin.py", line 152, in pytest_load_initial_conftests
    plugin = CovPlugin(options, early_config.pluginmanager)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pytest_cov/plugin.py", line 203, in __init__
    self.start(engine.Central)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pytest_cov/plugin.py", line 225, in start
    self.cov_controller.start()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pytest_cov/engine.py", line 44, in ensure_topdir_wrapper
    return meth(self, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/pytest_cov/engine.py", line 241, in start
    self.cov.start()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/coverage/control.py", line 652, in start
    self._collector.start()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/coverage/collector.py", line 373, in start
    self._start_tracer()
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/coverage/collector.py", line [32](https://github.com/hugovk/Pillow/actions/runs/7854326439/job/21434925668#step:10:33)7, in _start_tracer
    fn = tracer.start()
  File "/opt/hostedtoolcache/Python/3.10.13/x[64](https://github.com/hugovk/Pillow/actions/runs/7854326439/job/21434925668#step:10:65)/lib/python3.10/site-packages/coverage/sysmon.py", line 225, in start
    sys_monitoring.use_tool_id(self.myid, "coverage.py")
AttributeError: 'NoneType' object has no attribute 'use_tool_id'
```