### PR TITLE
CI: Temporarily pin to 3.13.0a3 for Windows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,6 +69,13 @@ jobs:
             python-version: "pypy-3.9"
           - os: windows
             python-version: "pypy-3.10"
+          # Skip 3.13.0a4 and pin to 3.13.0a3 for Windows due to build error.
+          # Undo when 3.13.0a5 is released.
+          - os: windows
+            python-version: "3.13"
+        include:
+          - os: windows
+            python-version: "3.13.0-alpha.3"
       # If one job fails, stop the whole thing.
       fail-fast: true
 

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -62,6 +62,13 @@ jobs:
             python-version: "pypy-3.9"
           - os: windows
             python-version: "pypy-3.10"
+          # Skip 3.13.0a4 and pin to 3.13.0a3 for Windows due to build error.
+          # Undo when 3.13.0a5 is released.
+          - os: windows
+            python-version: "3.13"
+        include:
+          - os: windows
+            python-version: "3.13.0-alpha.3"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Like https://github.com/python-pillow/Pillow/pull/7805.

As seen in https://github.com/nedbat/coveragepy/pull/1747.

There's a build error in 3.13.0a4 on Windows.

There might be an alpha 5 soonish, but rather than waiting we could pin to alpha 3 on Windows until it's out.

Finding these sort of problems is what alphas are for, right? :)

Related:

* https://github.com/python/cpython/pull/109922
* https://github.com/python/cpython/issues/115545
* https://github.com/python/cpython/issues/115582
* https://github.com/python/release-tools/pull/98
