### PR TITLE
Update config.py

### DIFF
--- a/coverage/config.py
+++ b/coverage/config.py
@@ -395,7 +395,7 @@ class CoverageConfig(TConfigurable, TPluginConfig):
         ("exclude_list", "report:exclude_lines", "regexlist"),
         ("exclude_also", "report:exclude_also", "regexlist"),
         ("fail_under", "report:fail_under", "float"),
-        ("format", "report:format", "boolean"),
+        ("format", "report:format"),
         ("ignore_errors", "report:ignore_errors", "boolean"),
         ("include_namespace_packages", "report:include_namespace_packages", "boolean"),
         ("partial_always_list", "report:partial_branches_always", "regexlist"),


### PR DESCRIPTION
Fixes report commands `format` config type. Which should be a `string`, but defined as `boolean`

https://github.com/nedbat/coveragepy/blob/fd4022ec6db7f4830c3d9b7f1c16b5fab8b14895/coverage/config.py#L220
https://github.com/nedbat/coveragepy/blob/fd4022ec6db7f4830c3d9b7f1c16b5fab8b14895/coverage/report.py#L31