### PR TITLE
Fix duplicating paths during remapping

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -489,6 +489,9 @@ class PathAliases:
 
         # If we get here, no pattern matched.
 
+        if self.relative:
+            path = relative_filename(path)
+
         if self.relative and not isabs_anywhere(path):
             # Auto-generate a pattern to implicitly match relative files
             parts = re.split(r"[/\\]", path)


### PR DESCRIPTION
Adds tests for #1752's bugs, along with a patch. Closes the issue.
