### PR TITLE
Support scrubbing absolute temporary paths in test_html.py on Windows

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -712,6 +712,7 @@ def compare_html(
     ]
     if env.WINDOWS:
         # For file paths...
+        scrubs += [(r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+', 'TEST_TMPDIR')]
         scrubs += [(r"\\", "/")]
     if extra_scrubs:
         scrubs += extra_scrubs

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -712,7 +712,10 @@ def compare_html(
     ]
     if env.WINDOWS:
         # For file paths...
-        scrubs += [(r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+', 'TEST_TMPDIR')]
+        scrubs += [
+            (r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+',
+             'TEST_TMPDIR')
+        ]
         scrubs += [(r"\\", "/")]
     if extra_scrubs:
         scrubs += extra_scrubs


### PR DESCRIPTION
Some gold files, like `tests/gold/html/other/index.html` record an absolute path that includes the temporary directory used while testing, like:
```
/private/var/folders/6j/khn0mcrj35d1k3yylpl8zl080000gn/T/pytest-of-ned/pytest-293/t40/othersrc/other.py
```

There's explicit support for the directory format above in the regex:
```regex
/private/var/[\w/]+/pytest-of-\w+/pytest-\d+/(popen-gw\d+/)?t\d+
```

However, when creating the gold files on Windows, the absolute path takes a rather different format, for example:
```
C:\Users\ddini\AppData\Local\Temp\pytest-of-ddini\pytest-9\popen-gw6\t1\othersrc\other.py
```

This PR adds a new regex to match and scrub directories in the format above:
```regex
[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+
```