### PR TITLE
Scrub absolute Windows temporary paths on all OSes when running test_html.py

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -709,13 +709,10 @@ def compare_html(
         (filepath_to_regex(abs_file(os.getcwd())), 'TEST_TMPDIR'),
         (filepath_to_regex(flat_rootname(str(abs_file(os.getcwd())))), '_TEST_TMPDIR'),
         (r'/private/var/[\w/]+/pytest-of-\w+/pytest-\d+/(popen-gw\d+/)?t\d+', 'TEST_TMPDIR'),
+        (r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+', 'TEST_TMPDIR'),
     ]
     if env.WINDOWS:
         # For file paths...
-        scrubs += [
-            (r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+',
-             'TEST_TMPDIR')
-        ]
         scrubs += [(r"\\", "/")]
     if extra_scrubs:
         scrubs += extra_scrubs

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -712,6 +712,7 @@ def compare_html(
     ]
     if env.WINDOWS:
         # For file paths...
+        scrubs += [(r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+', 'TEST_TMPDIR')]
         scrubs += [(r"\\", "/")]
     if extra_scrubs:
         scrubs += extra_scrubs

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -712,7 +712,10 @@ def compare_html(
     ]
     if env.WINDOWS:
         # For file paths...
-        scrubs += [(r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+', 'TEST_TMPDIR')]
+        scrubs += [
+            (r'[A-Z]:\\Users\\[\w\\]+\\pytest-of-\w+\\pytest-\d+\\(popen-gw\d+\\)?t\d+',
+             'TEST_TMPDIR')
+        ]
         scrubs += [(r"\\", "/")]
     if extra_scrubs:
         scrubs += extra_scrubs


### PR DESCRIPTION
Sorry, #1771 has a flaw: it only applies the scrubbing when tests run on Windows, so the tests fail on other OSes. 

This PR fixes that.