### PR TITLE
Support '# pragma: no branch' in multi-line if statements (fix #754)

### DIFF
--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -115,7 +115,7 @@ class PythonParser:
         matches = set()
         for i, ltext in enumerate(self.lines, start=1):
             if regex_c.search(ltext):
-                matches.add(i)
+                matches.add(self._multiline.get(i, i))
         return matches
 
     def _raw_parse(self) -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -425,6 +425,24 @@ class ExclusionParserTest(PythonParserTestBase):
         )
         assert parser.statements == {1,7}
 
+    def test_multiline_if_no_branch(self) -> None:
+        # From https://github.com/nedbat/coveragepy/issues/754
+        parser = self.parse_text("""\
+            if (this_is_a_verylong_boolean_expression == True   # pragma: no branch
+                and another_long_expression and here_another_expression):
+                do_something()
+            """,
+        )
+        parser2 = self.parse_text("""\
+            if this_is_a_verylong_boolean_expression == True and another_long_expression \\
+                and here_another_expression:  # pragma: no branch
+                do_something()
+            """,
+        )
+        assert parser.statements == parser2.statements == {1, 3}
+        pragma_re = ".*pragma: no branch.*"
+        assert parser.lines_matching(pragma_re) == parser2.lines_matching(pragma_re)
+
     def test_excluding_function(self) -> None:
         parser = self.parse_text("""\
             def fn(foo):      # nocover


### PR DESCRIPTION
`PythonParser.lines_matching()` records a set of lines matching a given regex. However, it doesn't take multi-line statements into account. That causes statements that should be marked as "# pragma: no branch" to be counted as partial branches. IOW, "a pragma comment on the continuation lines of a multi-line if-statement won't have an effect".

This PR fixes that by mapping line numbers through `parser._multiline`, so that the number of the first line in a multi-line statement gets recorded instead.

Fixes #754.