### PR TITLE
Remember the values for 'filter' and 'hide 100% covered' in HTML report (fix #1725)

### DIFF
--- a/coverage/htmlfiles/coverage_html.js
+++ b/coverage/htmlfiles/coverage_html.js
@@ -125,6 +125,16 @@ coverage.assign_shortkeys = function () {
 
 // Create the events for the filter box.
 coverage.wire_up_filter = function () {
+    // Populate the filter and hide inputs if there are saved values for them
+    const saved_filter_value = localStorage.getItem(coverage.FILTER_STORAGE);
+    if (saved_filter_value) {
+        document.getElementById("filter").value = saved_filter_value;
+    }
+    const saved_hide100_value = localStorage.getItem(coverage.HIDE_STORAGE);
+    if (saved_hide100_value) {
+        document.getElementById("hide100").checked = JSON.parse(saved_hide100_value);
+    }
+
     // Cache elements.
     const table = document.querySelector("table.index");
     const table_body_rows = table.querySelectorAll("tbody tr");
@@ -138,8 +148,12 @@ coverage.wire_up_filter = function () {
         totals[totals.length - 1] = { "numer": 0, "denom": 0 };  // nosemgrep: eslint.detect-object-injection
 
         var text = document.getElementById("filter").value;
+        // Store filter value
+        localStorage.setItem(coverage.FILTER_STORAGE, text);
         const casefold = (text === text.toLowerCase());
         const hide100 = document.getElementById("hide100").checked;
+        // Store hide value
+        localStorage.setItem(coverage.HIDE_STORAGE, JSON.stringify(hide100));
 
         // Hide / show elements.
         table_body_rows.forEach(row => {
@@ -240,6 +254,8 @@ coverage.wire_up_filter = function () {
     document.getElementById("filter").dispatchEvent(new Event("input"));
     document.getElementById("hide100").dispatchEvent(new Event("input"));
 };
+coverage.FILTER_STORAGE = "COVERAGE_FILTER_VALUE";
+coverage.HIDE_STORAGE = "COVERAGE_HIDE_VALUE";
 
 // Set up the click-to-sort columns.
 coverage.wire_up_sorting = function () {


### PR DESCRIPTION
This PR adds support for remembering the "hide covered" checkbox and filter text in HTML report pages.

It adds two new keys to localStorage, but this could be done with a single one if that's preferable. 

Fixes #1725.