### PR TITLE
Use os.device_encoding(0) to figure out stdin encoding in run_command() (Fix #1777)

### DIFF
--- a/coverage/misc.py
+++ b/coverage/misc.py
@@ -13,7 +13,6 @@ import hashlib
 import importlib
 import importlib.util
 import inspect
-import locale
 import os
 import os.path
 import re
@@ -22,7 +21,7 @@ import types
 
 from types import ModuleType
 from typing import (
-    Any, IO, Iterable, Iterator, Mapping, NoReturn, Sequence, TypeVar,
+    Any, Iterable, Iterator, Mapping, NoReturn, Sequence, TypeVar,
 )
 
 from coverage.exceptions import CoverageException
@@ -154,18 +153,6 @@ def ensure_dir(directory: str) -> None:
 def ensure_dir_for_file(path: str) -> None:
     """Make sure the directory for the path exists."""
     ensure_dir(os.path.dirname(path))
-
-
-def output_encoding(outfile: IO[str] | None = None) -> str:
-    """Determine the encoding to use for output written to `outfile` or stdout."""
-    if outfile is None:
-        outfile = sys.stdout
-    encoding = (
-        getattr(outfile, "encoding", None) or
-        getattr(sys.__stdout__, "encoding", None) or
-        locale.getpreferredencoding()
-    )
-    return encoding
 
 
 class Hasher:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,6 +9,7 @@ import collections
 import contextlib
 import dis
 import io
+import locale
 import os
 import os.path
 import re
@@ -62,7 +63,8 @@ def run_command(cmd: str) -> tuple[int, str]:
     status = proc.returncode
 
     # Get the output, and canonicalize it to strings with newlines.
-    output_str = output.decode(output_encoding()).replace("\r", "")
+    encoding = os.device_encoding(0) or locale.getpreferredencoding()
+    output_str = output.decode(encoding).replace("\r", "")
     return status, output_str
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,7 +29,6 @@ import pytest
 from coverage import env
 from coverage.debug import DebugControl
 from coverage.exceptions import CoverageWarning
-from coverage.misc import output_encoding
 from coverage.types import TArc, TLineNo
 
 
@@ -45,11 +44,13 @@ def run_command(cmd: str) -> tuple[int, str]:
         with open("/tmp/processes.txt", "a") as proctxt:  # type: ignore[unreachable]
             print(os.getenv("PYTEST_CURRENT_TEST", "unknown"), file=proctxt, flush=True)
 
+    encoding = os.device_encoding(1) or locale.getpreferredencoding()
+
     # In some strange cases (PyPy3 in a virtualenv!?) the stdout encoding of
     # the subprocess is set incorrectly to ascii.  Use an environment variable
     # to force the encoding to be the same as ours.
     sub_env = dict(os.environ)
-    sub_env['PYTHONIOENCODING'] = output_encoding()
+    sub_env['PYTHONIOENCODING'] = encoding
 
     proc = subprocess.Popen(
         cmd,
@@ -63,7 +64,6 @@ def run_command(cmd: str) -> tuple[int, str]:
     status = proc.returncode
 
     # Get the output, and canonicalize it to strings with newlines.
-    encoding = os.device_encoding(1) or locale.getpreferredencoding()
     output_str = output.decode(encoding).replace("\r", "")
     return status, output_str
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -63,7 +63,7 @@ def run_command(cmd: str) -> tuple[int, str]:
     status = proc.returncode
 
     # Get the output, and canonicalize it to strings with newlines.
-    encoding = os.device_encoding(0) or locale.getpreferredencoding()
+    encoding = os.device_encoding(1) or locale.getpreferredencoding()
     output_str = output.decode(encoding).replace("\r", "")
     return status, output_str
 


### PR DESCRIPTION
The output of `subprocess.Popen` on Windows might include bytes that cannot be decoded by UTF-8. 

This PR uses `os.device_encoding(0)` to figure out the real encoding of stdin (fd 0) so `run_command` can use that to decode the output. Since `os.device_encoding` may return None, we fallback to `locale.getpreferredencoding`.

Fixes #1777.