### PR TITLE
catch TokenError on parse

### DIFF
--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -263,10 +263,14 @@ class PythonParser:
         try:
             self._ast_root = ast.parse(self.text)
             self._raw_parse()
-        except (IndentationError, SyntaxError) as err:
+        except (tokenize.TokenError, IndentationError, SyntaxError) as err:
+            if hasattr(err, "lineno"):
+                lineno = err.lineno         # IndentationError
+            else:
+                lineno = err.args[1][0]     # TokenError
             raise NotPython(
                 f"Couldn't parse '{self.filename}' as Python source: " +
-                f"{err.args[0]!r} at line {err.lineno}",
+                f"{err.args[0]!r} at line {lineno}",
             ) from err
 
         ignore = self.excluded | self.raw_docstrings

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -133,7 +133,7 @@ class PythonParserTest(PythonParserTestBase):
             "\r'\\\n'''",
             id="leading_newline_eof",
             marks=[
-                pytest.mark.skipif(env.PYVERSION >= (3, 12), reason="parses fine in 3.12")
+                pytest.mark.skipif(env.PYVERSION >= (3, 12), reason="parses fine in 3.12"),
             ]
         )
     ])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import textwrap
+import sys
 
 import pytest
 
@@ -128,6 +129,14 @@ class PythonParserTest(PythonParserTestBase):
         pytest.param("0 spaces\n  2\n 1", id="bad_indent"),
         pytest.param("'''", id="string_eof"),
         pytest.param("$hello", id="dollar"),
+        # on 3.10 this passes ast.parse but fails on tokenize.generate_tokens
+        pytest.param(
+            "\r'\\\n'''",
+            id="ledaing_newline_eof",
+            marks=[
+                pytest.mark.skipif(sys.version_info >= (3, 12), reason="parses fine in 3.11")
+            ]
+        )
     ])
     def test_not_python(self, text: str) -> None:
         msg = r"Couldn't parse '<code>' as Python source: '.*' at line \d+"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import textwrap
-import sys
 
 import pytest
 
@@ -132,9 +131,9 @@ class PythonParserTest(PythonParserTestBase):
         # on 3.10 this passes ast.parse but fails on tokenize.generate_tokens
         pytest.param(
             "\r'\\\n'''",
-            id="ledaing_newline_eof",
+            id="leading_newline_eof",
             marks=[
-                pytest.mark.skipif(sys.version_info >= (3, 12), reason="parses fine in 3.11")
+                pytest.mark.skipif(env.PYVERSION >= (3, 12), reason="parses fine in 3.12")
             ]
         )
     ])


### PR DESCRIPTION
closes #1787.

Reproduced by running atheris locally on [the coverage.py oss-fuzz runner](https://github.com/google/oss-fuzz/blob/master/projects/coveragepy/fuzz_parse.py):

```python
p = PythonParser(text="\r'\\\n'''")
p.parse_source()
```

This string passes `ast.parse` but fails `tokenize.generate_tokens` (on 3.10 but not 3.12):

```python
s = "\r'\\\n'''"
ast.parse(s) # passes
generate_tokens(s) # errors on 3.10
```

so we can't rely on `ast.parse` to give us nice syntax/indentation errors.