### PR TITLE
Clarify default exclusion pattern in documentation

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -591,7 +591,7 @@ Settings common to many kinds of reporting.
 (multi-string) A list of regular expressions.  This setting is similar to
 :ref:`config_report_exclude_lines`: it specifies patterns for lines to exclude
 from reporting.  This setting is preferred, because it will preserve the
-default exclude patterns instead of overwriting them.
+default exclude pattern ``pragma: no cover`` instead of overwriting it.
 
 .. versionadded:: 7.2.0
 

--- a/doc/excluding.rst
+++ b/doc/excluding.rst
@@ -34,10 +34,10 @@ code, the "if debug" clause is excluded from reporting::
         log_message(msg, a)
     b = my_function2()
 
-Any line with a comment of "pragma: no cover" is excluded.  If that line
-introduces a clause, for example, an if clause, or a function or class
-definition, then the entire clause is also excluded.  Here the __repr__
-function is not reported as missing::
+By default, any line with a comment of ``pragma: no cover`` is excluded.
+If that line introduces a clause, for example, an ``if`` clause, or a function
+or class definition, then the entire clause is also excluded.
+Here the ``__repr__`` function is not reported as missing::
 
     class MyObject(object):
         def __init__(self):


### PR DESCRIPTION
The [documentation](https://coverage.readthedocs.io/en/latest/config.html#report-exclude-also) mentions that `exclude_also` should be preferred to `exclude_lines` because the default exclusion patterns will be preserved, but doesn't document what those patterns are.
The default pattern(s) should be documented somewhere.
Documentation at https://coverage.readthedocs.io/en/latest/excluding.html# mentions that lines containing ``pragma: no cover`` are excluded, but it is not explicit enough that this is the (only) default exclude pattern.

I rephrased and formatted the documentation a bit differently to make that more obvious.

Doing that because I noticed that `exclude_also` was recently introduced, and I wanted to update my config to use it instead of `exclude_lines`, but I did not see anywhere in the doc which patterns are part of the default. I found my answer by digging through the source code: https://github.com/nedbat/coveragepy/blob/2e849d1ca7d3382459a9cacae3df5bc8b0b8d6ec/coverage/config.py#L152