### PR TITLE
fix: runpy.run_path(path) crashes with pathlib.Path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,11 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
-Nothing yet.
+- Fix: coverage used to fail when measuring code using :func:`runpy.run_path
+  <python:runpy.run_path>` with a :class:`Path <python:pathlib.Path>` argument.
+  This is now fixed, thanks to `Ask Hjorth Larsen <pull 1819_>`_.
+
+.. _pull 1819: https://github.com/nedbat/coveragepy/pull/1819/files
 
 
 .. scriv-start-here

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Artem Dayneko
 Arthur Deygin
 Arthur Rio
 Asher Foa
+Ask Hjorth Larsen
 Ben Carlsson
 Ben Finney
 Benjamin Parzella

--- a/coverage/inorout.py
+++ b/coverage/inorout.py
@@ -321,7 +321,8 @@ class InOrOut:
             # co_filename value.
             dunder_file = frame.f_globals and frame.f_globals.get("__file__")
             if dunder_file:
-                filename = source_for_file(dunder_file)
+                # Danger: __file__ can (rarely?) be of type Path.
+                filename = source_for_file(str(dunder_file))
                 if original_filename and not original_filename.startswith("<"):
                     orig = os.path.basename(original_filename)
                     if orig != os.path.basename(filename):

--- a/coverage/python.py
+++ b/coverage/python.py
@@ -104,6 +104,9 @@ def source_for_file(filename: str) -> str:
     file to attribute it to.
 
     """
+    from pathlib import Path
+    filename = str(Path(filename))
+
     if filename.endswith(".py"):
         # .py files are themselves source files.
         return filename

--- a/coverage/python.py
+++ b/coverage/python.py
@@ -104,9 +104,6 @@ def source_for_file(filename: str) -> str:
     file to attribute it to.
 
     """
-    from pathlib import Path
-    filename = str(Path(filename))
-
     if filename.endswith(".py"):
         # .py files are themselves source files.
         return filename

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -65,10 +65,10 @@ def test_source_for_file_windows(tmp_path: pathlib.Path) -> None:
     assert source_for_file(src + 'c') == src
 
 
-class RunpyPathTest(CoverageTest):
-    run_in_temp_dir = True
+class RunpyTest(CoverageTest):
+    """Tests using runpy."""
 
-    def test_runpy_path(self):
+    def test_runpy_path(self) -> None:
         """Ensure runpy.run_path(path) works when path is pathlib.Path.
 
         runpy.run_path(pathlib.Path(...)) causes __file__ to be a Path,

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -63,3 +63,22 @@ def test_source_for_file_windows(tmp_path: pathlib.Path) -> None:
     # If both pyw and py exist, py is preferred
     a_py.write_text("")
     assert source_for_file(src + 'c') == src
+
+
+class RunpyPathTest(CoverageTest):
+    run_in_temp_dir = True
+
+    def test_runpy_path(self):
+        """Ensure runpy.run_path(path) works when path is pathlib.Path.
+
+        runpy.run_path(pathlib.Path(...)) causes __file__ to be a Path,
+        which may make source_for_file() stumble (#1819).
+        """
+
+        self.check_coverage("""\
+            import runpy
+            from pathlib import Path
+            pyfile = Path('script.py')
+            pyfile.write_text('')
+            runpy.run_path(pyfile)
+        """)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -68,17 +68,19 @@ def test_source_for_file_windows(tmp_path: pathlib.Path) -> None:
 class RunpyTest(CoverageTest):
     """Tests using runpy."""
 
-    def test_runpy_path(self) -> None:
-        """Ensure runpy.run_path(path) works when path is pathlib.Path.
+    @pytest.mark.parametrize("convert_to", ["str", "Path"])
+    def test_runpy_path(self, convert_to: str) -> None:
+        # Ensure runpy.run_path(path) works when path is pathlib.Path or str.
+        #
+        # runpy.run_path(pathlib.Path(...)) causes __file__ to be a Path,
+        # which may make source_for_file() stumble (#1819) with:
+        #
+        #    AttributeError: 'PosixPath' object has no attribute 'endswith'
 
-        runpy.run_path(pathlib.Path(...)) causes __file__ to be a Path,
-        which may make source_for_file() stumble (#1819).
-        """
-
-        self.check_coverage("""\
+        self.check_coverage(f"""\
             import runpy
             from pathlib import Path
             pyfile = Path('script.py')
             pyfile.write_text('')
-            runpy.run_path(pyfile)
+            runpy.run_path({convert_to}(pyfile))
         """)


### PR DESCRIPTION
I ran into the following problem where coverage replaces `runpy.run_path()` in a way that does not accept Path objects:

```
import runpy

script = "print('hello, world!')\n"

def test_path(tmp_path):
    pyfile = tmp_path / 'script.py'
    pyfile.write_text(script)
    runpy.run_path(pyfile)
```

This passes with ordinary pytest but crashes with `pytest --cov` with the following traceback:

```
Traceback (most recent call last):
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/_pytest/runner.py", line 341, in from_call
    result: Optional[TResult] = func()
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/flaky/flaky_pytest_plugin.py", line 146, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_callers.py", line 182, in _multicall
    return outcome.get_result()
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_result.py", line 100, in get_result
    raise exc.with_traceback(exc.__traceback__)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/_pytest/runner.py", line 177, in pytest_runtest_call
    raise e
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/_pytest/runner.py", line 169, in pytest_runtest_call
    item.runtest()
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/_pytest/python.py", line 1792, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_hooks.py", line 513, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_callers.py", line 139, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/pluggy/_callers.py", line 103, in _multicall
    res = hook_impl.function(*args)
  File "/home/askhl/install/pyenv/lib/python3.10/site-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/askhl/coverage-runpy/test.py", line 11, in test_path
    runpy.run_path(pyfile)
  File "/usr/lib/python3.10/runpy.py", line 289, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/askhl/src/coveragepy/coverage/control.py", line 395, in _should_trace
    disp = self._inorout.should_trace(filename, frame)
  File "/home/askhl/src/coveragepy/coverage/inorout.py", line 324, in should_trace
    filename = source_for_file(dunder_file)
  File "/home/askhl/src/coveragepy/coverage/python.py", line 107, in source_for_file
    if filename.endswith(".py"):
AttributeError: 'PosixPath' object has no attribute 'endswith'
```

This PR contains a minimal fix which sends the input through `str(Path(...))`.  However a proper fix might require some awareness of the surrounding code as well as a test, so I'd expect the PR in its current form to be insufficient.  Feedback would be appreciated.