### PR TITLE
Test error handling in setup.py

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -90,7 +90,7 @@ class SetupPyTest(CoverageTest):
             ext_builder.run()  # type: ignore
 
         # Sanity check: we don't handle unexpected errors
-        for error in setup.ext_errors:
+        for error in (ImportError, ZeroDivisionError, Exception):
             with pytest.raises(error):
                 setup.build_ext.build_extension = self.raise_error(error)
                 ext_builder = setup.ve_build_ext(setuptools.Distribution())


### PR DESCRIPTION
This PR adds some tests for exception handling in setup.py.

It currently uses direct monkey-patching, please let me know if using `mock,patch` or some other method would be better/cleaner.

I'd be happy to add or remove some of the testing done, as well as reworking or otherwise polishing this PR.