### PR TITLE
Fix incorrect backslash before multi-lines string

### DIFF
--- a/coverage/phystokens.py
+++ b/coverage/phystokens.py
@@ -57,7 +57,15 @@ def _phys_tokens(toks: TokenInfos) -> TokenInfos:
                 if last_ttext.endswith("\\"):
                     inject_backslash = False
                 elif ttype == token.STRING:
-                    if "\n" in ttext and ttext.split("\n", 1)[0][-1] == "\\":
+                    if last_line.endswith(last_ttext+"\\\n"):
+                        # Deal with special cases like such code::
+                        #
+                        #   a = ["aaa",\
+                        #        "bbb \
+                        #        ccc"]
+                        #
+                        pass
+                    elif "\n" in ttext and ttext.split("\n", 1)[0][-1] == "\\":
                         # It's a multi-line string and the first line ends with
                         # a backslash, so we don't need to inject another.
                         inject_backslash = False


### PR DESCRIPTION
The PR is used to fix incorrect backslash before multi-lines string which will result in incorrect lines alignment.

## Source code for test
```python
#################### case 1
a = ["aaa",\
     "bbb \
     ccc"]

#################### case 2
b = ("a",\
     "b \
     c")

########## case 3
c = "xxx"\
    "yyy \
    zzz"

#################### case 4
def f(a, b):
    pass

f(100,\
  "hello \
  world")

#################### case 5(good case)
d = """\
hello
"""


def show_incorrect_line_align():
    # line 1
    # line 2
    # line 3
    # line 4
    # line 5
    pass
```

## Run commands
```bash
coverage run main.py
coverage html
cd htmlcov
python3 -m http.server 9000
```

![image](https://github.com/user-attachments/assets/3505e566-f198-4b3b-b7cd-e8552492024f)

