### PR TITLE
fix: null array indexing in CTracer_handle_return

### DIFF
--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -722,9 +722,9 @@ CTracer_handle_return(CTracer *self, PyFrameObject *frame)
     if (CTracer_set_pdata_stack(self) < 0) {
         goto error;
     }
-    self->pcur_entry = &self->pdata_stack->stack[self->pdata_stack->depth];
 
     if (self->pdata_stack->depth >= 0) {
+        self->pcur_entry = &self->pdata_stack->stack[self->pdata_stack->depth];
         if (self->tracing_arcs && self->pcur_entry->file_data) {
             BOOL real_return = FALSE;
             pCode = MyCode_GetCode(MyFrame_GetCode(frame));


### PR DESCRIPTION
Fixes #1835 

`CTracer_set_pdata_stack` can initialize `self.pdata_stack` to an empty stack where `->stack` is `NULL` and `->deph` is -1.

Move index into `->stack` into `->depth>=0` check to avoid indexing into `NULL` array.

This issue was found running UndefinedBehaviourSanitizer. It's reproducible in regular test runs, e.g. `python3 -m tox -e py311`. Adding `if (self->pdata_stack->stack == NULL) { fprint(...) }` before the moved line shows the issue in several test cases.

---

The contributing guide mentions ever fix should include tests. I'd be happy to add some, but I'm not quite sure how to do that here. Do you have a preference/advice?