### PR TITLE
Lcov report fixes v2

### DIFF
--- a/coverage/config.py
+++ b/coverage/config.py
@@ -250,6 +250,7 @@ class CoverageConfig(TConfigurable, TPluginConfig):
 
         # Defaults for [lcov]
         self.lcov_output = "coverage.lcov"
+        self.lcov_line_checksums = False
 
         # Defaults for [paths]
         self.paths: dict[str, list[str]] = {}
@@ -428,6 +429,7 @@ class CoverageConfig(TConfigurable, TPluginConfig):
 
         # [lcov]
         ("lcov_output", "lcov:output"),
+        ("lcov_line_checksums", "lcov:line_checksums", "boolean")
     ]
 
     def _set_attr_from_config_option(

--- a/coverage/env.py
+++ b/coverage/env.py
@@ -99,10 +99,6 @@ class PYBEHAVIOR:
     # Some words are keywords in some places, identifiers in other places.
     soft_keywords = (PYVERSION >= (3, 10))
 
-    # Modules start with a line numbered zero. This means empty modules have
-    # only a 0-number line, which is ignored, giving a truly empty module.
-    empty_is_empty = (PYVERSION >= (3, 11, 0, "beta", 4))
-
     # PEP669 Low Impact Monitoring: https://peps.python.org/pep-0669/
     pep669 = bool(getattr(sys, "monitoring", None))
 

--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -53,13 +53,26 @@ class LcovReporter:
         self.coverage.get_data()
         outfile = outfile or sys.stdout
 
-        for fr, analysis in get_analysis_to_report(self.coverage, morfs):
+        # ensure file records are sorted by the _relative_ filename, not the full path
+        to_report = [
+            (fr.relative_filename(), fr, analysis)
+            for fr, analysis in get_analysis_to_report(self.coverage, morfs)
+        ]
+        to_report.sort()
+
+        for fname, fr, analysis in to_report:
             self.total += analysis.numbers
-            self.lcov_file(fr, analysis, outfile)
+            self.lcov_file(fname, fr, analysis, outfile)
 
         return self.total.n_statements and self.total.pc_covered
 
-    def lcov_file(self, fr: FileReporter, analysis: Analysis, outfile: IO[str]) -> None:
+    def lcov_file(
+        self,
+        rel_fname: str,
+        fr: FileReporter,
+        analysis: Analysis,
+        outfile: IO[str],
+    ) -> None:
         """Produces the lcov data for a single file.
 
         This currently supports both line and branch coverage,
@@ -70,74 +83,70 @@ class LcovReporter:
             if self.config.skip_empty:
                 return
 
-        outfile.write(f"SF:{fr.relative_filename()}\n")
+        outfile.write(f"SF:{rel_fname}\n")
 
-        source_lines = fr.source().splitlines()
-        for covered in sorted(analysis.executed):
-            if covered in analysis.excluded:
-                # Do not report excluded as executed
-                continue
+        if self.config.lcov_line_checksums:
+            source_lines = fr.source().splitlines()
 
-            if source_lines:
-                if covered-1 >= len(source_lines):
-                    break
-                line = source_lines[covered-1]
-            else:
-                line = ""
+        # Emit a DA: record for each line of the file.
+        lines = sorted(analysis.statements)
+        hash_suffix = ""
+        for line in lines:
             if self.config.lcov_line_checksums:
-                hash_suffix = "," + line_hash(line)
-            else:
-                hash_suffix = ""
-
-            # Note: Coverage.py currently only supports checking *if* a line
-            # has been executed, not how many times, so we set this to 1 for
-            # nice output even if it's technically incorrect.
-            outfile.write(f"DA:{covered},1{hash_suffix}\n")
-
-        for missed in sorted(analysis.missing):
-            # We don't have to skip excluded lines here, because `missing`
-            # already doesn't have them.
-            assert source_lines
-            line = source_lines[missed-1]
-            if self.config.lcov_line_checksums:
-                hash_suffix = "," + line_hash(line)
-            else:
-                hash_suffix = ""
-            outfile.write(f"DA:{missed},0{hash_suffix}\n")
+                hash_suffix = "," + line_hash(source_lines[line-1])
+            # Q: can we get info about the number of times a statement is
+            # executed?  If so, that should be recorded here.
+            hit = int(line not in analysis.missing)
+            outfile.write(f"DA:{line},{hit}{hash_suffix}\n")
 
         if analysis.numbers.n_statements > 0:
             outfile.write(f"LF:{analysis.numbers.n_statements}\n")
             outfile.write(f"LH:{analysis.numbers.n_executed}\n")
 
-        # More information dense branch coverage data.
-        missing_arcs = analysis.missing_branch_arcs()
-        executed_arcs = analysis.executed_branch_arcs()
-        for block_number, block_line_number in enumerate(
-            sorted(analysis.branch_stats().keys()),
-        ):
-            for branch_number, line_number in enumerate(
-                sorted(missing_arcs[block_line_number]),
-            ):
-                # The exit branches have a negative line number,
-                # this will not produce valid lcov. Setting
-                # the line number of the exit branch to 0 will allow
-                # for valid lcov, while preserving the data.
-                line_number = max(line_number, 0)
-                outfile.write(f"BRDA:{line_number},{block_number},{branch_number},-\n")
-
-            # The start value below allows for the block number to be
-            # preserved between these two for loops (stopping the loop from
-            # resetting the value of the block number to 0).
-            for branch_number, line_number in enumerate(
-                sorted(executed_arcs[block_line_number]),
-                start=len(missing_arcs[block_line_number]),
-            ):
-                line_number = max(line_number, 0)
-                outfile.write(f"BRDA:{line_number},{block_number},{branch_number},1\n")
-
-        # Summary of the branch coverage.
+        # More information dense branch coverage data, if available.
         if analysis.has_arcs:
             branch_stats = analysis.branch_stats()
+            executed_arcs = analysis.executed_branch_arcs()
+            missing_arcs = analysis.missing_branch_arcs()
+
+            for line in lines:
+                if line in branch_stats:
+                    # The meaning of a BRDA: line is not well explained in the lcov
+                    # documentation.  Based on what genhtml does with them, however,
+                    # the interpretation is supposed to be something like this:
+                    # BRDA: <line>, <block>, <branch>, <hit>
+                    # where <line> is the source line number of the *origin* of the
+                    # branch; <block> is an arbitrary number which distinguishes multiple
+                    # control flow operations on a single line; <branch> is an arbitrary
+                    # number which distinguishes the possible destinations of the specific
+                    # control flow operation identified by <line> + <block>; and <hit> is
+                    # either the hit count for <line> + <block> + <branch> or "-" meaning
+                    # that <line> + <block> was never *reached*.  <line> must be >= 1,
+                    # and <block>, <branch>, <hit> must be >= 0.
+
+                    # This is only one possible way to map our sets of executed and
+                    # not-executed arcs to BRDA codes. It seems to produce reasonable
+                    # results when fed through genhtml.
+
+                    # Q: can we get counts of the number of times each arc was executed?
+                    # branch_stats has "total" and "taken" counts for each branch, but it
+                    # doesn't have "taken" broken down by destination.
+                    destinations = {}
+                    for dst in executed_arcs[line]:
+                        destinations[(int(dst < 0), abs(dst))] = 1
+                    for dst in missing_arcs[line]:
+                        destinations[(int(dst < 0), abs(dst))] = 0
+
+                    if all(v == 0 for v in destinations.values()):
+                        # When _none_ of the out arcs from 'line' were executed, presume
+                        # 'line' was never reached.
+                        for branch, _ in enumerate(sorted(destinations.keys())):
+                            outfile.write(f"BRDA:{line},0,{branch},-\n")
+                    else:
+                        for branch, (_, hit) in enumerate(sorted(destinations.items())):
+                            outfile.write(f"BRDA:{line},0,{branch},{hit}\n")
+
+            # Summary of the branch coverage.
             brf = sum(t for t, k in branch_stats.values())
             brh = brf - sum(t - k for t, k in branch_stats.values())
             if brf > 0:

--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -22,9 +22,12 @@ if TYPE_CHECKING:
 
 def line_hash(line: str) -> str:
     """Produce a hash of a source line for use in the LCOV file."""
-    # The LCOV file format requires MD5 as a fingerprint of the file. This is
-    # not a security use.  Some security scanners raise alarms about the use of
-    # MD5 here, but it is a false positive. This is not a security concern.
+    # The LCOV file format optionally allows each line to be MD5ed as a
+    # fingerprint of the file.  This is not a security use.  Some security
+    # scanners raise alarms about the use of MD5 here, but it is a false
+    # positive.  This is not a security concern.
+    # The unusual encoding of the MD5 hash, as a base64 sequence with the
+    # trailing = signs stripped, is specified by the LCOV file format.
     hashed = hashlib.md5(line.encode("utf-8")).digest()
     return base64.b64encode(hashed).decode("ascii").rstrip("=")
 
@@ -68,34 +71,39 @@ class LcovReporter:
                 return
 
         outfile.write(f"SF:{fr.relative_filename()}\n")
+
         source_lines = fr.source().splitlines()
         for covered in sorted(analysis.executed):
             if covered in analysis.excluded:
                 # Do not report excluded as executed
                 continue
-            # Note: Coverage.py currently only supports checking *if* a line
-            # has been executed, not how many times, so we set this to 1 for
-            # nice output even if it's technically incorrect.
 
-            # The lines below calculate a 64-bit encoded md5 hash of the line
-            # corresponding to the DA lines in the lcov file, for either case
-            # of the line being covered or missed in coverage.py. The final two
-            # characters of the encoding ("==") are removed from the hash to
-            # allow genhtml to run on the resulting lcov file.
             if source_lines:
                 if covered-1 >= len(source_lines):
                     break
                 line = source_lines[covered-1]
             else:
                 line = ""
-            outfile.write(f"DA:{covered},1,{line_hash(line)}\n")
+            if self.config.lcov_line_checksums:
+                hash_suffix = "," + line_hash(line)
+            else:
+                hash_suffix = ""
+
+            # Note: Coverage.py currently only supports checking *if* a line
+            # has been executed, not how many times, so we set this to 1 for
+            # nice output even if it's technically incorrect.
+            outfile.write(f"DA:{covered},1{hash_suffix}\n")
 
         for missed in sorted(analysis.missing):
             # We don't have to skip excluded lines here, because `missing`
             # already doesn't have them.
             assert source_lines
             line = source_lines[missed-1]
-            outfile.write(f"DA:{missed},0,{line_hash(line)}\n")
+            if self.config.lcov_line_checksums:
+                hash_suffix = "," + line_hash(line)
+            else:
+                hash_suffix = ""
+            outfile.write(f"DA:{missed},0{hash_suffix}\n")
 
         if analysis.numbers.n_statements > 0:
             outfile.write(f"LF:{analysis.numbers.n_statements}\n")

--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -50,17 +50,17 @@ class LcovReporter:
         outfile = outfile or sys.stdout
 
         for fr, analysis in get_analysis_to_report(self.coverage, morfs):
-            self.get_lcov(fr, analysis, outfile)
+            self.total += analysis.numbers
+            self.lcov_file(fr, analysis, outfile)
 
         return self.total.n_statements and self.total.pc_covered
 
-    def get_lcov(self, fr: FileReporter, analysis: Analysis, outfile: IO[str]) -> None:
+    def lcov_file(self, fr: FileReporter, analysis: Analysis, outfile: IO[str]) -> None:
         """Produces the lcov data for a single file.
 
         This currently supports both line and branch coverage,
         however function coverage is not supported.
         """
-        self.total += analysis.numbers
 
         outfile.write("TN:\n")
         outfile.write(f"SF:{fr.relative_filename()}\n")

--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -36,6 +36,7 @@ class LcovReporter:
 
     def __init__(self, coverage: Coverage) -> None:
         self.coverage = coverage
+        self.config = coverage.config
         self.total = Numbers(self.coverage.config.precision)
 
     def report(self, morfs: Iterable[TMorf] | None, outfile: IO[str]) -> float:
@@ -62,7 +63,10 @@ class LcovReporter:
         however function coverage is not supported.
         """
 
-        outfile.write("TN:\n")
+        if analysis.numbers.n_statements == 0:
+            if self.config.skip_empty:
+                return
+
         outfile.write(f"SF:{fr.relative_filename()}\n")
         source_lines = fr.source().splitlines()
         for covered in sorted(analysis.executed):
@@ -93,8 +97,9 @@ class LcovReporter:
             line = source_lines[missed-1]
             outfile.write(f"DA:{missed},0,{line_hash(line)}\n")
 
-        outfile.write(f"LF:{analysis.numbers.n_statements}\n")
-        outfile.write(f"LH:{analysis.numbers.n_executed}\n")
+        if analysis.numbers.n_statements > 0:
+            outfile.write(f"LF:{analysis.numbers.n_statements}\n")
+            outfile.write(f"LH:{analysis.numbers.n_executed}\n")
 
         # More information dense branch coverage data.
         missing_arcs = analysis.missing_branch_arcs()
@@ -127,7 +132,8 @@ class LcovReporter:
             branch_stats = analysis.branch_stats()
             brf = sum(t for t, k in branch_stats.values())
             brh = brf - sum(t - k for t, k in branch_stats.values())
-            outfile.write(f"BRF:{brf}\n")
-            outfile.write(f"BRH:{brh}\n")
+            if brf > 0:
+                outfile.write(f"BRF:{brf}\n")
+                outfile.write(f"BRH:{brh}\n")
 
         outfile.write("end_of_record\n")

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -890,3 +890,14 @@ Settings particular to LCOV reporting (see :ref:`cmd_lcov`).
 .............
 
 (string, default "coverage.lcov") Where to write the LCOV file.
+
+[lcov] line_checksums
+.....................
+
+(boolean, default false) Whether to write per-line checksums as part of the
+lcov file.  Because these checksums cover only lines with actual code on
+them, and do not verify the ordering of lines, they provide only a weak
+assurance that the source code available to analysis tools (e.g. ``genhtml``)
+matches the code that was used to generate the coverage data.
+
+.. versionadded:: 7.6.2

--- a/tests/test_lcov.py
+++ b/tests/test_lcov.py
@@ -11,7 +11,6 @@ import textwrap
 from tests.coveragetest import CoverageTest
 
 import coverage
-from coverage import env
 
 
 class LcovTest(CoverageTest):
@@ -60,8 +59,8 @@ class LcovTest(CoverageTest):
         expected_result = textwrap.dedent("""\
             SF:main_file.py
             DA:1,1
-            DA:4,1
             DA:2,0
+            DA:4,1
             DA:5,0
             LF:4
             LH:2
@@ -92,8 +91,8 @@ class LcovTest(CoverageTest):
         expected_result = textwrap.dedent("""\
             SF:main_file.py
             DA:1,1,7URou3io0zReBkk69lEb/Q
-            DA:4,1,ilhb4KUfytxtEuClijZPlQ
             DA:2,0,Xqj6H1iz/nsARMCAbE90ng
+            DA:4,1,ilhb4KUfytxtEuClijZPlQ
             DA:5,0,LWILTcvARcydjFFyo9qM0A
             LF:4
             LH:2
@@ -116,8 +115,8 @@ class LcovTest(CoverageTest):
         expected_result = textwrap.dedent("""\
             SF:main_file.py
             DA:1,1
-            DA:4,1
             DA:2,0
+            DA:4,1
             DA:5,0
             LF:4
             LH:2
@@ -161,8 +160,8 @@ class LcovTest(CoverageTest):
             DA:5,0
             LF:4
             LH:1
-            BRDA:3,0,0,-
-            BRDA:5,0,1,-
+            BRDA:2,0,0,-
+            BRDA:2,0,1,-
             BRF:2
             BRH:0
             end_of_record
@@ -204,8 +203,8 @@ class LcovTest(CoverageTest):
             DA:5,0
             LF:4
             LH:1
-            BRDA:3,0,0,-
-            BRDA:5,0,1,-
+            BRDA:2,0,0,-
+            BRDA:2,0,1,-
             BRF:2
             BRH:0
             end_of_record
@@ -248,8 +247,8 @@ class LcovTest(CoverageTest):
             DA:6,0
             LF:4
             LH:3
-            BRDA:6,0,0,-
-            BRDA:4,0,1,1
+            BRDA:3,0,0,1
+            BRDA:3,0,1,0
             BRF:2
             BRH:1
             end_of_record
@@ -258,11 +257,8 @@ class LcovTest(CoverageTest):
         assert expected_result == actual_result
 
     def test_empty_init_files(self) -> None:
-        # Test that an empty __init__.py still generates a (mostly vacuous)
-        # coverage record.  The overall coverage will be zero lines of code
-        # and zero branches to execute, and therefore no LF/LH nor BRF/BRH
-        # lines will be emitted.  However, in old Pythons there will be one
-        # DA line emitted for the empty source line 1.
+        # Test that an empty __init__.py still generates a (vacuous)
+        # coverage record.
         self.make_file("__init__.py", "")
         self.assert_doesnt_exist(".coverage")
         cov = coverage.Coverage(branch=True, source=".")
@@ -270,18 +266,10 @@ class LcovTest(CoverageTest):
         pct = cov.lcov_report()
         assert pct == 0.0
         self.assert_exists("coverage.lcov")
-        # Newer Pythons have truly empty empty files.
-        if env.PYBEHAVIOR.empty_is_empty:
-            expected_result = textwrap.dedent("""\
-                SF:__init__.py
-                end_of_record
-                """)
-        else:
-            expected_result = textwrap.dedent("""\
-                SF:__init__.py
-                DA:1,1
-                end_of_record
-                """)
+        expected_result = textwrap.dedent("""\
+            SF:__init__.py
+            end_of_record
+            """)
         actual_result = self.get_lcov_report_content()
         assert expected_result == actual_result
 
@@ -323,12 +311,12 @@ class LcovTest(CoverageTest):
             SF:runme.py
             DA:1,1
             DA:3,1
-            DA:6,1
             DA:4,0
+            DA:6,1
             LF:4
             LH:3
-            BRDA:4,0,0,-
-            BRDA:6,0,1,1
+            BRDA:3,0,0,0
+            BRDA:3,0,1,1
             BRF:2
             BRH:1
             end_of_record

--- a/tests/test_lcov.py
+++ b/tests/test_lcov.py
@@ -59,10 +59,10 @@ class LcovTest(CoverageTest):
             """)
         expected_result = textwrap.dedent("""\
             SF:main_file.py
-            DA:1,1,7URou3io0zReBkk69lEb/Q
-            DA:4,1,ilhb4KUfytxtEuClijZPlQ
-            DA:2,0,Xqj6H1iz/nsARMCAbE90ng
-            DA:5,0,LWILTcvARcydjFFyo9qM0A
+            DA:1,1
+            DA:4,1
+            DA:2,0
+            DA:5,0
             LF:4
             LH:2
             end_of_record
@@ -72,6 +72,33 @@ class LcovTest(CoverageTest):
         self.start_import_stop(cov, "main_file")
         pct = cov.lcov_report()
         assert pct == 50.0
+        actual_result = self.get_lcov_report_content()
+        assert expected_result == actual_result
+
+    def test_line_checksums(self) -> None:
+        self.make_file("main_file.py", """\
+            def cuboid_volume(l):
+                return (l*l*l)
+
+            def IsItTrue():
+                return True
+            """)
+        self.make_file(".coveragerc", "[lcov]\nline_checksums = true\n")
+        self.assert_doesnt_exist(".coverage")
+        cov = coverage.Coverage(source=["."])
+        self.start_import_stop(cov, "main_file")
+        pct = cov.lcov_report()
+        assert pct == 50.0
+        expected_result = textwrap.dedent("""\
+            SF:main_file.py
+            DA:1,1,7URou3io0zReBkk69lEb/Q
+            DA:4,1,ilhb4KUfytxtEuClijZPlQ
+            DA:2,0,Xqj6H1iz/nsARMCAbE90ng
+            DA:5,0,LWILTcvARcydjFFyo9qM0A
+            LF:4
+            LH:2
+            end_of_record
+            """)
         actual_result = self.get_lcov_report_content()
         assert expected_result == actual_result
 
@@ -88,22 +115,22 @@ class LcovTest(CoverageTest):
         self.assert_exists("data.lcov")
         expected_result = textwrap.dedent("""\
             SF:main_file.py
-            DA:1,1,7URou3io0zReBkk69lEb/Q
-            DA:4,1,ilhb4KUfytxtEuClijZPlQ
-            DA:2,0,Xqj6H1iz/nsARMCAbE90ng
-            DA:5,0,LWILTcvARcydjFFyo9qM0A
+            DA:1,1
+            DA:4,1
+            DA:2,0
+            DA:5,0
             LF:4
             LH:2
             end_of_record
             SF:test_file.py
-            DA:1,1,R5Rb4IzmjKRgY/vFFc1TRg
-            DA:2,1,E/tvV9JPVDhEcTCkgrwOFw
-            DA:4,1,GP08LPBYJq8EzYveHJy2qA
-            DA:5,1,MV+jSLi6PFEl+WatEAptog
-            DA:6,0,qyqd1mF289dg6oQAQHA+gQ
-            DA:7,0,nmEYd5F1KrxemgC9iVjlqg
-            DA:8,0,jodMK26WYDizOO1C7ekBbg
-            DA:9,0,LtxfKehkX8o4KvC5GnN52g
+            DA:1,1
+            DA:2,1
+            DA:4,1
+            DA:5,1
+            DA:6,0
+            DA:7,0
+            DA:8,0
+            DA:9,0
             LF:8
             LH:4
             end_of_record
@@ -128,10 +155,10 @@ class LcovTest(CoverageTest):
         self.assert_exists("coverage.lcov")
         expected_result = textwrap.dedent("""\
             SF:main_file.py
-            DA:1,1,4MDXMbvwQ3L7va1tsphVzw
-            DA:2,0,MuERA6EYyZNpKPqoJfzwkA
-            DA:3,0,sAyiiE6iAuPMte9kyd0+3g
-            DA:5,0,W/g8GJDAYJkSSurt59Mzfw
+            DA:1,1
+            DA:2,0
+            DA:3,0
+            DA:5,0
             LF:4
             LH:1
             BRDA:3,0,0,-
@@ -171,10 +198,10 @@ class LcovTest(CoverageTest):
         self.assert_exists("coverage.lcov")
         expected_result = textwrap.dedent("""\
             SF:main_file.py
-            DA:1,1,4MDXMbvwQ3L7va1tsphVzw
-            DA:2,0,MuERA6EYyZNpKPqoJfzwkA
-            DA:3,0,sAyiiE6iAuPMte9kyd0+3g
-            DA:5,0,W/g8GJDAYJkSSurt59Mzfw
+            DA:1,1
+            DA:2,0
+            DA:3,0
+            DA:5,0
             LF:4
             LH:1
             BRDA:3,0,0,-
@@ -183,12 +210,12 @@ class LcovTest(CoverageTest):
             BRH:0
             end_of_record
             SF:test_file.py
-            DA:1,1,9TxKIyoBtmhopmlbDNa8FQ
-            DA:2,1,E/tvV9JPVDhEcTCkgrwOFw
-            DA:4,1,C3s/c8C1Yd/zoNG1GnGexg
-            DA:5,1,9qPyWexYysgeKtB+YvuzAg
-            DA:6,0,LycuNcdqoUhPXeuXUTf5lA
-            DA:7,0,FPTWzd68bDx76HN7VHu1wA
+            DA:1,1
+            DA:2,1
+            DA:4,1
+            DA:5,1
+            DA:6,0
+            DA:7,0
             LF:6
             LH:4
             end_of_record
@@ -215,10 +242,10 @@ class LcovTest(CoverageTest):
         self.assert_exists("coverage.lcov")
         expected_result = textwrap.dedent("""\
             SF:main_file.py
-            DA:1,1,N4kbVOlkNI1rqOfCArBClw
-            DA:3,1,CmlqqPf0/H+R/p7/PLEXZw
-            DA:4,1,rE3mWnpoMq2W2sMETVk/uQ
-            DA:6,0,+Aov7ekIts7C96udNDVIIQ
+            DA:1,1
+            DA:3,1
+            DA:4,1
+            DA:6,0
             LF:4
             LH:3
             BRDA:6,0,0,-
@@ -252,7 +279,7 @@ class LcovTest(CoverageTest):
         else:
             expected_result = textwrap.dedent("""\
                 SF:__init__.py
-                DA:1,1,1B2M2Y8AsgTpgAmY7PhCfg
+                DA:1,1
                 end_of_record
                 """)
         actual_result = self.get_lcov_report_content()
@@ -294,10 +321,10 @@ class LcovTest(CoverageTest):
         cov.lcov_report()
         expected_result = textwrap.dedent("""\
             SF:runme.py
-            DA:1,1,nWfwsz0pRTEJrInVF+xNvQ
-            DA:3,1,uV4NoIauDo5LCti6agX9sg
-            DA:6,1,+PfQRgSChjQOGkA6MArMDg
-            DA:4,0,GR4ThLStnqpcZvm3alfRaA
+            DA:1,1
+            DA:3,1
+            DA:6,1
+            DA:4,0
             LF:4
             LH:3
             BRDA:4,0,0,-

--- a/tests/test_report_common.py
+++ b/tests/test_report_common.py
@@ -270,8 +270,8 @@ class ReportWithJinjaTest(CoverageTest):
         expected = textwrap.dedent("""\
             SF:good.j2
             DA:1,1
-            DA:3,1
             DA:2,0
+            DA:3,1
             LF:3
             LH:2
             end_of_record

--- a/tests/test_report_common.py
+++ b/tests/test_report_common.py
@@ -268,7 +268,6 @@ class ReportWithJinjaTest(CoverageTest):
         with open("coverage.lcov") as lcov:
             actual = lcov.read()
         expected = textwrap.dedent("""\
-            TN:
             SF:good.j2
             DA:1,1,FHs1rDakj9p/NAzMCu3Kgw
             DA:3,1,DGOyp8LEgI+3CcdFYw9uKQ

--- a/tests/test_report_common.py
+++ b/tests/test_report_common.py
@@ -269,9 +269,9 @@ class ReportWithJinjaTest(CoverageTest):
             actual = lcov.read()
         expected = textwrap.dedent("""\
             SF:good.j2
-            DA:1,1,FHs1rDakj9p/NAzMCu3Kgw
-            DA:3,1,DGOyp8LEgI+3CcdFYw9uKQ
-            DA:2,0,5iUbzxp9w7peeTPjJbvmBQ
+            DA:1,1
+            DA:3,1
+            DA:2,0
             LF:3
             LH:2
             end_of_record


### PR DESCRIPTION
Fixes #1846 (per my understanding of the lcov file format) and addresses several other issues. See individual commit logs for details. Should be ready to merge.

Changes from #1847:

- Verified that the lcov report for real partially covered code is sensible
- Adjusted handling of BRDA: based on what genhtml does with it on real code
- "File checksums" mode removed; now there's just a toggle for line checksums
- Passes `tox` locally with Python 3.8 through 3.12 and PyPy installed
- I *think* I have fixed the formatting issues you were concerned with; if I still didn't get it quite right please point me at specific sections you'd like formatted differently