### PR TITLE
Use fully-qualified names in autodoc directives

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -5,6 +5,7 @@ Other contributions, including writing code, updating docs, and submitting
 useful bug reports, have been made by:
 
 Abdeali Kothari
+Adam Turner
 Adi Roiban
 Agbonze O. Jeremiah
 Albertas Agejevas

--- a/doc/api_coverage.rst
+++ b/doc/api_coverage.rst
@@ -6,10 +6,7 @@
 The Coverage class
 ------------------
 
-.. module:: coverage
-    :noindex:
-
-.. autoclass:: Coverage
+.. autoclass:: coverage.Coverage
     :members:
     :exclude-members: sys_info
     :special-members: __init__

--- a/doc/api_coveragedata.rst
+++ b/doc/api_coveragedata.rst
@@ -8,9 +8,6 @@ The CoverageData class
 
 .. versionadded:: 4.0
 
-.. module:: coverage
-    :no-index:
-
-.. autoclass:: CoverageData
+.. autoclass:: coverage.CoverageData
     :members:
     :special-members: __init__

--- a/doc/api_exceptions.rst
+++ b/doc/api_exceptions.rst
@@ -6,11 +6,6 @@
 Coverage exceptions
 -------------------
 
-.. module:: coverage.exceptions
-
-.. autoclass:: CoverageException
-
 .. automodule:: coverage.exceptions
-    :no-index:
     :members:
-    :exclude-members: CoverageException
+    :member-order: bysource

--- a/doc/api_module.rst
+++ b/doc/api_module.rst
@@ -26,7 +26,7 @@ available by name.
 
 A string with the version of coverage.py, for example, ``"5.0b2"``.
 
-.. autoclass:: CoverageException
+.. autoexception:: coverage.CoverageException
 
 
 Starting coverage.py automatically
@@ -35,4 +35,4 @@ Starting coverage.py automatically
 This function is used to start coverage measurement automatically when Python
 starts.  See :ref:`subprocess` for details.
 
-.. autofunction:: process_startup
+.. autofunction:: coverage.process_startup

--- a/doc/api_plugin.rst
+++ b/doc/api_plugin.rst
@@ -9,33 +9,30 @@ Plug-in classes
 
 .. automodule:: coverage.plugin
 
-.. module:: coverage
-    :no-index:
-
 The CoveragePlugin class
 ------------------------
 
-.. autoclass:: CoveragePlugin
+.. autoclass:: coverage.CoveragePlugin
     :members:
     :member-order: bysource
 
 The FileTracer class
 --------------------
 
-.. autoclass:: FileTracer
+.. autoclass:: coverage.FileTracer
     :members:
     :member-order: bysource
 
 The FileReporter class
 ----------------------
 
-.. autoclass:: FileReporter
+.. autoclass:: coverage.FileReporter
     :members:
     :member-order: bysource
 
 The CodeRegion class
 --------------------
 
-.. autoclass:: CodeRegion
+.. autoclass:: coverage.CodeRegion
     :members:
     :member-order: bysource


### PR DESCRIPTION
This yields identical output, save for `api_exceptions` (where I contend the change is an improvement).

Previews:

* https://coverage--1882.org.readthedocs.build/en/1882/
* https://coverage--1882.org.readthedocs.build/en/1882/api_coverage.html
* https://coverage--1882.org.readthedocs.build/en/1882/api_coveragedata.html
* https://coverage--1882.org.readthedocs.build/en/1882/api_exceptions.html
* https://coverage--1882.org.readthedocs.build/en/1882/api_module.html
* https://coverage--1882.org.readthedocs.build/en/1882/api_plugin.html

Current:

* https://coverage.readthedocs.io/en/latest/api_coverage.html
* https://coverage.readthedocs.io/en/latest/api_coveragedata.html
* https://coverage.readthedocs.io/en/latest/api_exceptions.html
* https://coverage.readthedocs.io/en/latest/api_module.html
* https://coverage.readthedocs.io/en/latest/api_plugin.html

A