### PR TITLE
Introducing Coverage.py Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Code coverage measurement for Python.
 
 |  |kit| |license| |versions|
 |  |test-status| |quality-status| |docs| |metacov|
-|  |tidelift| |sponsor| |stars| |mastodon-coveragepy| |mastodon-nedbat|
+|  |tidelift| |sponsor| |stars| |mastodon-coveragepy| |mastodon-nedbat| |gurubase|
 
 Coverage.py measures code coverage, typically during test execution. It uses
 the code analysis tools and tracing hooks provided in the Python standard
@@ -160,3 +160,7 @@ Licensed under the `Apache 2.0 License`_.  For details, see `NOTICE.txt`_.
 .. |sponsor| image:: https://img.shields.io/badge/%E2%9D%A4-Sponsor%20me-brightgreen?style=flat&logo=GitHub
     :target: https://github.com/sponsors/nedbat
     :alt: Sponsor me on GitHub
+
+.. |gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Coverage.py%20Guru-006BFF
+    :target: https://gurubase.io/g/coverage-py
+    :alt: Coverage.py Guru on Gurubase.io


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Coverage.py Guru](https://gurubase.io/g/coverage-py) to Gurubase. Coverage.py Guru uses the data from this repo and data from the [docs](https://coverage.readthedocs.io/en/7.6.4/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Coverage.py Guru", which highlights that Coverage.py now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Coverage.py Guru in Gurubase, just let me know that's totally fine.