### PR TITLE
Limit test suite Workflow to only run on changes to Python files

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -8,7 +8,11 @@ on:
     branches:
       - master
       - nedbat/*
+    paths:
+      - '**/*.py'
   pull_request:
+    paths:
+      - '**/*.py'
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Add a filter to `testsuite.yml` to only run when `.py` files are changed.

This should cleanly coexist with the existing branch filter:
> If you define both `branches`/`branches-ignore` and `paths/paths-ignore`, the workflow will only run when both filters are satisfied.
> \- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

ref: https://discord.com/channels/267624335836053506/1253355750684753950/1298279250830557236

