### PR TITLE
Make branch coverage accessible via the API

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -926,7 +926,7 @@ class Coverage(TConfigurable):
         coverage data.
 
         """
-        analysis = self._analyze(morf)
+        analysis = self.analyze(morf)
         return (
             analysis.filename,
             sorted(analysis.statements),
@@ -935,7 +935,7 @@ class Coverage(TConfigurable):
             analysis.missing_formatted(),
         )
 
-    def _analyze(self, morf: TMorf) -> Analysis:
+    def analyze(self, morf: TMorf) -> Analysis:
         """Analyze a module or file.  Private for now."""
         self._init()
         self._post_init()

--- a/coverage/report_core.py
+++ b/coverage/report_core.py
@@ -98,7 +98,7 @@ def get_analysis_to_report(
 
     for fr, morf in sorted(fr_morfs):
         try:
-            analysis = coverage._analyze(morf)
+            analysis = coverage.analyze(morf)
         except NotPython:
             # Only report errors for .py files, and only if we didn't
             # explicitly suppress those errors.

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -55,4 +55,5 @@ only.  :ref:`dbschema` explains more.
     api_module
     api_plugin
     api_coveragedata
+    api_analysis
     dbschema

--- a/doc/api_analysis.rst
+++ b/doc/api_analysis.rst
@@ -1,0 +1,10 @@
+.. Licensed under the Apache License: http://www.apache.org/licenses/LICENSE-2.0
+.. For details: https://github.com/nedbat/coveragepy/blob/master/NOTICE.txt
+
+.. _api_analysis:
+
+The Analysis class
+------------------
+
+.. autoclass:: coverage.results.Analysis
+    :members: branch_stats

--- a/tests/coveragetest.py
+++ b/tests/coveragetest.py
@@ -197,7 +197,7 @@ class CoverageTest(
         del sys.modules[modname]
 
         # Get the analysis results, and check that they are right.
-        analysis = cov._analyze(mod)
+        analysis = cov.analyze(mod)
         statements = sorted(analysis.statements)
         if lines:
             if isinstance(lines[0], int):
@@ -493,7 +493,7 @@ class CoverageTest(
         assert self.last_module_name is not None
         filename = self.last_module_name + ".py"
         fr = cov._get_file_reporter(filename)
-        arcs_executed = cov._analyze(filename).arcs_executed
+        arcs_executed = cov.analyze(filename).arcs_executed
         return fr.missing_arc_description(start, end, arcs_executed)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1016,7 +1016,7 @@ class AnalysisTest(CoverageTest):
         # Import the Python file, executing it.
         self.start_import_stop(cov, "missing")
 
-        nums = cov._analyze("missing.py").numbers
+        nums = cov.analyze("missing.py").numbers
         assert nums.n_files == 1
         assert nums.n_statements == 7
         assert nums.n_excluded == 1

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -410,7 +410,7 @@ class GoodFileTracerTest(FileTracerTest):
         # The way plugin2 works, a file named foo_7.html will be claimed to
         # have 7 lines in it.  If render() was called with line number 4,
         # then the plugin will claim that lines 4 and 5 were executed.
-        analysis = cov._analyze("foo_7.html")
+        analysis = cov.analyze("foo_7.html")
         assert analysis.statements == {1, 2, 3, 4, 5, 6, 7}
         # Plugins don't do branch coverage yet.
         assert analysis.has_arcs is True


### PR DESCRIPTION
fixes https://github.com/nedbat/coveragepy/issues/1888

one edit from above proposal is I exposed `branch_stats` from the `Analysis` class as it has the (total_exits, taken_exits) which is the info needed and is already public.

another note is Im not entirely sure how to test / view the changes to the `.rst` files for https://coverage.readthedocs.io/ so any advice here would be appreciated. Thanks!