### PR TITLE
Add py3-none-any wheels to the distribution artefacts

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           python -m pip install -r requirements/kit.pip
 
-      - name: "Build wheels"
+      - name: "Build binary wheels"
         env:
           CIBW_BUILD: ${{ matrix.py }}*-*
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -173,7 +173,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
-      - name: "List wheels"
+      - name: "List binary wheels"
         run: |
           ls -al wheelhouse/
 
@@ -181,15 +181,15 @@ jobs:
         run: |
           python -m twine check wheelhouse/*
 
-      - name: "Upload wheels"
+      - name: "Upload binary wheels"
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: dist-${{ env.MATRIX_ID }}
           path: wheelhouse/*.whl
           retention-days: 7
 
-  sdist:
-    name: "Source distribution"
+  non-binary:
+    name: "Non-binary artifacts"
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
@@ -208,23 +208,25 @@ jobs:
         run: |
           python -m pip install -r requirements/kit.pip
 
-      - name: "Build sdist"
+      - name: "Build non-binary artifacts"
+        env:
+          COVERAGE_DISABLE_EXTENSION: 1
         run: |
           python -m build
 
-      - name: "List sdist"
+      - name: "List non-binary artifacts"
         run: |
           ls -al dist/
 
-      - name: "Check sdist"
+      - name: "Check non-binary artifacts"
         run: |
           python -m twine check dist/*
 
-      - name: "Upload sdist"
+      - name: "Upload non-binary artifacts"
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
-          name: dist-sdist
-          path: dist/*.tar.gz
+          name: dist-non-binary
+          path: dist/*
           retention-days: 7
 
   pypy:

--- a/setup.py
+++ b/setup.py
@@ -170,9 +170,11 @@ class ve_build_ext(build_ext):
 
 
 # There are a few reasons we might not be able to compile the C extension.
-# Figure out if we should attempt the C extension or not.
+# Figure out if we should attempt the C extension or not. Define
+# COVERAGE_DISABLE_EXTENSION in the build environment to explicitly disable the
+# extension.
 
-compile_extension = True
+compile_extension = os.getenv("COVERAGE_DISABLE_EXTENSION", None) is None
 
 if "__pypy__" in sys.builtin_module_names:
     # Pypy can't compile C extensions


### PR DESCRIPTION
Fixes #1912.

* Adds support for generating py3-none-any wheels. If the user has `COVERAGE_DISABLE_EXTENSION` defined in their environment, no attempt will be made to compile a binary wheel, even if the platform would otherwise support building the binary extension
* Adds a py3-none-any artefact to the build products of a normal build. A wheel was already being compiled as part of the sdist step; this ensures that (a) the wheel is a py3-none-any wheel, and (b) it's included in the release artefacts.