### PR TITLE
PyPy3.11 test fixes

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -123,7 +123,7 @@ class PythonParserTest(PythonParserTestBase):
         )
     ])
     def test_not_python(self, text: str) -> None:
-        msg = r"Couldn't parse '<code>' as Python source: '.*' at line \d+"
+        msg = r"Couldn't parse '<code>' as Python source: ['\"].*['\"] at line \d+"
         with pytest.raises(NotPython, match=msg):
             _ = self.parse_text(text)
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ install_command = python -m pip install -U {opts} {packages}
 
 passenv = *
 setenv =
-    pypy3{,9,10}: COVERAGE_TEST_CORES=pytrace
+    pypy3{,9,10,11}: COVERAGE_TEST_CORES=pytrace
     # For some tests, we need .pyc files written in the current directory,
     # so override any local setting.
     PYTHONPYCACHEPREFIX=


### PR DESCRIPTION
Fix a regex in a single test, and add `pypy311` to `tox.ini` targets using `pytrace` only.