### PR TITLE
Improve Warning Suppression Performance by Using `set`

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -258,7 +258,7 @@ class Coverage(TConfigurable):
         self._warn_no_data = True
         self._warn_unimported_source = True
         self._warn_preimported_source = check_preimported
-        self._no_warn_slugs: list[str] = []
+        self._no_warn_slugs: set[str] = []
         self._messages = messages
 
         # A record of all the warnings that have been issued.
@@ -438,7 +438,7 @@ class Coverage(TConfigurable):
 
         """
         if not self._no_warn_slugs:
-            self._no_warn_slugs = list(self.config.disable_warnings)
+            self._no_warn_slugs = set(self.config.disable_warnings)
 
         if slug in self._no_warn_slugs:
             # Don't issue the warning
@@ -453,7 +453,7 @@ class Coverage(TConfigurable):
 
         if once:
             assert slug is not None
-            self._no_warn_slugs.append(slug)
+            self._no_warn_slugs.add(slug)
 
     def _message(self, msg: str) -> None:
         """Write a message to the user, if configured to do so."""

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -258,7 +258,7 @@ class Coverage(TConfigurable):
         self._warn_no_data = True
         self._warn_unimported_source = True
         self._warn_preimported_source = check_preimported
-        self._no_warn_slugs: set[str] = []
+        self._no_warn_slugs: set[str] = set()
         self._messages = messages
 
         # A record of all the warnings that have been issued.


### PR DESCRIPTION
## Description

This PR optimizes the way warning suppression is handled by changing `_no_warn_slugs` from a `list` to a `set`. This improves performance when checking if a warning should be suppressed, reducing lookup complexity from O(n) to O(1) on average. Additionally, using a `set` ensures uniqueness, preventing duplicate warning slugs from being added.

## Changes

- Replaced `list[str]` with `set[str]` for `_no_warn_slugs`.
- Updated initialization to use `set(self.config.disable_warnings)`.
- Replaced `.append(slug)` with `.add(slug)` to maintain set behavior.

## Why?

- Improves lookup efficiency.
- Ensures uniqueness of suppressed warning slugs.
- Reduces potential performance overhead in cases with many warnings.