### PR TITLE
Support `.coveragerc.toml` for configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Unreleased
 - New feature: coverage.py now supports :file:`.coveragerc.toml` configuration
   files. These files use TOML syntax and take priority over
   :file:`pyproject.toml` but lower priority than :file:`.coveragerc` files.
+  Closes `issue 1643`_ thanks to `Olena Yefymenko <pull 1952_>`_.
 
 - The .pth file we install was done incorrectly and didn't work when using
   the source wheel (`py3-none-any`).  This is now fixed. Thanks, `Henry
@@ -36,6 +37,8 @@ Unreleased
   3.10). The second and third of these are not needed and will eventually be
   removed.
 
+.. _issue 1643: https://github.com/coveragepy/coveragepy/issues/1643
+.. _pull 1952: https://github.com/coveragepy/coveragepy/pull/1952
 .. _pull 2100: https://github.com/coveragepy/coveragepy/pull/2100
 
 .. start-releases

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,9 +181,9 @@ Version 7.10.7 — 2025-09-21
   LCOV reports could take far too long due to some quadratic behavior when
   creating the function and class index pages.  This is now fixed, closing
   `issue 2048`_.  Thanks to Daniel Diniz for help diagnosing the problem.
-- New feature: coverage.py now supports `.coveragerc.toml` configuration files.
+- New feature: coverage.py now supports :file:`.coveragerc.toml` configuration files.
   These files use TOML syntax and take priority over `pyproject.toml` but lower
-  priority than `.coveragerc` files.
+  priority than :file:`.coveragerc` files.
 
 - Most warnings and a few errors now have links to a page in the docs
   explaining the specific message.  Closes `issue 1921`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,8 +182,8 @@ Version 7.10.7 — 2025-09-21
   creating the function and class index pages.  This is now fixed, closing
   `issue 2048`_.  Thanks to Daniel Diniz for help diagnosing the problem.
 - New feature: coverage.py now supports :file:`.coveragerc.toml` configuration
-  files. These files use TOML syntax and take priority over :file:`pyproject.toml`
-  but lower priority than :file:`.coveragerc` files.
+  files. These files use TOML syntax and take priority over
+  :file:`pyproject.toml` but lower priority than :file:`.coveragerc` files.
 
 - Most warnings and a few errors now have links to a page in the docs
   explaining the specific message.  Closes `issue 1921`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,6 +181,9 @@ Version 7.10.7 — 2025-09-21
   LCOV reports could take far too long due to some quadratic behavior when
   creating the function and class index pages.  This is now fixed, closing
   `issue 2048`_.  Thanks to Daniel Diniz for help diagnosing the problem.
+- New feature: coverage.py now supports `.coveragerc.toml` configuration files.
+  These files use TOML syntax and take priority over `pyproject.toml` but lower
+  priority than `.coveragerc` files.
 
 - Most warnings and a few errors now have links to a page in the docs
   explaining the specific message.  Closes `issue 1921`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
+- New feature: coverage.py now supports :file:`.coveragerc.toml` configuration
+  files. These files use TOML syntax and take priority over
+  :file:`pyproject.toml` but lower priority than :file:`.coveragerc` files.
+
 - The .pth file we install was done incorrectly and didn't work when using
   the source wheel (`py3-none-any`).  This is now fixed. Thanks, `Henry
   Schreiner <pull 2100_>`_.
@@ -181,9 +185,6 @@ Version 7.10.7 — 2025-09-21
   LCOV reports could take far too long due to some quadratic behavior when
   creating the function and class index pages.  This is now fixed, closing
   `issue 2048`_.  Thanks to Daniel Diniz for help diagnosing the problem.
-- New feature: coverage.py now supports :file:`.coveragerc.toml` configuration
-  files. These files use TOML syntax and take priority over
-  :file:`pyproject.toml` but lower priority than :file:`.coveragerc` files.
 
 - Most warnings and a few errors now have links to a page in the docs
   explaining the specific message.  Closes `issue 1921`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,9 +181,9 @@ Version 7.10.7 — 2025-09-21
   LCOV reports could take far too long due to some quadratic behavior when
   creating the function and class index pages.  This is now fixed, closing
   `issue 2048`_.  Thanks to Daniel Diniz for help diagnosing the problem.
-- New feature: coverage.py now supports :file:`.coveragerc.toml` configuration files.
-  These files use TOML syntax and take priority over :file:`pyproject.toml` but lower
-  priority than :file:`.coveragerc` files.
+- New feature: coverage.py now supports :file:`.coveragerc.toml` configuration
+  files. These files use TOML syntax and take priority over :file:`pyproject.toml`
+  but lower priority than :file:`.coveragerc` files.
 
 - Most warnings and a few errors now have links to a page in the docs
   explaining the specific message.  Closes `issue 1921`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,7 +182,7 @@ Version 7.10.7 — 2025-09-21
   creating the function and class index pages.  This is now fixed, closing
   `issue 2048`_.  Thanks to Daniel Diniz for help diagnosing the problem.
 - New feature: coverage.py now supports :file:`.coveragerc.toml` configuration files.
-  These files use TOML syntax and take priority over `pyproject.toml` but lower
+  These files use TOML syntax and take priority over :file:`pyproject.toml` but lower
   priority than :file:`.coveragerc` files.
 
 - Most warnings and a few errors now have links to a page in the docs

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -188,6 +188,7 @@ Nils Kattenbeck
 Noel O'Boyle
 Oleg Höfling
 Oleh Krehel
+Olena Yefymenko
 Olivier Grisel
 Ori Avtalion
 Pablo Carballo

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -658,6 +658,7 @@ def config_files_to_try(config_file: bool | str) -> list[tuple[str, bool, bool]]
     assert isinstance(config_file, str)
     files_to_try = [
         (config_file, True, specified_file),
+        (".coveragerc.toml", True, False),
         ("setup.cfg", False, False),
         ("tox.ini", False, False),
         ("pyproject.toml", False, False),

--- a/coverage/tomlconfig.py
+++ b/coverage/tomlconfig.py
@@ -84,6 +84,8 @@ class TomlConfigParser:
 
         """
         prefixes = ["tool.coverage."]
+        if self.our_file:
+            prefixes.append("")
         for prefix in prefixes:
             real_section = prefix + section
             parts = real_section.split(".")

--- a/doc/cog_helpers.py
+++ b/doc/cog_helpers.py
@@ -93,7 +93,7 @@ def show_configs(ini, toml):
     print(".. tabs::\n")
     for name, syntax, text in [
         (".coveragerc", "ini", ini),
-        ("pyproject.toml", "toml", toml),
+        (".coveragerc.toml or pyproject.toml", "toml", toml),
         ("setup.cfg or tox.ini", "ini", ini2),
     ]:
         print(f"    .. code-tab:: {syntax}")

--- a/doc/cog_helpers.py
+++ b/doc/cog_helpers.py
@@ -76,7 +76,7 @@ def show_configs(ini, toml):
     The equivalence is checked for accuracy, and the process fails if there's
     a mismatch.
 
-    A three-tabbed box will be produced.
+    A four-tabbed box will be produced.
     """
     ini, ini_vals = _read_config(ini, "covrc")
     toml, toml_vals = _read_config(toml, "covrc.toml")
@@ -89,11 +89,15 @@ def show_configs(ini, toml):
             )
 
     ini2 = re.sub(r"(?m)^\[", "[coverage:", ini)
+    toml2 = "# You can also use sections like [tool.coverage.run]\n"
+    toml2 += toml.replace("[tool.coverage.", "[")
+
     print()
     print(".. tabs::\n")
     for name, syntax, text in [
+        ("pyproject.toml", "toml", toml),
         (".coveragerc", "ini", ini),
-        (".coveragerc.toml or pyproject.toml", "toml", toml),
+        (".coveragerc.toml", "toml", toml2),
         ("setup.cfg or tox.ini", "ini", ini2),
     ]:
         print(f"    .. code-tab:: {syntax}")

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -39,8 +39,9 @@ environment variable.
 
 If ``.coveragerc`` doesn't exist and another file hasn't been specified, then
 coverage.py will look for settings in other common configuration files, in this
-order: :file:`.coveragerc.toml`, :file:`setup.cfg`, :file:`tox.ini`, or :file:`pyproject.toml`.  The first file found with
-coverage.py settings will be used and other files won't be consulted.
+order: :file:`.coveragerc.toml`, :file:`setup.cfg`, :file:`tox.ini`, or
+:file:`pyproject.toml`.  The first file found with coverage.py settings will be
+used and other files won't be consulted.
 
 Coverage.py will read from "pyproject.toml" if TOML support is available,
 either because you are running on Python 3.11 or later, or because you

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -39,7 +39,7 @@ environment variable.
 
 If ``.coveragerc`` doesn't exist and another file hasn't been specified, then
 coverage.py will look for settings in other common configuration files, in this
-order: .coveragerc.toml, setup.cfg, tox.ini, or pyproject.toml.  The first file found with
+order: :file:`.coveragerc.toml`, :file:`setup.cfg`, :file:`tox.ini`, or :file:`pyproject.toml`.  The first file found with
 coverage.py settings will be used and other files won't be consulted.
 
 Coverage.py will read from "pyproject.toml" if TOML support is available,

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -257,7 +257,7 @@ Here's a sample configuration file, in each syntax:
         [coverage:html]
         directory = coverage_html_report
 
-.. [[[end]]] (sum: HU1Z62mvRK)
+.. [[[end]]] (sum: FvgoIIyfXR)
 
 
 The specific configuration settings are described below.  Many sections and
@@ -624,7 +624,7 @@ equivalent when combining data from different machines:
             /jenkins/build/*/src
             c:\myproj\src
 
-.. [[[end]]] (sum: oHSl8SGiMT)
+.. [[[end]]] (sum: bV+PjKu+HS)
 
 
 The names of the entries ("source" in this example) are ignored, you may choose

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -39,7 +39,7 @@ environment variable.
 
 If ``.coveragerc`` doesn't exist and another file hasn't been specified, then
 coverage.py will look for settings in other common configuration files, in this
-order: setup.cfg, tox.ini, or pyproject.toml.  The first file found with
+order: .coveragerc.toml, setup.cfg, tox.ini, or pyproject.toml.  The first file found with
 coverage.py settings will be used and other files won't be consulted.
 
 Coverage.py will read from "pyproject.toml" if TOML support is available,
@@ -199,7 +199,7 @@ Here's a sample configuration file, in each syntax:
         directory = coverage_html_report
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.run]
         branch = true
@@ -606,7 +606,7 @@ equivalent when combining data from different machines:
             c:\myproj\src
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.paths]
         source = [

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -170,6 +170,36 @@ Here's a sample configuration file, in each syntax:
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.run]
+        branch = true
+
+        [tool.coverage.report]
+        # Regexes for lines to exclude from consideration
+        exclude_also = [
+            # Don't complain about missing debug-only code:
+            "def __repr__",
+            "if self\\.debug",
+
+            # Don't complain if tests don't hit defensive assertion code:
+            "raise AssertionError",
+            "raise NotImplementedError",
+
+            # Don't complain if non-runnable code isn't run:
+            "if 0:",
+            "if __name__ == .__main__.:",
+
+            # Don't complain about abstract methods, they aren't run:
+            "@(abc\\.)?abstractmethod",
+            ]
+
+        ignore_errors = true
+
+        [tool.coverage.html]
+        directory = "coverage_html_report"
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -200,12 +230,13 @@ Here's a sample configuration file, in each syntax:
         directory = coverage_html_report
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.run]
+        # You can also use sections like [tool.coverage.run]
+        [run]
         branch = true
 
-        [tool.coverage.report]
+        [report]
         # Regexes for lines to exclude from consideration
         exclude_also = [
             # Don't complain about missing debug-only code:
@@ -226,7 +257,7 @@ Here's a sample configuration file, in each syntax:
 
         ignore_errors = true
 
-        [tool.coverage.html]
+        [html]
         directory = "coverage_html_report"
 
     .. code-tab:: ini
@@ -258,7 +289,7 @@ Here's a sample configuration file, in each syntax:
         [coverage:html]
         directory = coverage_html_report
 
-.. [[[end]]] (sum: FvgoIIyfXR)
+.. [[[end]]] (sum: qYCtIxMe+3)
 
 
 The specific configuration settings are described below.  Many sections and
@@ -597,6 +628,16 @@ equivalent when combining data from different machines:
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.paths]
+        source = [
+            "src/",
+            "/jenkins/build/*/src",
+            "c:\\myproj\\src",
+            ]
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -607,9 +648,10 @@ equivalent when combining data from different machines:
             c:\myproj\src
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.paths]
+        # You can also use sections like [tool.coverage.run]
+        [paths]
         source = [
             "src/",
             "/jenkins/build/*/src",
@@ -625,7 +667,7 @@ equivalent when combining data from different machines:
             /jenkins/build/*/src
             c:\myproj\src
 
-.. [[[end]]] (sum: bV+PjKu+HS)
+.. [[[end]]] (sum: Aq4877/XV0)
 
 
 The names of the entries ("source" in this example) are ignored, you may choose

--- a/doc/contexts.rst
+++ b/doc/contexts.rst
@@ -97,7 +97,7 @@ The ``[run] dynamic_context`` setting has only one option now.  Set it to
         dynamic_context = test_function
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.run]
         dynamic_context = "test_function"
@@ -108,7 +108,7 @@ The ``[run] dynamic_context`` setting has only one option now.  Set it to
         [coverage:run]
         dynamic_context = test_function
 
-.. [[[end]]] (sum: dZTDYjHw71)
+.. [[[end]]] (sum: Hn9VZdxp00)
 
 Each test function you run will be considered a separate dynamic context, and
 coverage data will be segregated for each.  A test function is any function

--- a/doc/contexts.rst
+++ b/doc/contexts.rst
@@ -90,6 +90,12 @@ The ``[run] dynamic_context`` setting has only one option now.  Set it to
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.run]
+        dynamic_context = "test_function"
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -97,9 +103,10 @@ The ``[run] dynamic_context`` setting has only one option now.  Set it to
         dynamic_context = test_function
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.run]
+        # You can also use sections like [tool.coverage.run]
+        [run]
         dynamic_context = "test_function"
 
     .. code-tab:: ini
@@ -108,7 +115,7 @@ The ``[run] dynamic_context`` setting has only one option now.  Set it to
         [coverage:run]
         dynamic_context = test_function
 
-.. [[[end]]] (sum: Hn9VZdxp00)
+.. [[[end]]] (sum: G1Fc1tVhgd)
 
 Each test function you run will be considered a separate dynamic context, and
 coverage data will be segregated for each.  A test function is any function

--- a/doc/excluding.rst
+++ b/doc/excluding.rst
@@ -145,7 +145,7 @@ all of them by adding a regex to the exclusion list:
             def __repr__
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.report]
         exclude_also = [
@@ -159,7 +159,7 @@ all of them by adding a regex to the exclusion list:
         exclude_also =
             def __repr__
 
-.. [[[end]]] (sum: 8+cOvxKPvv)
+.. [[[end]]] (sum: QqurBI2O5i)
 
 For example, here's a list of exclusions I've used:
 
@@ -216,7 +216,7 @@ For example, here's a list of exclusions I've used:
             @(abc\.)?abstractmethod
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.report]
         exclude_also = [
@@ -248,7 +248,7 @@ For example, here's a list of exclusions I've used:
             class .*\bProtocol\):
             @(abc\.)?abstractmethod
 
-.. [[[end]]] (sum: ZQsgnt0nES)
+.. [[[end]]] (sum: z5MhXz2dFm)
 
 The :ref:`config_report_exclude_also` option adds regexes to the built-in
 default list so that you can add your own exclusions.  The older
@@ -319,7 +319,7 @@ Here are some examples:
             \A(?s:.*# pragma: exclude file.*)\Z
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.report]
         exclude_also = [
@@ -343,7 +343,7 @@ Here are some examples:
             ; 3. A pragma comment that excludes an entire file:
             \A(?s:.*# pragma: exclude file.*)\Z
 
-.. [[[end]]] (sum: xG6Bmtmh06)
+.. [[[end]]] (sum: 3EupeurnDP)
 
 The first regex matches a specific except line followed by a specific function
 call.  Both lines must be present for the exclusion to take effect. Note that

--- a/doc/excluding.rst
+++ b/doc/excluding.rst
@@ -137,6 +137,14 @@ all of them by adding a regex to the exclusion list:
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.report]
+        exclude_also = [
+            "def __repr__",
+        ]
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -145,9 +153,10 @@ all of them by adding a regex to the exclusion list:
             def __repr__
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.report]
+        # You can also use sections like [tool.coverage.run]
+        [report]
         exclude_also = [
             "def __repr__",
         ]
@@ -159,7 +168,7 @@ all of them by adding a regex to the exclusion list:
         exclude_also =
             def __repr__
 
-.. [[[end]]] (sum: QqurBI2O5i)
+.. [[[end]]] (sum: pma7Vgh8a0)
 
 For example, here's a list of exclusions I've used:
 
@@ -199,6 +208,23 @@ For example, here's a list of exclusions I've used:
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.report]
+        exclude_also = [
+            'def __repr__',
+            'if self.debug:',
+            'if settings.DEBUG',
+            'raise AssertionError',
+            'raise NotImplementedError',
+            'if 0:',
+            'if __name__ == .__main__.:',
+            'if TYPE_CHECKING:',
+            'class .*\bProtocol\):',
+            '@(abc\.)?abstractmethod',
+        ]
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -216,9 +242,10 @@ For example, here's a list of exclusions I've used:
             @(abc\.)?abstractmethod
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.report]
+        # You can also use sections like [tool.coverage.run]
+        [report]
         exclude_also = [
             'def __repr__',
             'if self.debug:',
@@ -248,7 +275,7 @@ For example, here's a list of exclusions I've used:
             class .*\bProtocol\):
             @(abc\.)?abstractmethod
 
-.. [[[end]]] (sum: z5MhXz2dFm)
+.. [[[end]]] (sum: QV2NECVQ1X)
 
 The :ref:`config_report_exclude_also` option adds regexes to the built-in
 default list so that you can add your own exclusions.  The older
@@ -306,6 +333,19 @@ Here are some examples:
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.report]
+        exclude_also = [
+            # 1. Exclude an except clause of a specific form:
+            'except ValueError:\n\s*assume\(False\)',
+            # 2. Comments to turn coverage on and off:
+            'no cover: start(?s:.)*?no cover: stop',
+            # 3. A pragma comment that excludes an entire file:
+            '\A(?s:.*# pragma: exclude file.*)\Z',
+        ]
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -319,9 +359,10 @@ Here are some examples:
             \A(?s:.*# pragma: exclude file.*)\Z
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.report]
+        # You can also use sections like [tool.coverage.run]
+        [report]
         exclude_also = [
             # 1. Exclude an except clause of a specific form:
             'except ValueError:\n\s*assume\(False\)',
@@ -343,7 +384,7 @@ Here are some examples:
             ; 3. A pragma comment that excludes an entire file:
             \A(?s:.*# pragma: exclude file.*)\Z
 
-.. [[[end]]] (sum: 3EupeurnDP)
+.. [[[end]]] (sum: LAn0Y4yP/X)
 
 The first regex matches a specific except line followed by a specific function
 call.  Both lines must be present for the exclusion to take effect. Note that

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -191,7 +191,7 @@ file:
         disable_warnings = no-data-collected
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.run]
         disable_warnings = ["no-data-collected"]
@@ -202,4 +202,4 @@ file:
         [coverage:run]
         disable_warnings = no-data-collected
 
-.. [[[end]]] (sum: SJKFvPoXO2)
+.. [[[end]]] (sum: lZkA6+wMrL)

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -184,6 +184,12 @@ file:
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.run]
+        disable_warnings = ["no-data-collected"]
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -191,9 +197,10 @@ file:
         disable_warnings = no-data-collected
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.run]
+        # You can also use sections like [tool.coverage.run]
+        [run]
         disable_warnings = ["no-data-collected"]
 
     .. code-tab:: ini
@@ -202,4 +209,4 @@ file:
         [coverage:run]
         disable_warnings = no-data-collected
 
-.. [[[end]]] (sum: lZkA6+wMrL)
+.. [[[end]]] (sum: 29eQyqSCXt)

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -72,7 +72,7 @@ a coverage.py plug-in called ``something.plugin``.
                something.plugin
 
        .. code-tab:: toml
-           :caption: pyproject.toml
+           :caption: .coveragerc.toml or pyproject.toml
 
            [tool.coverage.run]
            plugins = [ "something.plugin" ]
@@ -84,7 +84,7 @@ a coverage.py plug-in called ``something.plugin``.
            plugins =
                something.plugin
 
-   .. [[[end]]] (sum: boZjI9S8MZ)
+   .. [[[end]]] (sum: 7iXDMHhoLG)
 
 #. If the plug-in needs its own configuration, you can add those settings in
    the .coveragerc file in a section named for the plug-in:
@@ -114,7 +114,7 @@ a coverage.py plug-in called ``something.plugin``.
            option2 = abc.foo
 
        .. code-tab:: toml
-           :caption: pyproject.toml
+           :caption: .coveragerc.toml or pyproject.toml
 
            [tool.coverage.something.plugin]
            option1 = true
@@ -127,7 +127,7 @@ a coverage.py plug-in called ``something.plugin``.
            option1 = True
            option2 = abc.foo
 
-   .. [[[end]]] (sum: tpARXb5/bH)
+   .. [[[end]]] (sum: QeURQmX7B1)
 
    Check the documentation for the plug-in for details on the options it takes.
 

--- a/doc/plugins.rst
+++ b/doc/plugins.rst
@@ -64,6 +64,12 @@ a coverage.py plug-in called ``something.plugin``.
 
    .. tabs::
 
+       .. code-tab:: toml
+           :caption: pyproject.toml
+
+           [tool.coverage.run]
+           plugins = [ "something.plugin" ]
+
        .. code-tab:: ini
            :caption: .coveragerc
 
@@ -72,9 +78,10 @@ a coverage.py plug-in called ``something.plugin``.
                something.plugin
 
        .. code-tab:: toml
-           :caption: .coveragerc.toml or pyproject.toml
+           :caption: .coveragerc.toml
 
-           [tool.coverage.run]
+           # You can also use sections like [tool.coverage.run]
+           [run]
            plugins = [ "something.plugin" ]
 
        .. code-tab:: ini
@@ -84,7 +91,7 @@ a coverage.py plug-in called ``something.plugin``.
            plugins =
                something.plugin
 
-   .. [[[end]]] (sum: 7iXDMHhoLG)
+   .. [[[end]]] (sum: 7exEgyBxea)
 
 #. If the plug-in needs its own configuration, you can add those settings in
    the .coveragerc file in a section named for the plug-in:
@@ -106,6 +113,13 @@ a coverage.py plug-in called ``something.plugin``.
 
    .. tabs::
 
+       .. code-tab:: toml
+           :caption: pyproject.toml
+
+           [tool.coverage.something.plugin]
+           option1 = true
+           option2 = "abc.foo"
+
        .. code-tab:: ini
            :caption: .coveragerc
 
@@ -114,9 +128,10 @@ a coverage.py plug-in called ``something.plugin``.
            option2 = abc.foo
 
        .. code-tab:: toml
-           :caption: .coveragerc.toml or pyproject.toml
+           :caption: .coveragerc.toml
 
-           [tool.coverage.something.plugin]
+           # You can also use sections like [tool.coverage.run]
+           [something.plugin]
            option1 = true
            option2 = "abc.foo"
 
@@ -127,7 +142,7 @@ a coverage.py plug-in called ``something.plugin``.
            option1 = True
            option2 = abc.foo
 
-   .. [[[end]]] (sum: QeURQmX7B1)
+   .. [[[end]]] (sum: xPc0F1izoA)
 
    Check the documentation for the plug-in for details on the options it takes.
 

--- a/doc/source.rst
+++ b/doc/source.rst
@@ -115,7 +115,7 @@ current directory:
             utils/tirefire.py
 
     .. code-tab:: toml
-        :caption: pyproject.toml
+        :caption: .coveragerc.toml or pyproject.toml
 
         [tool.coverage.run]
         omit = [
@@ -139,7 +139,7 @@ current directory:
             # omit this single file
             utils/tirefire.py
 
-.. [[[end]]] (sum: hK0nQ8wMeg)
+.. [[[end]]] (sum: 6pS//9tCe4)
 
 The ``source``, ``include``, and ``omit`` values all work together to determine
 the source that will be measured.

--- a/doc/source.rst
+++ b/doc/source.rst
@@ -102,6 +102,19 @@ current directory:
 
 .. tabs::
 
+    .. code-tab:: toml
+        :caption: pyproject.toml
+
+        [tool.coverage.run]
+        omit = [
+            # omit anything in a .local directory anywhere
+            "*/.local/*",
+            # omit everything in /usr
+            "/usr/*",
+            # omit this single file
+            "utils/tirefire.py",
+            ]
+
     .. code-tab:: ini
         :caption: .coveragerc
 
@@ -115,9 +128,10 @@ current directory:
             utils/tirefire.py
 
     .. code-tab:: toml
-        :caption: .coveragerc.toml or pyproject.toml
+        :caption: .coveragerc.toml
 
-        [tool.coverage.run]
+        # You can also use sections like [tool.coverage.run]
+        [run]
         omit = [
             # omit anything in a .local directory anywhere
             "*/.local/*",
@@ -139,7 +153,7 @@ current directory:
             # omit this single file
             utils/tirefire.py
 
-.. [[[end]]] (sum: 6pS//9tCe4)
+.. [[[end]]] (sum: r3vqCJZ28r)
 
 The ``source``, ``include``, and ``omit`` values all work together to determine
 the source that will be measured.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1035,6 +1035,27 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
         with pytest.raises(ConfigError, match="No option 'foo' in section: 'tool.coverage.run'"):
             config.get("run", "foo")
 
+    def test_coveragerc_toml_priority(self) -> None:
+        """Test that .coveragerc.toml has priority over pyproject.toml."""
+        self.make_file(".coveragerc.toml", """\
+            [tool.coverage.run]
+            timid = true
+            data_file = ".toml-data.dat"
+            branch = true
+            """)
+
+        self.make_file("pyproject.toml", """\
+            [tool.coverage.run]
+            timid = false
+            data_file = "pyproject-data.dat"
+            branch = false
+            """)
+        cov = coverage.Coverage()
+
+        assert cov.config.timid is True
+        assert cov.config.data_file == ".toml-data.dat"
+        assert cov.config.branch is True
+
 
 class SerializeConfigTest(CoverageTest):
     """Tests of serializing the configuration for subprocesses."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1017,7 +1017,7 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
             assert cov.config.data_file == ".coverage"
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_exceptions_from_missing_toml_things(self, filename) -> None:
+    def test_exceptions_from_missing_toml_things(self, filename: str) -> None:
         self.make_file(
             filename,
             """\

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1037,19 +1037,25 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
 
     def test_coveragerc_toml_priority(self) -> None:
         """Test that .coveragerc.toml has priority over pyproject.toml."""
-        self.make_file(".coveragerc.toml", """\
+        self.make_file(
+            ".coveragerc.toml",
+            """\
             [tool.coverage.run]
             timid = true
             data_file = ".toml-data.dat"
             branch = true
-            """)
+            """,
+        )
 
-        self.make_file("pyproject.toml", """\
+        self.make_file(
+            "pyproject.toml",
+            """\
             [tool.coverage.run]
             timid = false
             data_file = "pyproject-data.dat"
             branch = false
-            """)
+            """,
+        )
         cov = coverage.Coverage()
 
         assert cov.config.timid is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,7 +75,7 @@ class ConfigTest(CoverageTest):
         assert cov.config.data_file == "delete.me"
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_toml_config_file(self, filename) -> None:
+    def test_toml_config_file(self, filename: str) -> None:
         # A pyproject.toml and .coveragerc.toml file will be read into the configuration.
         self.make_file(
             filename,
@@ -109,7 +109,7 @@ class ConfigTest(CoverageTest):
         assert cov.config.get_plugin_options("plugins.a_plugin") == {"hello": "world"}
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_toml_ints_can_be_floats(self, filename) -> None:
+    def test_toml_ints_can_be_floats(self, filename: str) -> None:
         # Test that our class doesn't reject integers when loading floats
         self.make_file(
             filename,
@@ -301,7 +301,7 @@ class ConfigTest(CoverageTest):
             ('[tool.coverage.report]\nfail_under="s"', "couldn't convert to a float"),
         ],
     )
-    def test_toml_parse_errors(self, filename, bad_config: str, msg: str) -> None:
+    def test_toml_parse_errors(self, filename: str, bad_config: str, msg: str) -> None:
         # Im-parsable values raise ConfigError, with details.
         self.make_file(filename, bad_config)
         with pytest.raises(ConfigError, match=msg):
@@ -333,7 +333,7 @@ class ConfigTest(CoverageTest):
         assert cov.config.exclude_list == ["the_$one", "anotherZZZ", "xZZZy", "xy", "huh${X}what"]
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_environment_vars_in_toml_config(self, filename) -> None:
+    def test_environment_vars_in_toml_config(self, filename: str) -> None:
         # Config files can have $envvars in them.
         self.make_file(
             filename,
@@ -405,7 +405,7 @@ class ConfigTest(CoverageTest):
         self.assert_tilde_results()
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_tilde_in_toml_config(self, filename) -> None:
+    def test_tilde_in_toml_config(self, filename: str) -> None:
         # Config entries that are file paths can be tilde-expanded.
         self.make_file(
             filename,
@@ -546,7 +546,7 @@ class ConfigTest(CoverageTest):
             _ = coverage.Coverage()
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_unknown_option_toml(self, filename) -> None:
+    def test_unknown_option_toml(self, filename: str) -> None:
         self.make_file(
             filename,
             """\
@@ -614,7 +614,7 @@ class ConfigTest(CoverageTest):
             config.get("xyzzy", "foo")
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_exclude_also(self, filename) -> None:
+    def test_exclude_also(self, filename: str) -> None:
         self.make_file(
             filename,
             """\
@@ -966,7 +966,7 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
 
     @pytest.mark.skipif(env.PYVERSION >= (3, 11), reason="Python 3.11 has toml in stdlib")
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_no_toml_installed_pyproject_toml(self, filename) -> None:
+    def test_no_toml_installed_pyproject_toml(self, filename: str) -> None:
         # Can't have coverage config in pyproject.toml/.coveragerc.toml without toml installed.
         self.make_file(
             filename,
@@ -983,7 +983,7 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
 
     @pytest.mark.skipif(env.PYVERSION >= (3, 11), reason="Python 3.11 has toml in stdlib")
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_no_toml_installed_pyproject_toml_shorter_syntax(self, filename) -> None:
+    def test_no_toml_installed_pyproject_toml_shorter_syntax(self, filename: str) -> None:
         # Can't have coverage config in pyproject.toml/.coveragerc.toml without toml installed.
         self.make_file(
             filename,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,10 +74,11 @@ class ConfigTest(CoverageTest):
         assert not cov.config.branch
         assert cov.config.data_file == "delete.me"
 
-    def test_toml_config_file(self) -> None:
-        # A pyproject.toml file will be read into the configuration.
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_toml_config_file(self, filename) -> None:
+        # A pyproject.toml and .coveragerc.toml file will be read into the configuration.
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             # This is just a bogus toml file for testing.
             [tool.somethingelse]
@@ -107,10 +108,11 @@ class ConfigTest(CoverageTest):
         assert cov.config.fail_under == 90.5
         assert cov.config.get_plugin_options("plugins.a_plugin") == {"hello": "world"}
 
-    def test_toml_ints_can_be_floats(self) -> None:
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_toml_ints_can_be_floats(self, filename) -> None:
         # Test that our class doesn't reject integers when loading floats
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             # This is just a bogus toml file for testing.
             [tool.coverage.report]
@@ -262,6 +264,7 @@ class ConfigTest(CoverageTest):
         with pytest.raises(ConfigError, match=msg):
             coverage.Coverage()
 
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
     @pytest.mark.parametrize(
         "bad_config, msg",
         [
@@ -298,9 +301,9 @@ class ConfigTest(CoverageTest):
             ('[tool.coverage.report]\nfail_under="s"', "couldn't convert to a float"),
         ],
     )
-    def test_toml_parse_errors(self, bad_config: str, msg: str) -> None:
+    def test_toml_parse_errors(self, filename, bad_config: str, msg: str) -> None:
         # Im-parsable values raise ConfigError, with details.
-        self.make_file("pyproject.toml", bad_config)
+        self.make_file(filename, bad_config)
         with pytest.raises(ConfigError, match=msg):
             coverage.Coverage()
 
@@ -329,10 +332,11 @@ class ConfigTest(CoverageTest):
         assert cov.config.branch is True
         assert cov.config.exclude_list == ["the_$one", "anotherZZZ", "xZZZy", "xy", "huh${X}what"]
 
-    def test_environment_vars_in_toml_config(self) -> None:
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_environment_vars_in_toml_config(self, filename) -> None:
         # Config files can have $envvars in them.
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             [tool.coverage.run]
             data_file = "$DATA_FILE.fooey"
@@ -400,10 +404,11 @@ class ConfigTest(CoverageTest):
 
         self.assert_tilde_results()
 
-    def test_tilde_in_toml_config(self) -> None:
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_tilde_in_toml_config(self, filename) -> None:
         # Config entries that are file paths can be tilde-expanded.
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             [tool.coverage.run]
             data_file = "~/data.file"
@@ -540,15 +545,16 @@ class ConfigTest(CoverageTest):
         with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 
-    def test_unknown_option_toml(self) -> None:
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_unknown_option_toml(self, filename) -> None:
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             [tool.coverage.run]
             xyzzy = 17
             """,
         )
-        msg = r"Unrecognized option '\[tool.coverage.run\] xyzzy=' in config file pyproject.toml"
+        msg = f"Unrecognized option '\\[tool.coverage.run\\] xyzzy=' in config file {filename}"
         with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 
@@ -607,9 +613,10 @@ class ConfigTest(CoverageTest):
         with pytest.raises(ConfigError, match="No option 'foo' in section: 'xyzzy'"):
             config.get("xyzzy", "foo")
 
-    def test_exclude_also(self) -> None:
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_exclude_also(self, filename) -> None:
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             [tool.coverage.report]
             exclude_also = ["foobar", "raise .*Error"]
@@ -958,10 +965,11 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
                 coverage.Coverage(config_file="cov.toml")
 
     @pytest.mark.skipif(env.PYVERSION >= (3, 11), reason="Python 3.11 has toml in stdlib")
-    def test_no_toml_installed_pyproject_toml(self) -> None:
-        # Can't have coverage config in pyproject.toml without toml installed.
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_no_toml_installed_pyproject_toml(self, filename) -> None:
+        # Can't have coverage config in pyproject.toml/.coveragerc.toml without toml installed.
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             # A toml file!
             [tool.coverage.run]
@@ -969,15 +977,16 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
             """,
         )
         with mock.patch.object(coverage.tomlconfig, "has_tomllib", False):
-            msg = "Can't read 'pyproject.toml' without TOML support"
+            msg = f"Can't read '{filename}' without TOML support"
             with pytest.raises(ConfigError, match=msg):
                 coverage.Coverage()
 
     @pytest.mark.skipif(env.PYVERSION >= (3, 11), reason="Python 3.11 has toml in stdlib")
-    def test_no_toml_installed_pyproject_toml_shorter_syntax(self) -> None:
-        # Can't have coverage config in pyproject.toml without toml installed.
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_no_toml_installed_pyproject_toml_shorter_syntax(self, filename) -> None:
+        # Can't have coverage config in pyproject.toml/.coveragerc.toml without toml installed.
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             # A toml file!
             [tool.coverage]
@@ -985,15 +994,16 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
             """,
         )
         with mock.patch.object(coverage.tomlconfig, "has_tomllib", False):
-            msg = "Can't read 'pyproject.toml' without TOML support"
+            msg = f"Can't read '{filename}' without TOML support"
             with pytest.raises(ConfigError, match=msg):
                 coverage.Coverage()
 
     @pytest.mark.skipif(env.PYVERSION >= (3, 11), reason="Python 3.11 has toml in stdlib")
-    def test_no_toml_installed_pyproject_no_coverage(self) -> None:
-        # It's ok to have non-coverage pyproject.toml without toml installed.
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_no_toml_installed_pyproject_no_coverage(self, filename) -> None:
+        # It's ok to have non-coverage pyproject.toml/.coveragerc.toml without toml installed.
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             # A toml file!
             [tool.something]
@@ -1007,16 +1017,17 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
             assert not cov.config.branch
             assert cov.config.data_file == ".coverage"
 
-    def test_exceptions_from_missing_toml_things(self) -> None:
+    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
+    def test_exceptions_from_missing_toml_things(self, filename) -> None:
         self.make_file(
-            "pyproject.toml",
+            filename,
             """\
             [tool.coverage.run]
             branch = true
             """,
         )
         config = TomlConfigParser(False)
-        config.read("pyproject.toml")
+        config.read(filename)
         with pytest.raises(ConfigError, match="No section: 'xyzzy'"):
             config.options("xyzzy")
         with pytest.raises(ConfigError, match="No section: 'xyzzy'"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -999,11 +999,10 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
                 coverage.Coverage()
 
     @pytest.mark.skipif(env.PYVERSION >= (3, 11), reason="Python 3.11 has toml in stdlib")
-    @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
-    def test_no_toml_installed_pyproject_no_coverage(self, filename) -> None:
-        # It's ok to have non-coverage pyproject.toml/.coveragerc.toml without toml installed.
+    def test_no_toml_installed_pyproject_no_coverage(self) -> None:
+        # It's ok to have non-coverage pyproject.toml without toml installed.
         self.make_file(
-            filename,
+            "pyproject.toml",
             """\
             # A toml file!
             [tool.something]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,7 +76,7 @@ class ConfigTest(CoverageTest):
 
     @pytest.mark.parametrize("filename", ["pyproject.toml", ".coveragerc.toml"])
     def test_toml_config_file(self, filename: str) -> None:
-        # A pyproject.toml and .coveragerc.toml file will be read into the configuration.
+        # A pyproject.toml or .coveragerc.toml file will be read into the configuration.
         self.make_file(
             filename,
             """\

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -554,7 +554,7 @@ class ConfigTest(CoverageTest):
             xyzzy = 17
             """,
         )
-        msg = f"Unrecognized option '\\[tool.coverage.run\\] xyzzy=' in config file {filename}"
+        msg = fr"Unrecognized option '\[tool.coverage.run\] xyzzy=' in config file {filename}"
         with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1082,6 +1082,26 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
         assert cov.config.branch is True
         assert cov.config.precision == 2
 
+    def test_pyproject_toml_ignores_unprefixed_sections(self) -> None:
+        """Test that pyproject.toml ignores unprefixed sections."""
+        self.make_file(
+            "pyproject.toml",
+            """\
+            [run]
+            timid = true
+            data_file = "should-be-ignored.dat"
+            branch = true
+            
+            [tool.coverage.run]
+            data_file = "correct-data.dat"
+            """,
+        )
+        cov = coverage.Coverage()
+
+        assert cov.config.timid is False
+        assert cov.config.data_file == "correct-data.dat"
+        assert cov.config.branch is False
+
 
 class SerializeConfigTest(CoverageTest):
     """Tests of serializing the configuration for subprocesses."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -554,7 +554,7 @@ class ConfigTest(CoverageTest):
             xyzzy = 17
             """,
         )
-        msg = fr"Unrecognized option '\[tool.coverage.run\] xyzzy=' in config file {filename}"
+        msg = rf"Unrecognized option '\[tool.coverage.run\] xyzzy=' in config file {filename}"
         with pytest.warns(CoverageWarning, match=msg):
             _ = coverage.Coverage()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1061,6 +1061,27 @@ class ConfigFileTest(UsingModulesMixin, CoverageTest):
         assert cov.config.data_file == ".toml-data.dat"
         assert cov.config.branch is True
 
+    def test_coveragerc_toml_unprefixed_syntax(self) -> None:
+        """Test that .coveragerc.toml supports unprefixed section syntax."""
+        self.make_file(
+            ".coveragerc.toml",
+            """\
+            [run]
+            timid = true
+            data_file = ".toml-data.dat"
+            branch = true
+            
+            [report]
+            precision = 2
+            """,
+        )
+        cov = coverage.Coverage()
+
+        assert cov.config.timid is True
+        assert cov.config.data_file == ".toml-data.dat"
+        assert cov.config.branch is True
+        assert cov.config.precision == 2
+
 
 class SerializeConfigTest(CoverageTest):
     """Tests of serializing the configuration for subprocesses."""


### PR DESCRIPTION
This patch provides a new configuration — `.coveragerc.toml `. Considering that many projects have switched to toml configurations, this change offers a more flexible approach to manage coverage settings.

Resolves #1643