### PR TITLE
Fix TypeError: Strings must be encoded before hashing

### DIFF
--- a/coverage/data.py
+++ b/coverage/data.py
@@ -162,7 +162,12 @@ def combine_parallel_data(
 
         with open(f, "rb") as fobj:
             hasher = hashlib.new("sha3_256", usedforsecurity=False)
-            hasher.update(fobj.read())
+            content = fobj.read()
+
+            # Ensure content is bytes before hashing
+            if isinstance(content, str):
+                content = content.encode('utf-8')
+            hasher.update(content)
             sha = hasher.digest()
             combine_this_one = sha not in file_hashes
 


### PR DESCRIPTION
This PR fixes an issue that occurs when using pytest with both coverage and pytest-testmon plugins. The error happens in the combine_parallel_data function when hasher.update(fobj.read()) tries to hash content that might sometimes be a string instead of bytes, despite opening the file in binary mode.

```
INTERNALERROR> Traceback (most recent call last):
...
INTERNALERROR> File "/opt/venv/lib/python3.10/site-packages/coverage/data.py", line 158, in combine_parallel_data
INTERNALERROR> hasher.update(fobj.read())
INTERNALERROR> TypeError: Strings must be encoded before hashing
```

This just adds a simple check to ensure the content is always bytes before passing it to the hasher's update method. This is a defensive programming approach that makes the code more robust against unexpected input types.