### PR TITLE
Enable measuring test coverage for Python archive (.par) files

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -166,7 +166,7 @@ def zip_location(filename: str) -> tuple[str, str] | None:
     name is in the zipfile.
 
     """
-    for ext in [".zip", ".whl", ".egg", ".pex"]:
+    for ext in [".zip", ".whl", ".egg", ".pex", ".par"]:
         zipbase, extension, inner = filename.partition(ext + sep(filename))
         if extension:
             zipfile = zipbase + ext


### PR DESCRIPTION
".par" files are another common(?) (at least at Meta) zip-based binary format for python applications. This change enables coverage to unpack and use the unpacked files under any .par archives as source files.

we've been carrying this patch for years, so I thought I'd try to upstream it, as it could benefit any PAR users out there (and should be harmless for anyone else).