### PR TITLE
Use flaky pytest fixture instead of decorator

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -25,8 +25,6 @@ from typing import (
 )
 from collections.abc import Iterable, Iterator
 
-import flaky
-
 import coverage
 from coverage import env
 from coverage.debug import DebugControl
@@ -388,15 +386,6 @@ class DebugControlString(DebugControl):
     def get_output(self) -> str:
         """Get the output text from the `DebugControl`."""
         return self.io.getvalue()
-
-
-TestMethod = Callable[[Any], None]
-
-def flaky_method(max_runs: int) -> Callable[[TestMethod], TestMethod]:
-    """flaky.flaky, but with type annotations."""
-    def _decorator(fn: TestMethod) -> TestMethod:
-        return cast(TestMethod, flaky.flaky(max_runs)(fn))
-    return _decorator
 
 
 def all_our_source_files() -> Iterator[tuple[Path, str]]:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -18,7 +18,6 @@ import time
 from types import ModuleType
 from collections.abc import Iterable
 
-from flaky import flaky
 import pytest
 
 import coverage
@@ -30,7 +29,6 @@ from coverage.misc import import_local_file
 
 from tests import testenv
 from tests.coveragetest import CoverageTest
-from tests.helpers import flaky_method
 
 
 # These libraries aren't always available, we'll skip tests if they aren't.
@@ -318,7 +316,8 @@ class ConcurrencyTest(CoverageTest):
             """
         self.try_some_code(BUG_330, "eventlet", eventlet, "0\n")
 
-    @flaky_method(max_runs=3)   # Sometimes a test fails due to inherent randomness. Try more times.
+    # Sometimes a test fails due to inherent randomness. Try more times.
+    @pytest.mark.flaky(max_runs=3)
     def test_threads_with_gevent(self) -> None:
         self.make_file("both.py", """\
             import queue
@@ -452,7 +451,8 @@ def start_method_fixture(request: pytest.FixtureRequest) -> str:
     return start_method
 
 
-#@flaky(max_runs=30)         # Sometimes a test fails due to inherent randomness. Try more times.
+# Sometimes a test fails due to inherent randomness. Try more times.
+#@pytest.mark.flaky(max_runs=30)
 class MultiprocessingTest(CoverageTest):
     """Test support of the multiprocessing module."""
 
@@ -705,7 +705,7 @@ def test_thread_safe_save_data(tmp_path: pathlib.Path) -> None:
 
 
 @pytest.mark.skipif(env.WINDOWS, reason="SIGTERM doesn't work the same on Windows")
-@flaky(max_runs=3)          # Sometimes a test fails due to inherent randomness. Try more times.
+@pytest.mark.flaky(max_runs=3)  # Sometimes a test fails due to inherent randomness. Try more times.
 class SigtermTest(CoverageTest):
     """Tests of our handling of SIGTERM."""
 

--- a/tests/test_oddball.py
+++ b/tests/test_oddball.py
@@ -10,7 +10,6 @@ import re
 import sys
 import warnings
 
-from flaky import flaky
 import pytest
 
 import coverage
@@ -167,7 +166,7 @@ class MemoryLeakTest(CoverageTest):
     It may still fail occasionally, especially on PyPy.
 
     """
-    @flaky      # type: ignore[misc]
+    @pytest.mark.flaky
     @pytest.mark.skipif(not testenv.C_TRACER, reason="Only the C tracer has refcounting issues")
     def test_for_leaks(self) -> None:
         # Our original bad memory leak only happened on line numbers > 255, so


### PR DESCRIPTION
Replace the direct use of `flaky.flaky` decorator with the equivalent pytest fixture.  This is both more canonical, and has the additional advantage of being compatible with the more modern `pytest-rerunfailures` plugin, that can be used in place of `flaky`.

Fixes #2003