### PR TITLE
Loosen dependency version range for requests library

### DIFF
--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -6,8 +6,6 @@ attrs==25.3.0
     # via
     #   hypothesis
     #   scriv
-backports-tarfile==1.2.0
-    # via jaraco-context
 build==1.2.2.post1
     # via check-manifest
 cachetools==6.1.0
@@ -20,7 +18,7 @@ charset-normalizer==3.4.2
     # via requests
 check-manifest==0.50
     # via -r requirements/dev.in
-click==8.1.8
+click==8.2.1
     # via
     #   click-log
     #   scriv
@@ -39,10 +37,6 @@ distlib==0.4.0
     # via virtualenv
 docutils==0.21.2
     # via readme-renderer
-exceptiongroup==1.3.0
-    # via
-    #   hypothesis
-    #   pytest
 execnet==2.1.1
     # via pytest-xdist
 filelock==3.18.0
@@ -53,17 +47,12 @@ flaky==3.8.1
     # via -r requirements/pytest.in
 greenlet==3.2.3
     # via -r requirements/dev.in
-hypothesis==6.136.3
+hypothesis==6.136.4
     # via -r requirements/pytest.in
 id==1.5.0
     # via twine
 idna==3.10
     # via requests
-importlib-metadata==8.7.0
-    # via
-    #   build
-    #   keyring
-    #   twine
 iniconfig==2.1.0
     # via pytest
 isort==6.0.1
@@ -155,7 +144,7 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.1.0
     # via twine
 scriv==1.7.0
     # via -r requirements/dev.in
@@ -167,17 +156,9 @@ sortedcontainers==2.4.0
     # via hypothesis
 tabulate==0.9.0
     # via -r requirements/dev.in
-tomli==2.2.1
-    # via
-    #   build
-    #   check-manifest
-    #   pylint
-    #   pyproject-api
-    #   pytest
-    #   tox
 tomlkit==0.13.3
     # via pylint
-tox==4.28.1
+tox==4.28.2
     # via
     #   -r requirements/tox.in
     #   tox-gh
@@ -185,13 +166,6 @@ tox-gh==1.5.0
     # via -r requirements/tox.in
 twine==6.1.0
     # via -r requirements/dev.in
-typing-extensions==4.14.1
-    # via
-    #   astroid
-    #   exceptiongroup
-    #   pylint
-    #   rich
-    #   tox
 urllib3==2.5.0
     # via
     #   requests
@@ -208,5 +182,3 @@ virtualenv==20.32.0
     #   tox
 wcwidth==0.2.13
     # via urwid
-zipp==3.23.0
-    # via importlib-metadata

--- a/requirements/kit.pip
+++ b/requirements/kit.pip
@@ -18,7 +18,7 @@ certifi==2025.7.14
     #   requests
 charset-normalizer==3.4.2
     # via requests
-cibuildwheel==3.1.0
+cibuildwheel==3.1.1
     # via -r requirements/kit.in
 colorama==0.4.6
     # via -r requirements/kit.in
@@ -84,7 +84,7 @@ requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.1.0
     # via twine
 setuptools==80.9.0
     # via -r requirements/kit.in

--- a/requirements/mypy.pip
+++ b/requirements/mypy.pip
@@ -4,15 +4,11 @@ attrs==25.3.0
     # via hypothesis
 colorama==0.4.6
     # via -r requirements/pytest.in
-exceptiongroup==1.3.0
-    # via
-    #   hypothesis
-    #   pytest
 execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.1
     # via -r requirements/pytest.in
-hypothesis==6.136.3
+hypothesis==6.136.4
     # via -r requirements/pytest.in
 iniconfig==2.1.0
     # via pytest
@@ -38,17 +34,11 @@ pytest-xdist==3.8.0
     # via -r requirements/pytest.in
 sortedcontainers==2.4.0
     # via hypothesis
-tomli==2.2.1
-    # via
-    #   mypy
-    #   pytest
 types-requests==2.32.4.20250611
     # via -r requirements/mypy.in
 types-tabulate==0.9.0.20241207
     # via -r requirements/mypy.in
 typing-extensions==4.14.1
-    # via
-    #   exceptiongroup
-    #   mypy
+    # via mypy
 urllib3==2.5.0
     # via types-requests

--- a/requirements/pytest.pip
+++ b/requirements/pytest.pip
@@ -4,15 +4,11 @@ attrs==25.3.0
     # via hypothesis
 colorama==0.4.6
     # via -r requirements/pytest.in
-exceptiongroup==1.3.0
-    # via
-    #   hypothesis
-    #   pytest
 execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.1
     # via -r requirements/pytest.in
-hypothesis==6.136.3
+hypothesis==6.136.4
     # via -r requirements/pytest.in
 iniconfig==2.1.0
     # via pytest
@@ -32,7 +28,3 @@ pytest-xdist==3.8.0
     # via -r requirements/pytest.in
 sortedcontainers==2.4.0
     # via hypothesis
-tomli==2.2.1
-    # via pytest
-typing-extensions==4.14.1
-    # via exceptiongroup

--- a/requirements/tox.pip
+++ b/requirements/tox.pip
@@ -26,17 +26,11 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.9.1
     # via tox
-tomli==2.2.1
-    # via
-    #   pyproject-api
-    #   tox
-tox==4.28.1
+tox==4.28.2
     # via
     #   -r requirements/tox.in
     #   tox-gh
 tox-gh==1.5.0
     # via -r requirements/tox.in
-typing-extensions==4.14.1
-    # via tox
 virtualenv==20.32.0
     # via tox


### PR DESCRIPTION
I was installing [`mkdocs-material`](https://pypi.org/project/mkdocs-material/) which requests a newer version than coveragepy requires.

> ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
coveragepy 1.6.0 requires requests==2.25.0, but you have requests 2.32.4 which is incompatible.

Or more explicitly on reverse:

> ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
mkdocs-material 9.6.15 requires requests~=2.26, but you have requests 2.25.0 which is incompatible.

This PR just loosens up your dependency. Let me know if you want any alterations, like more specific `requests` version range.