### PR TITLE
fix thread safety of resuming ctracers 

### DIFF
--- a/coverage/collector.py
+++ b/coverage/collector.py
@@ -375,13 +375,14 @@ class Collector:
 
     def resume(self) -> None:
         """Resume tracing after a `pause`."""
-        for tracer in self.tracers:
-            tracer.start()
         if self.core.systrace:
             if self.threading:
                 self.threading.settrace(self._installation_trace)
             else:
                 self._start_tracer()
+        else:
+            for tracer in self.tracers:
+                tracer.start()
 
     def post_fork(self) -> None:
         """After a fork, tracers might need to adjust."""


### PR DESCRIPTION
Instead of calling `tracer.start` directly which would set `PyEval_SetTrace` for incorrect thread, let it be handled by `threading.settrace` and `self._start_tracer()`.