### PR TITLE
Demo: use c11 atomics

### DIFF
--- a/coverage/ctracer/tracer.h
+++ b/coverage/ctracer/tracer.h
@@ -32,7 +32,7 @@ typedef struct CTracer {
     PyObject * disable_plugin;
 
     /* Has the tracer been started? */
-    BOOL started;
+    _Atomic BOOL started;
     /* Are we tracing arcs, or just lines? */
     BOOL tracing_arcs;
     /* Have we had any activity? */

--- a/coverage/ctracer/util.h
+++ b/coverage/ctracer/util.h
@@ -5,6 +5,7 @@
 #define _COVERAGE_UTIL_H
 
 #include <Python.h>
+#include <stdatomic.h>
 
 /* Compile-time debugging helpers */
 #undef WHAT_LOG         /* Define to log the WHAT params in the trace function. */

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,11 @@ class ve_build_ext(build_ext):
 
     def build_extension(self, ext):
         """Wrap `build_extension` with `BuildFailed`."""
+        if self.compiler.compiler_type == "msvc":
+            ext.extra_compile_args = (ext.extra_compile_args or []) + [
+                "/std:c11",
+                "/experimental:c11atomics",
+            ]
         try:
             # Uncomment to test compile failure handling:
             #   raise errors.CCompilerError("OOPS")


### PR DESCRIPTION
This shows how to use C11 atomics in `coveragepy`.