### PR TITLE
Revert "fix thread safety of resuming ctracers "

### DIFF
--- a/coverage/collector.py
+++ b/coverage/collector.py
@@ -374,14 +374,13 @@ class Collector:
 
     def resume(self) -> None:
         """Resume tracing after a `pause`."""
+        for tracer in self.tracers:
+            tracer.start()
         if self.core.systrace:
             if self.threading:
                 self.threading.settrace(self._installation_trace)
             else:
                 self._start_tracer()
-        else:
-            for tracer in self.tracers:
-                tracer.start()
 
     def post_fork(self) -> None:
         """After a fork, tracers might need to adjust."""


### PR DESCRIPTION
Reverts nedbat/coveragepy#2018

This broke usage of nested contexts, reverting until I find a better fix for it.