### PR TITLE
test: Find source directory relative to tests rather than `coverage`

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -25,7 +25,6 @@ from typing import (
 )
 from collections.abc import Iterable, Iterator
 
-import coverage
 from coverage import env
 from coverage.debug import DebugControl
 from coverage.exceptions import CoverageWarning
@@ -396,7 +395,7 @@ def all_our_source_files() -> Iterator[tuple[Path, str]]:
 
     Produces a stream of (filename, file contents) tuples.
     """
-    cov_dir = Path(coverage.__file__).parent.parent
+    cov_dir = Path(__file__).parent.parent
     if ".tox" in cov_dir.parts:
         # We are in a tox-installed environment, look above the .tox dir to
         # also find the uninstalled source files.


### PR DESCRIPTION
Use the path to the `tests/helpers.py` module itself rather than the `coverage` package to determine what the source directory is. The former is always imported from the source tree, while the latter does not necessarily have to -- in particular, in Gentoo we are installing it to a temporary directory to keep the source directory clean of artifacts.