### PR TITLE
Add run-report to command line

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -563,7 +563,8 @@ COMMANDS = {
             Opts.timid,
             ] + GLOBAL_ARGS,
         usage="[options] <pyfile> [program options]",
-        description="Run a Python program, measuring code execution and report without saving in file.",
+        description=(
+            "Run a Python program, measuring code execution and report without saving in file."),
     ),
 
     "xml": CmdOptionParser(
@@ -690,7 +691,8 @@ class CoverageScript:
 
         # Do something.
         self.coverage = Coverage(
-            data_file=None if options.action == "run-report" else options.data_file or DEFAULT_DATAFILE,
+            data_file=(
+                None if options.action == "run-report" else options.data_file or DEFAULT_DATAFILE),
             data_suffix=options.parallel_mode,
             cover_pylib=options.pylib,
             timid=options.timid,
@@ -851,7 +853,7 @@ class CoverageScript:
         print("Saving coverage data...", flush=True)
         self.coverage.save()
 
-    def do_run(self, options: optparse.Values, args: list[str], report=False) -> int:
+    def do_run(self, options: optparse.Values, args: list[str], report: bool = False) -> int:
         """Implementation of 'coverage run'."""
 
         if not args:


### PR DESCRIPTION
I added a `run-report` command that can be used to show a report without creating a .coverage file.

I may be one of the very few to really want such a feature as I don't like adding unnecessary files and I/O to my SSD storage. This is obviously desirable only for small code base.

Instead of opening an issue I thought it would be better to already give a solution to start a conversation.

Feel free to close this PR if this is definitely not something you think is desirable as a feature.

One caveat of this implementation is the fact that I merged the arguments or `run` and `report` and the `-m` argument is in conflict so I left it for the `run` only and forced it for the report (always showing missing lines).