### PR TITLE
Feature/build riscv64 wheel

### DIFF
--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -36,7 +36,7 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
   # PYVERSIONS: changing the list of versions will change the number of
   # expected distributions. This must match the same number in publish.yml.
-  EXPECTED: 88
+  EXPECTED: 104
 
 permissions:
   contents: read

--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -201,7 +201,7 @@ jobs:
           python -m pip install -r requirements/kit.pip
       - name: Set up QEMU
         if: ${{ matrix.arch == 'riscv64' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: "Build binary wheels"
         env:
           CIBW_BUILD: ${{ matrix.py }}*-*

--- a/.github/workflows/kit.yml
+++ b/.github/workflows/kit.yml
@@ -73,7 +73,7 @@ jobs:
           #
           #   # For each OS, what arch to use with cibuildwheel:
           #   os_archs = {
-          #       "ubuntu": ["x86_64", "i686", "aarch64"],
+          #       "ubuntu": ["x86_64", "i686", "aarch64", "riscv64"],
           #       "macos": ["arm64", "x86_64"],
           #       "windows": ["x86", "AMD64", "ARM64"],
           #   }
@@ -128,6 +128,12 @@ jobs:
           - {"os": "ubuntu", "py": "cp312", "arch": "aarch64", "os-version": "22.04-arm"}
           - {"os": "ubuntu", "py": "cp313", "arch": "aarch64", "os-version": "22.04-arm"}
           - {"os": "ubuntu", "py": "cp314", "arch": "aarch64", "os-version": "22.04-arm"}
+          - {"os": "ubuntu", "py": "cp39", "arch": "riscv64"}
+          - {"os": "ubuntu", "py": "cp310", "arch": "riscv64"}
+          - {"os": "ubuntu", "py": "cp311", "arch": "riscv64"}
+          - {"os": "ubuntu", "py": "cp312", "arch": "riscv64"}
+          - {"os": "ubuntu", "py": "cp313", "arch": "riscv64"}
+          - {"os": "ubuntu", "py": "cp314", "arch": "riscv64"}
           - {"os": "macos", "py": "cp39", "arch": "arm64", "os-version": "13"}
           - {"os": "macos", "py": "cp310", "arch": "arm64", "os-version": "13"}
           - {"os": "macos", "py": "cp311", "arch": "arm64", "os-version": "13"}
@@ -156,7 +162,7 @@ jobs:
           - {"os": "windows", "py": "cp312", "arch": "ARM64", "os-version": "11-arm"}
           - {"os": "windows", "py": "cp313", "arch": "ARM64", "os-version": "11-arm"}
           - {"os": "windows", "py": "cp314", "arch": "ARM64", "os-version": "11-arm"}
-        # [[[end]]] (sum: 7BoHzaIHKR)
+        # [[[end]]] (sum: 0tXzcJPEQS)
         #            ^^^^^^^^^^^^^^^
         # If a check fails and points to this checksum line, it means you edited
         # the matrix directly instead of editing the Python code in the comment
@@ -193,7 +199,9 @@ jobs:
       - name: "Install tools"
         run: |
           python -m pip install -r requirements/kit.pip
-
+      - name: Set up QEMU
+        if: ${{ matrix.arch == 'riscv64' }}
+        uses: docker/setup-qemu-action@v3
       - name: "Build binary wheels"
         env:
           CIBW_BUILD: ${{ matrix.py }}*-*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ defaults:
 env:
   # PYVERSIONS: changing the list of versions will change the number of
   # expected distributions. This must match the same number in kit.yml.
-  EXPECTED: 88
+  EXPECTED: 104
 
 permissions:
   contents: read


### PR DESCRIPTION
PyPI recently added support for riscv64(rv64) wheel packages, so we can consider adding rv64 support for coverage.

I ran CI on my fork, and here are the [results](https://github.com/ffgan/coveragepy/actions/runs/17800820318): it builds and works fine. Regarding testing, I don't see any tests for architectures other than x86, such as aarch64, in  `testsuite.yaml` file, so I haven't added CI tests for rv64 yet. If you think rv64 testing is necessary, I'd be happy to assist you in completing the required tests. 

Feel free to contact me.


**Other Information**
Co-authored by: [nijincheng@iscas.ac.cn](mailto:nijincheng@iscas.ac.cn);