### PR TITLE
Fix comments: `co_lnotab` to `co_lines`

### DIFF
--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -449,8 +449,7 @@ class ByteParser:
     def _line_numbers(self) -> Iterable[TLineNo]:
         """Yield the line numbers possible in this code object.
 
-        Uses co_lines described in Python/compile.c to find the
-        line numbers.  Produces a sequence: l0, l1, ...
+        Uses co_lines() to produce a sequence: l0, l1, ...
         """
         for _, _, line in self.code.co_lines():
             if line:

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -449,7 +449,7 @@ class ByteParser:
     def _line_numbers(self) -> Iterable[TLineNo]:
         """Yield the line numbers possible in this code object.
 
-        Uses co_lnotab described in Python/compile.c to find the
+        Uses co_lines described in Python/compile.c to find the
         line numbers.  Produces a sequence: l0, l1, ...
         """
         for _, _, line in self.code.co_lines():


### PR DESCRIPTION
In https://github.com/nedbat/coveragepy/commit/34786db69a639a38af30cd97ac698d083ae76abf the code was changed, but the comment was not.
> DeprecationWarning: co_lnotab is deprecated, use co_lines instead.

`lnotab` still exists in the codebase, but I do not think those files are on the critical path.
* https://github.com/search?q=repo%3Anedbat%2Fcoveragepy%20lnotab&type=code