### PR TITLE
docs: clarify trace function implementation used by default depending on Python version

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -336,7 +336,8 @@ Before version 4.2, this option only accepted a single string.
 (string) Specify which trace function implementation to use. Valid values are:
 "pytrace" for the pure Python implementation, "ctrace" for the C implementation
 (default until Python 3.13),
-or "sysmon" (Python 3.12+ only) for the :mod:`sys.monitoring <python:sys.monitoring>`
+or "sysmon" (Python 3.12+ only) for the
+:mod:`sys.monitoring <python:sys.monitoring>`
 implementation (default with Python 3.14+).
 
 This was previously only available as the COVERAGE_CORE environment variable.

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -335,8 +335,9 @@ Before version 4.2, this option only accepted a single string.
 
 (string) Specify which trace function implementation to use. Valid values are:
 "pytrace" for the pure Python implementation, "ctrace" for the C implementation
-(default), or "sysmon" for the :mod:`sys.monitoring <python:sys.monitoring>`
-implementation (Python 3.12+ only).
+(default until Python 3.13),
+or "sysmon" for the :mod:`sys.monitoring <python:sys.monitoring>`
+implementation (default with Python 3.14+).
 
 This was previously only available as the COVERAGE_CORE environment variable.
 Note that the "sysmon" core does not yet support plugins or dynamic contexts.

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -336,7 +336,7 @@ Before version 4.2, this option only accepted a single string.
 (string) Specify which trace function implementation to use. Valid values are:
 "pytrace" for the pure Python implementation, "ctrace" for the C implementation
 (default until Python 3.13),
-or "sysmon" for the :mod:`sys.monitoring <python:sys.monitoring>`
+or "sysmon" (Python 3.12+ only) for the :mod:`sys.monitoring <python:sys.monitoring>`
 implementation (default with Python 3.14+).
 
 This was previously only available as the COVERAGE_CORE environment variable.


### PR DESCRIPTION
Starting with Python 3.14, the default core is `sysmon`.

https://github.com/nedbat/coveragepy/blob/5a69e053e67932bd8113b4f50d3d509860b4a000/coverage/env.py#L49

Refs: https://github.com/nedbat/django_coverage_plugin/issues/102