### PR TITLE
WIP, BUG: futures with dir switching

### DIFF
--- a/coverage/multiproc.py
+++ b/coverage/multiproc.py
@@ -113,6 +113,8 @@ def patch_multiprocessing(rcfile: str) -> None:
             """Get the original preparation data, and also insert our stowaway."""
             d = original_get_preparation_data(name)
             d["stowaway"] = Stowaway(rcfile)
+            with open(".coverpath", "w", encoding="utf-8") as cpath:
+                cpath.write(d["orig_dir"])
             return d
 
         spawn.get_preparation_data = get_preparation_data_with_stowaway

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -11,6 +11,7 @@ import functools
 import glob
 import itertools
 import os
+import shutil
 import random
 import socket
 import sqlite3
@@ -232,6 +233,8 @@ class CoverageData:
         no_disk: bool = False,
         warn: TWarnFn | None = None,
         debug: TDebugCtl | None = None,
+        *,
+        orig_dir = None,
     ) -> None:
         """Create a :class:`CoverageData` object to hold coverage-measured data.
 
@@ -271,6 +274,7 @@ class CoverageData:
         self._current_context: str | None = None
         self._current_context_id: int | None = None
         self._query_context_ids: list[int] | None = None
+        self.orig_dir = orig_dir
 
     __repr__ = auto_repr
 
@@ -898,6 +902,11 @@ class CoverageData:
     def write(self) -> None:
         """Ensure the data is written to the data file."""
         self._debug_dataio("Writing (no-op) data file", self._filename)
+        if self.orig_dir is not None:
+            for fname in os.listdir():
+                if fname.startswith(".coverage."):
+                    if not os.path.exists(os.path.join(self.orig_dir, fname)):
+                        shutil.copy(fname, self.orig_dir)
 
     def _start_using(self) -> None:
         """Call this before using the database at all."""


### PR DESCRIPTION
* Fixes gh-2065.

* Add a regression test for the failure to collect `.coverage` files when parent and child (`concurrent.futures`) processes have different directory contexts. This test fails for the expected reason it seems.

* Add a patch that fixes the problem described in the matching issue, but for some reason does not manage to restore the desired behavior in the regression test (something I'm not understanding about the "meta" testing?)