### PR TITLE
DOC: clarify that `COVERAGE_START_PROCESS` needs to be set in child processes with `patch=subprocess`

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -460,9 +460,8 @@ Available patches:
   This patch configures Python to start coverage automatically, and will apply
   to processes created with :mod:`subprocess`, :func:`os.system`, or one of the
   :func:`execv <python:os.execl>` or :func:`spawnv <python:os.spawnl>` family
-  of functions.  If an ``exec*e`` or ``spawn*e`` function is used, the new
-  environment must copy over the ``COVERAGE_PROCESS_START`` environment
-  variable.
+  of functions. The ``COVERAGE_PROCESS_START`` value must be copied from the
+  current environment into the new environment or set.
 
   The ``subprocess`` patch sets :ref:`parallel = True <config_run_parallel>`
   and will require combining data files before reporting.  See


### PR DESCRIPTION
close #2073
I copied the phrasing from the `Starting processes` section. Hopefully that's correct.