### PR TITLE
chore: incorrect classifier usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from setuptools.command.build_ext import build_ext  # pylint: disable=wrong-impo
 
 # PYVERSIONS
 classifiers = """\
+Development Status :: 5 - Production/Stable
 Environment :: Console
 Intended Audience :: Developers
 Operating System :: OS Independent
@@ -64,15 +65,6 @@ with open("CONTRIBUTORS.txt", "rb") as contributors:
     num_others += 1  # Count Gareth Rees, who is mentioned in the top paragraph.
 
 classifier_list = classifiers.splitlines()
-
-if version_info[3] == "alpha":
-    devstat = "3 - Alpha"
-elif version_info[3] in ["beta", "candidate"]:
-    devstat = "4 - Beta"
-else:
-    assert version_info[3] == "final"
-    devstat = "5 - Production/Stable"
-classifier_list.append(f"Development Status :: {devstat}")
 
 
 def do_make_pth():

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -50,7 +50,7 @@ class SetupPyTest(CoverageTest):
 
         classifiers = cast(list[str], setup_args["classifiers"])
         assert len(classifiers) > 7
-        assert classifiers[-1].startswith("Development Status ::")
+        assert classifiers[0].startswith("Development Status ::")
         assert "Programming Language :: Python :: %d" % sys.version_info[:1] in classifiers
         assert "Programming Language :: Python :: %d.%d" % sys.version_info[:2] in classifiers
 


### PR DESCRIPTION
The Development Status classifier is _not_ a proxy for the version status. It's an indicator for how stable the _project as a whole_ is. That's why the don't match dev/alpha/beta/rc/final/post, but instead have things like 6 - Mature and 7 - Inactive. Coverage is a 5 - Production / Stable. It is, as a project, Production / Stable even in development and beta releases. The dev release _version_ tells you it's a dev release (of a stable project), not the classifier.

