### PR TITLE
fix: set fixed paths_list in TreeMatcher init

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -260,10 +260,11 @@ class TreeMatcher(Matcher):
         caption: str = "",
         debug: DebugFn = None,
     ) -> None:
-        self.original_paths = human_sorted(paths)
+        paths_list = list(paths)
+        self.original_paths = human_sorted(paths_list)
         super().__init__(self.original_paths, name=name, caption=caption, debug=debug)
         self.paths = []
-        for p in paths:
+        for p in paths_list:
             ap = abs_file(p)
             if ap != p and debug:
                 debug(f"        Normalized {p!r} to {ap!r}")


### PR DESCRIPTION
This lil fix simply ensures we don't get hit with `RuntimeError: Set changed size during iteration`  if there's any concurrent update to `sys.paths` while `TreeMatcher.__init__` runs.


My CI pipeline has encountered this error:
```
.venv/lib/python3.11/site-packages/coverage/inorout.py:354: in should_trace
    self.set_matchers_depending_on_syspath()
.venv/lib/python3.11/site-packages/coverage/inorout.py:308: in set_matchers_depending_on_syspath 
    self.third_match = TreeMatcher(self.third_paths, "third", "Third-party lib", self._debug)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/coverage/files.py:266: in __init_
    for p in paths: 
E     RuntimeError: Set changed size during iteration
```

This seems like a very similar situation to https://github.com/coveragepy/coveragepy/issues/1733
which was fixed by something similar:  https://github.com/coveragepy/coveragepy/commit/08fc997b6b3d881e8e5082b71ad6d6bcc4e2f752.