### PR TITLE
Allow excluding region reporting in all report types that support it

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -255,6 +255,12 @@ class Opts:
         action="store_true",
         help="Format the JSON for human readers.",
     )
+    omit_regions = optparse.make_option(
+        "",
+        "--omit-regions",
+        action="store_true",
+        help="Do not emit region-level data in the report.",
+    )
     parallel_mode = optparse.make_option(
         "-p",
         "--parallel-mode",
@@ -614,6 +620,7 @@ COMMANDS = {
             Opts.skip_covered,
             Opts.no_skip_covered,
             Opts.skip_empty,
+            Opts.omit_regions,
             Opts.title,
         ]
         + GLOBAL_ARGS,
@@ -637,6 +644,7 @@ COMMANDS = {
             Opts.omit,
             Opts.output_json,
             Opts.json_pretty_print,
+            Opts.omit_regions,
             Opts.quiet,
             Opts.show_contexts,
         ]
@@ -895,6 +903,7 @@ class CoverageScript:
                 skip_covered=options.skip_covered,
                 skip_empty=options.skip_empty,
                 show_contexts=options.show_contexts,
+                omit_regions=options.omit_regions,
                 title=options.title,
                 **report_args,
             )
@@ -909,6 +918,7 @@ class CoverageScript:
                 outfile=options.outfile,
                 pretty_print=options.pretty_print,
                 show_contexts=options.show_contexts,
+                omit_regions=options.omit_regions,
                 **report_args,
             )
         elif options.action == "lcov":

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -218,6 +218,7 @@ class CoverageConfig(TConfigurable, TPluginConfig):
         self._crash: str | None = None
 
         # Defaults for [report]
+        self.omit_regions = False
         self.exclude_list = DEFAULT_EXCLUDE[:]
         self.exclude_also: list[str] = []
         self.fail_under = 0.0
@@ -428,6 +429,7 @@ class CoverageConfig(TConfigurable, TPluginConfig):
         ("_crash", "run:_crash"),
         #
         # [report]
+        ("omit_regions", "report:omit_regions", "boolean"),
         ("exclude_list", "report:exclude_lines", "regexlist"),
         ("exclude_also", "report:exclude_also", "regexlist"),
         ("fail_under", "report:fail_under", "float"),

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -1215,6 +1215,7 @@ class Coverage(TConfigurable):
         contexts: list[str] | None = None,
         skip_empty: bool | None = None,
         precision: int | None = None,
+        omit_regions: bool | None = None,
     ) -> float:
         """Generate an HTML report.
 
@@ -1254,6 +1255,7 @@ class Coverage(TConfigurable):
             report_contexts=contexts,
             html_skip_empty=skip_empty,
             precision=precision,
+            omit_regions=omit_regions,
         ):
             reporter = HtmlReporter(self)
             return reporter.report(morfs)
@@ -1302,6 +1304,7 @@ class Coverage(TConfigurable):
         contexts: list[str] | None = None,
         pretty_print: bool | None = None,
         show_contexts: bool | None = None,
+        omit_regions: bool | None = None,
     ) -> float:
         """Generate a JSON report of coverage results.
 
@@ -1327,6 +1330,7 @@ class Coverage(TConfigurable):
             report_contexts=contexts,
             json_pretty_print=pretty_print,
             json_show_contexts=show_contexts,
+            omit_regions=omit_regions,
         ):
             return render_report(self.config.json_output, JsonReporter(self), morfs, self._message)
 

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -390,9 +390,10 @@ class HtmlReporter:
 
         for ftr in files_to_report:
             self.write_html_page(ftr)
-            for noun, plural_noun in ftr.fr.code_region_kinds():
-                if noun not in self.index_pages:
-                    self.index_pages[noun] = self.new_index_page(noun, plural_noun)
+            if not self.config.omit_regions:
+                for noun, plural_noun in ftr.fr.code_region_kinds():
+                    if noun not in self.index_pages:
+                        self.index_pages[noun] = self.new_index_page(noun, plural_noun)
 
         # Write the index page.
         if files_to_report:
@@ -403,7 +404,8 @@ class HtmlReporter:
         self.write_file_index_page(first_html, final_html)
 
         # Write function and class index pages.
-        self.write_region_index_pages(files_to_report)
+        if not self.config.omit_regions:
+            self.write_region_index_pages(files_to_report)
 
         return (
             self.index_pages["file"].totals.n_statements

--- a/coverage/jsonreport.py
+++ b/coverage/jsonreport.py
@@ -131,6 +131,9 @@ class JsonReporter:
                 _convert_branch_arcs(analysis.missing_branch_arcs()),
             )
 
+        if self.config.omit_regions:
+            return reported_file
+
         num_lines = len(file_reporter.source().splitlines())
         regions = file_reporter.code_regions()
         for noun, plural in file_reporter.code_region_kinds():

--- a/doc/commands/cmd_html.rst
+++ b/doc/commands/cmd_html.rst
@@ -67,6 +67,7 @@ Click the keyboard icon in the upper right to see the complete list.
       --skip-covered        Skip files with 100% coverage.
       --no-skip-covered     Disable --skip-covered.
       --skip-empty          Skip files with no code.
+      --omit-regions        Do not emit region-level data in the report.
       --title=TITLE         A text string to use as the title on the HTML.
       --debug=OPTS          Debug options, separated by commas. [env:
                             COVERAGE_DEBUG]
@@ -74,7 +75,7 @@ Click the keyboard icon in the upper right to see the complete list.
       --rcfile=RCFILE       Specify configuration file. By default '.coveragerc',
                             'setup.cfg', 'tox.ini', and 'pyproject.toml' are
                             tried. [env: COVERAGE_RCFILE]
-.. [[[end]]] (sum: DwG6DxRZIf)
+.. [[[end]]] (sum: 7IA6oLLLpx)
 
 The title of the report can be set with the ``title`` setting in the
 ``[html]`` section of the configuration file, or the ``--title`` switch on

--- a/doc/commands/cmd_json.rst
+++ b/doc/commands/cmd_json.rst
@@ -45,6 +45,7 @@ The **json** command writes coverage data to a "coverage.json" file.
       -o OUTFILE            Write the JSON report to this file. Defaults to
                             'coverage.json'
       --pretty-print        Format the JSON for human readers.
+      --omit-regions        Do not emit region-level data in the report.
       -q, --quiet           Don't print messages about what is happening.
       --show-contexts       Show contexts for covered lines.
       --debug=OPTS          Debug options, separated by commas. [env:
@@ -53,7 +54,7 @@ The **json** command writes coverage data to a "coverage.json" file.
       --rcfile=RCFILE       Specify configuration file. By default '.coveragerc',
                             'setup.cfg', 'tox.ini', and 'pyproject.toml' are
                             tried. [env: COVERAGE_RCFILE]
-.. [[[end]]] (sum: 5T5gy2XZcc)
+.. [[[end]]] (sum: Z1WF7akY2h)
 
 You can specify the name of the output file with the ``-o`` switch.  The JSON
 can be nicely formatted by specifying the ``--pretty-print`` switch.

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -61,6 +61,7 @@ class BaseCmdLineTest(CoverageTest):
         contexts=None,
         skip_empty=None,
         precision=None,
+        omit_regions=None,
     )
     _defaults.Coverage().report(
         ignore_errors=None,
@@ -93,6 +94,7 @@ class BaseCmdLineTest(CoverageTest):
         contexts=None,
         pretty_print=None,
         show_contexts=None,
+        omit_regions=None,
     )
     _defaults.Coverage().lcov_report(
         ignore_errors=None,

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -712,6 +712,27 @@ class HtmlTest(HtmlTestHelpers, CoverageTest):
         self.assert_doesnt_exist("htmlcov/function_index.html")
         self.assert_doesnt_exist("htmlcov/class_index.html")
 
+    def test_report_omit_regions(self) -> None:
+        self.make_file(
+            "main_file.py",
+            """\
+            def normal():
+                print("z")
+            def abnormal():
+                print("a")
+            normal()
+        """,
+        )
+        res = self.run_coverage(
+            covargs=dict(source="."), htmlargs=dict(skip_covered=True, omit_regions=True)
+        )
+        assert res == 80.0
+        self.assert_exists("htmlcov/main_file_py.html")
+        # We have a file to report, but do not break it down into function
+        # and class indices.
+        self.assert_doesnt_exist("htmlcov/function_index.html")
+        self.assert_doesnt_exist("htmlcov/class_index.html")
+
     def test_report_skip_covered_100_functions(self) -> None:
         self.make_file(
             "main_file.py",


### PR DESCRIPTION
This PR adds a new flag, `--omit-regions`, to the JSON and HTML reports.

I use coverage.py on a particularly large monolithic application (several millions of lines of code), and we have custom tooling that parses JSON reports created by coverage.py. When region-level reporting was added to JSON reports, this tooling had a notable regression in memory usage and performance. We don't use this information, so it's helpful if coverage.py doesn't emit it in the first place.