### PR TITLE
fix: escape filename in markdown report #2141

### DIFF
--- a/coverage/report.py
+++ b/coverage/report.py
@@ -126,8 +126,13 @@ class SummaryReporter:
         `end_lines` is a list of ending lines with information about skipped files.
 
         """
+
+        def escape_markdown(input_value: str) -> str:
+            """Crudely replace characters meaningful in markdown tables."""
+            return input_value.replace("_", "\\_").replace("|", "\\|")
+
         # Prepare the formatting strings, header, and column sorting.
-        max_name = max((len(line[0].replace("_", "\\_")) for line in lines_values), default=0)
+        max_name = max((len(escape_markdown(line[0])) for line in lines_values), default=0)
         max_name = max(max_name, len("**TOTAL**")) + 1
         formats = dict(
             Name="| {:{name_len}}|",
@@ -160,7 +165,7 @@ class SummaryReporter:
             self.write_items(
                 (
                     formats[item].format(
-                        str(value).replace("_", "\\_"), name_len=max_name, n=max_n - 1
+                        escape_markdown(str(value)), name_len=max_name, n=max_n - 1
                     )
                     for item, value in zip(header, values)
                 )

--- a/coverage/report.py
+++ b/coverage/report.py
@@ -25,9 +25,9 @@ ESCAPE_PUNCTUATION_TABLE = "".maketrans(
 )
 
 
-def escape_markdown(input_value: str) -> str:
+def escape_markdown(text: str) -> str:
     """Prefix all characters meaningful in markdown tables with backslashes."""
-    return input_value.translate(ESCAPE_PUNCTUATION_TABLE)
+    return text.translate(ESCAPE_PUNCTUATION_TABLE)
 
 
 class SummaryReporter:

--- a/coverage/report.py
+++ b/coverage/report.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Iterable
+from string import punctuation
 from typing import IO, TYPE_CHECKING, Any
 
 from coverage.exceptions import ConfigError, NoDataError
@@ -18,6 +19,15 @@ from coverage.types import TMorfs
 
 if TYPE_CHECKING:
     from coverage import Coverage
+
+ESCAPE_PUNCTUATION_TABLE = "".maketrans(
+    {char: f"\\{char}" for char in punctuation if char not in ".,/-"}
+)
+
+
+def escape_markdown(input_value: str) -> str:
+    """Prefix all characters meaningful in markdown tables with backslashes."""
+    return input_value.translate(ESCAPE_PUNCTUATION_TABLE)
 
 
 class SummaryReporter:
@@ -126,10 +136,6 @@ class SummaryReporter:
         `end_lines` is a list of ending lines with information about skipped files.
 
         """
-
-        def escape_markdown(input_value: str) -> str:
-            """Crudely replace characters meaningful in markdown tables."""
-            return input_value.replace("_", "\\_").replace("|", "\\|")
 
         # Prepare the formatting strings, header, and column sorting.
         max_name = max((len(escape_markdown(line[0])) for line in lines_values), default=0)

--- a/tests/coveragetest.py
+++ b/tests/coveragetest.py
@@ -133,7 +133,7 @@ class CoverageTest(
         kwargs.setdefault("show_missing", False)
         cov.report(file=repout, output_format=output_format, **kwargs)
         if output_format == "markdown":
-            report = repout.getvalue().replace("\\\\", r"\/")
+            report = repout.getvalue().replace("\\\\", "/")
         else:
             report = repout.getvalue().replace("\\", "/")
         print(report)  # When tests fail, it's helpful to see the output

--- a/tests/coveragetest.py
+++ b/tests/coveragetest.py
@@ -125,12 +125,17 @@ class CoverageTest(
             cov.stop()
         return mod
 
-    def get_report(self, cov: Coverage, squeeze: bool = True, **kwargs: Any) -> str:
+    def get_report(
+        self, cov: Coverage, squeeze: bool = True, output_format: str | None = None, **kwargs: Any
+    ) -> str:
         """Get the report from `cov`, and canonicalize it."""
         repout = io.StringIO()
         kwargs.setdefault("show_missing", False)
-        cov.report(file=repout, **kwargs)
-        report = repout.getvalue().replace("\\", "/")
+        cov.report(file=repout, output_format=output_format, **kwargs)
+        if output_format == "markdown":
+            report = repout.getvalue().replace("\\\\", r"\/")
+        else:
+            report = repout.getvalue().replace("\\", "/")
         print(report)  # When tests fail, it's helpful to see the output
         if squeeze:
             report = re.sub(r" +", " ", report)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -907,8 +907,8 @@ class SummaryTest(UsingModulesMixin, CoverageTest):
             pytest.param(
                 "\\",  # seperate only to make test failure messages easy to read
                 set("\\"),
-                r"\/",
-                id="backslash-escaped",
+                "/",  # munged to forward slash by get_report
+                id="backslash-untouched",
             ),
             pytest.param(
                 "/",

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -891,6 +891,18 @@ class SummaryTest(UsingModulesMixin, CoverageTest):
         report = self.report_from_command("coverage report --format=markdown")
         assert self.last_line_squeezed(report) == "| **TOTAL** | **5** | **0** | **100%** |"
 
+    @pytest.mark.skipif(env.WINDOWS, reason="No pipe characters in filenames on Windows")
+    def test_markdown_escape_filename(self) -> None:
+        self.make_file("subdir/so_me|file.py", "print(1)")
+        self.make_data_file(lines={"subdir/so_me|file.py": [1]})
+
+        cov = coverage.Coverage()
+        cov.load()
+        report = self.get_report(cov, ignore_errors=True, output_format="markdown")
+
+        squeezed = self.squeezed_lines(report)
+        assert squeezed[2] == "| subdir/so/_me/|file.py | 1 | 1 | 0% |"
+
     def test_bug_156_file_not_run_should_be_zero(self) -> None:
         # https://github.com/coveragepy/coveragepy/issues/156
         self.make_file(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1028,11 +1028,9 @@ class SummaryTest(UsingModulesMixin, CoverageTest):
         assert "tests/modules/pkg1/__init__.py 1 0 0 0 100%" in report
         assert "tests/modules/pkg2/__init__.py 0 0 0 0 100%" in report
         report = self.get_report(cov, squeeze=False, output_format="markdown")
-        # get_report() escapes backslash so we expect forward slash escaped
-        # underscore
-        assert "tests/modules/pkg1//_/_init/_/_.py " in report
+        assert r"tests/modules/pkg1/\_\_init\_\_.py " in report
         assert "|        1 |        0 |        0 |        0 |     100% |" in report
-        assert "tests/modules/pkg2//_/_init/_/_.py " in report
+        assert r"tests/modules/pkg2/\_\_init\_\_.py " in report
         assert "|        0 |        0 |        0 |        0 |     100% |" in report
 
     def test_markdown_with_missing(self) -> None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -12,6 +12,7 @@ import os
 import os.path
 import py_compile
 import re
+import string
 
 
 import pytest
@@ -891,17 +892,57 @@ class SummaryTest(UsingModulesMixin, CoverageTest):
         report = self.report_from_command("coverage report --format=markdown")
         assert self.last_line_squeezed(report) == "| **TOTAL** | **5** | **0** | **100%** |"
 
-    @pytest.mark.skipif(env.WINDOWS, reason="No pipe characters in filenames on Windows")
-    def test_markdown_escape_filename(self) -> None:
-        self.make_file("subdir/so_me|file.py", "print(1)")
-        self.make_data_file(lines={"subdir/so_me|file.py": [1]})
+    DISALLOWED_WINDOWS_FILENAME_CHARACTERS = r'\/:*?"<>|'
+
+    @pytest.mark.parametrize(
+        ("punctuation", "expected_characters", "escaped_punctuation"),
+        [
+            pytest.param(
+                # everything that's not covered by the other items
+                "!#$%&'()+,-.;=@[]^_`{}~",
+                set(string.punctuation) - set(DISALLOWED_WINDOWS_FILENAME_CHARACTERS),
+                r"\!\#\$\%\&\'\(\)\+,-.\;\=\@\[\]\^\_\`\{\}\~",
+                id="cross-platform-punctuation",
+            ),
+            pytest.param(
+                "\\",  # seperate only to make test failure messages easy to read
+                set("\\"),
+                r"\/",
+                id="backslash-escaped",
+            ),
+            pytest.param(
+                "/",
+                set("/"),
+                "/",
+                id="forwardslash-untouched-posix-only",
+                marks=pytest.mark.skipif(env.WINDOWS, reason="Disallowed in Windows filenames."),
+            ),
+            pytest.param(
+                ':*?"<>|',
+                set(DISALLOWED_WINDOWS_FILENAME_CHARACTERS) - set("\\/"),
+                r"\:\*\?\"\<\>\|",
+                id="posix-only-punctuation",
+                marks=pytest.mark.skipif(env.WINDOWS, reason="Disallowed in Windows filenames."),
+            ),
+        ],
+    )
+    def test_markdown_escape_filename(
+        self, punctuation: str, expected_characters: set[str], escaped_punctuation: str
+    ) -> None:
+        """Make a horrible filename of punctuation, and ensure coverage report is escaped."""
+        self.make_file(f"horrible-{punctuation}-filename.py", "print(1)")
+        self.make_data_file(lines={f"horrible-{punctuation}-filename.py": [1]})
+
+        # make sure everything in the expected set of punctuation is here,
+        # and none have been dropped. Full diff on mismatch is readable.
+        assert expected_characters == set(punctuation)
 
         cov = coverage.Coverage()
         cov.load()
-        report = self.get_report(cov, ignore_errors=True, output_format="markdown")
+        report = self.get_report(cov, output_format="markdown")
 
         squeezed = self.squeezed_lines(report)
-        assert squeezed[2] == "| subdir/so/_me/|file.py | 1 | 1 | 0% |"
+        assert squeezed[2] == f"| horrible-{escaped_punctuation}-filename.py | 1 | 1 | 0% |"
 
     def test_bug_156_file_not_run_should_be_zero(self) -> None:
         # https://github.com/coveragepy/coveragepy/issues/156


### PR DESCRIPTION
Both underscore and pipe characters are valid in filenames and meaningful in markdown tables. Underscores were already escaped by the markdown report, using a simple string replacement, but pipe characters were not.

```sh
touch 'pipe|.py'
uv tool run dist/coverage-7.13.5a0.dev1-cp314-cp314-macosx_11_0_arm64.whl erase
uv tool run dist/coverage-7.13.5a0.dev1-cp314-cp314-macosx_11_0_arm64.whl run 'pipe|.py'
uv tool run dist/coverage-7.13.5a0.dev1-cp314-cp314-macosx_11_0_arm64.whl report --format=markdown
| Name      |    Stmts |     Miss |    Cover |
|---------- | -------: | -------: | -------: |
| pipe\|.py |        0 |        0 |     100% |
| **TOTAL** |    **0** |    **0** | **100%** |
```

aka

| Name      |    Stmts |     Miss |    Cover |
|---------- | -------: | -------: | -------: |
| pipe\|.py |        0 |        0 |     100% |
| **TOTAL** |    **0** |    **0** | **100%** |