### PR TITLE
docs: add invite link alongside Discord channel links

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -34,7 +34,8 @@ you frustration.
 
 We have a `#coverage channel in the Python Discord <discord_>`_ that can be a
 good place to explore ideas, get help, or help people with coverage.py.
-`Join us <discord_>`_!
+`Join us <discord_>`_!  (`Join the Python Discord server <https://discord.com/invite/python>`_ first,
+if you haven't already.)
 
 .. _discord: https://discord.com/channels/267624335836053506/1253355750684753950
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -181,7 +181,8 @@ Q: Where can I get more help with coverage.py?
 
 You can discuss coverage.py or get help using it on the `Python discussion
 forums`_ or in the `Python Discord`_.  If you ping me (``@nedbat``), there's a
-higher chance I'll see the post.
+higher chance I'll see the post.  (`Join the Python Discord server <https://discord.com/invite/python>`_ first,
+if you haven't already.)
 
 .. _Python discussion forums: https://discuss.python.org/
 .. _Python Discord: https://discord.com/channels/267624335836053506/1253355750684753950

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -201,7 +201,9 @@ Getting help
 If the :ref:`FAQ <faq>` doesn't answer your question, you can discuss
 coverage.py or get help using it on the `Python discussion forums`_ or in the
 `Python Discord`_. If you ping me (``@nedbat``), there's a higher chance I'll
-see the post.
+see the post.  (The Discord link goes straight to the #coverage channel; if
+you're not a member yet, `join the Python Discord server
+<https://discord.com/invite/python>`_ first — it's a welcoming place.)
 
 .. _Python discussion forums: https://discuss.python.org/
 .. _Python Discord: https://discord.com/channels/267624335836053506/1253355750684753950


### PR DESCRIPTION
The channel links go directly to #coverage, but Discord shows "nothing
here" if you're not already a member of the Python Discord server --
not a helpful experience, especially for first-time contributors.
Added a link to the server invite (discord.com/invite/python) so
readers know to join first.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>