### PR TITLE
Add contributor prerequisite notes

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -49,6 +49,13 @@ The coverage.py code is hosted on a GitHub repository at
 https://github.com/coveragepy/coveragepy.  To get a working environment, follow
 these steps:
 
+These steps assume you already have ``git`` and ``make`` installed.  Building
+and testing coverage.py also needs a C compiler, such as ``gcc`` or ``clang``,
+because the test suite builds the C tracer extension.  The development
+requirements install ``tox``; if you skip that step, install ``tox`` yourself
+before running tests.  Install any extra Python versions you want ``tox`` to
+test, including free-threading builds only if you are testing that support.
+
 #.  `Fork the repo`_ into your own GitHub account.  The coverage.py code will
     then be copied into a GitHub repository at
     ``https://github.com/GITHUB_USER/coveragepy`` where GITHUB_USER is your


### PR DESCRIPTION
Summary
- Adds a short prerequisite note to the contributing guide before the setup steps.
- Calls out the platform tools used by the documented workflow: git, make, and a C compiler for the C tracer extension.
- Clarifies that the development requirements install tox, and that extra Python runtimes are only needed for the tox environments a contributor wants to run.

Validation
- `git diff --check` passed.
- `python -m tox --version` passed after installing the pinned tox requirements from `requirements/tox.pip`.
- `python -m tox -e doc --override testenv:doc.basepython=python` was attempted, but could not complete on this machine because only Python 3.11 is installed and the doc dependency `linklint==0.4.1` requires Python >=3.12.

Notes
- Fixes #2051.
- Documentation-only change; no runtime behavior impact.