### PR TITLE
docs: list system prerequisites in the contributing doc

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -40,6 +40,30 @@ if you haven't already.)
 .. _discord: https://discord.com/channels/267624335836053506/1253355750684753950
 
 
+System prerequisites
+--------------------
+
+A few things need to be available on your system before you can build and test
+coverage.py locally:
+
+- **git**, to clone the repository.
+- **A C compiler** (``gcc`` or ``clang`` on Linux/macOS, MSVC on Windows) and
+  Python development headers, to build the bundled C tracer.  See
+  :ref:`install_extension` for the package names on common Linux distributions.
+- **make**, used by the ``make`` targets shown below.  Many distributions
+  install it alongside ``gcc``.
+- **tox**, used to run the test matrix.  It can be installed with
+  ``pip install tox`` or your system package manager.
+
+To exercise the full ``tox`` matrix you also need each supported CPython and
+PyPy interpreter installed and on ``PATH``; see the ``envlist`` in
+``tox.ini``.  This includes the free-threaded CPython builds (``py313t``,
+``py314t``, ...) used to test coverage.py without the GIL, which on some
+distributions ship as separate packages (for example
+``python3.13-freethreading`` on Fedora).  Interpreters that aren't installed
+are skipped, so you can start with just one or two and expand from there.
+
+
 Getting the code
 ----------------
 


### PR DESCRIPTION
## Summary

Closes #2051.

The contributing doc currently walks straight from "Before you begin" into `git clone` and `make install`, leaving newcomers to discover implicit prerequisites the hard way:

- `make` and `tox` weren't named anywhere on the page.
- The bundled C tracer needs a C compiler and Python development headers, but that requirement was only visible after a confusing `tox` failure.
- The free-threaded CPython builds in the `tox` envlist (`py313t`, `py314t`, ...) weren't explained, even though they ship as separate distro packages on some platforms (e.g. `python3.13-freethreading` on Fedora).

This PR adds a small "System prerequisites" subsection between "Before you begin" and "Getting the code" that:

- Names the system tools required (`git`, a C compiler + headers, `make`, `tox`) and links to the existing `install_extension` section for the Linux package hints already documented there.
- Notes that the full tox matrix needs the interpreters listed in `tox.ini`'s `envlist`, including the free-threaded `py3{13,14,...}t` builds, and that interpreters which aren't installed are skipped — so contributors can start with one or two and expand.

The change is text-only; no code or build-system changes.

## Testing

Verified locally with:

- `doc8 -q doc/contributing.rst` — no errors.
- `sphinx-lint doc/contributing.rst` — "No problems found."

The `:ref:` target (`install_extension`) is the existing label in `doc/install.rst`. Section underline length matches the new title.