### PR TITLE
Feature/multiline json

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -368,6 +368,12 @@ class Opts:
         action="store_true",
         help="Display version information and exit.",
     )
+    multiline = optparse.make_option(
+        "",
+        "--multiline",
+        action="store_true",
+        help="Output actual covered lines and not just statements"
+    )
 
 
 class CoverageOptionParser(optparse.OptionParser):
@@ -639,6 +645,7 @@ COMMANDS = {
             Opts.json_pretty_print,
             Opts.quiet,
             Opts.show_contexts,
+            Opts.multiline,
         ]
         + GLOBAL_ARGS,
         usage="[options] [modules]",
@@ -910,6 +917,7 @@ class CoverageScript:
                 outfile=options.outfile,
                 pretty_print=options.pretty_print,
                 show_contexts=options.show_contexts,
+                multiline=options.multiline,
                 **report_args,
             )
         elif options.action == "lcov":

--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -372,7 +372,7 @@ class Opts:
         "",
         "--multiline",
         action="store_true",
-        help="Output actual covered lines and not just statements"
+        help="Output actual covered lines and not just statements",
     )
 
 

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -252,6 +252,7 @@ class CoverageConfig(TConfigurable, TPluginConfig):
         self.json_output = "coverage.json"
         self.json_pretty_print = False
         self.json_show_contexts = False
+        self.json_multiline = False
 
         # Defaults for [lcov]
         self.lcov_output = "coverage.lcov"

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -1302,6 +1302,7 @@ class Coverage(TConfigurable):
         contexts: list[str] | None = None,
         pretty_print: bool | None = None,
         show_contexts: bool | None = None,
+        multiline: bool | None = None,
     ) -> float:
         """Generate a JSON report of coverage results.
 
@@ -1327,6 +1328,7 @@ class Coverage(TConfigurable):
             report_contexts=contexts,
             json_pretty_print=pretty_print,
             json_show_contexts=show_contexts,
+            json_multiline=multiline,
         ):
             return render_report(self.config.json_output, JsonReporter(self), morfs, self._message)
 

--- a/coverage/jsonreport.py
+++ b/coverage/jsonreport.py
@@ -115,7 +115,7 @@ class JsonReporter:
         self.total += nums
         summary = self.make_summary(nums)
         final_executed_lines = analysis.executed
-        if (self.config.json_multiline):
+        if self.config.json_multiline:
             multiline_map = {}
             flag = {}
             original_executed_line = {}
@@ -124,13 +124,16 @@ class JsonReporter:
                 original_executed_line[line] = True
             if hasattr(file_reporter, "multiline_map"):
                 multiline_map = file_reporter.multiline_map()
-                tot_lines = len(file_reporter.source().split('\n'))
+                tot_lines = len(file_reporter.source().split("\n"))
                 for line in range(0, tot_lines + 1):
                     original_stmt_line = multiline_map.get(line)
-                    if (original_executed_line.get(original_stmt_line) == True and multiline_map.get(line) != None and flag.get(line) != True):
+                    if (
+                        original_executed_line.get(original_stmt_line) is True
+                        and multiline_map.get(line) is not None
+                        and flag.get(line) is not True
+                    ):
                         final_executed_lines.add(line)
                         flag[line] = True
-                        
         reported_file: JsonObj = {
             "executed_lines": sorted(final_executed_lines),
             "summary": summary,

--- a/coverage/jsonreport.py
+++ b/coverage/jsonreport.py
@@ -114,8 +114,23 @@ class JsonReporter:
         nums = analysis.numbers
         self.total += nums
         summary = self.make_summary(nums)
+        final_executed_lines = analysis.executed
+        if (self.config.json_multiline):
+            multiline_map = {}
+            
+            flag = {}
+            for i in analysis.executed:
+                flag[i] = True
+            if hasattr(file_reporter, "multiline_map"):
+                multiline_map = file_reporter.multiline_map()
+                tot_lines = len(file_reporter.source().split('\n'))
+                for i in range(0, tot_lines + 1):
+                    if (multiline_map.get(i) != None and flag.get(i) != True):
+                        final_executed_lines.add(i)
+                        flag[i] = True
+                        
         reported_file: JsonObj = {
-            "executed_lines": sorted(analysis.executed),
+            "executed_lines": sorted(final_executed_lines),
             "summary": summary,
             "missing_lines": sorted(analysis.missing),
             "excluded_lines": sorted(analysis.excluded),

--- a/coverage/jsonreport.py
+++ b/coverage/jsonreport.py
@@ -117,17 +117,19 @@ class JsonReporter:
         final_executed_lines = analysis.executed
         if (self.config.json_multiline):
             multiline_map = {}
-            
             flag = {}
-            for i in analysis.executed:
-                flag[i] = True
+            original_executed_line = {}
+            for line in analysis.executed:
+                flag[line] = True
+                original_executed_line[line] = True
             if hasattr(file_reporter, "multiline_map"):
                 multiline_map = file_reporter.multiline_map()
                 tot_lines = len(file_reporter.source().split('\n'))
-                for i in range(0, tot_lines + 1):
-                    if (multiline_map.get(i) != None and flag.get(i) != True):
-                        final_executed_lines.add(i)
-                        flag[i] = True
+                for line in range(0, tot_lines + 1):
+                    original_stmt_line = multiline_map.get(line)
+                    if (original_executed_line.get(original_stmt_line) == True and multiline_map.get(line) != None and flag.get(line) != True):
+                        final_executed_lines.add(line)
+                        flag[line] = True
                         
         reported_file: JsonObj = {
             "executed_lines": sorted(final_executed_lines),

--- a/doc/commands/cmd_json.rst
+++ b/doc/commands/cmd_json.rst
@@ -47,6 +47,7 @@ The **json** command writes coverage data to a "coverage.json" file.
       --pretty-print        Format the JSON for human readers.
       -q, --quiet           Don't print messages about what is happening.
       --show-contexts       Show contexts for covered lines.
+      --multiline           Output actual covered lines and not just statements
       --debug=OPTS          Debug options, separated by commas. [env:
                             COVERAGE_DEBUG]
       -h, --help            Get help on this command.

--- a/doc/commands/cmd_json.rst
+++ b/doc/commands/cmd_json.rst
@@ -54,7 +54,7 @@ The **json** command writes coverage data to a "coverage.json" file.
       --rcfile=RCFILE       Specify configuration file. By default '.coveragerc',
                             'setup.cfg', 'tox.ini', and 'pyproject.toml' are
                             tried. [env: COVERAGE_RCFILE]
-.. [[[end]]] (sum: 5T5gy2XZcc)
+.. [[[end]]] (sum: RGT9YaYsPg)
 
 You can specify the name of the output file with the ``-o`` switch.  The JSON
 can be nicely formatted by specifying the ``--pretty-print`` switch.

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -93,6 +93,7 @@ class BaseCmdLineTest(CoverageTest):
         contexts=None,
         pretty_print=None,
         show_contexts=None,
+        multiline=None,
     )
     _defaults.Coverage().lcov_report(
         ignore_errors=None,
@@ -204,7 +205,6 @@ class BaseCmdLineTest(CoverageTest):
         for name, _, kwargs in expected.mock_calls:
             for k, v in self.DEFAULT_KWARGS.get(name, {}).items():
                 kwargs.setdefault(k, v)
-
         self.assert_same_mock_calls(expected, called)
 
     def cmd_executes_same(self, args1: str, args2: str) -> None:
@@ -716,6 +716,15 @@ class CmdLineTest(BaseCmdLineTest):
             cov.load()
             cov.combine(strict=False, keep=False)
             cov.json_report()
+            """,
+        )
+        self.cmd_executes(
+            "json --multiline",
+            """\
+            cov = Coverage()
+            cov.load()
+            cov.combine(strict=False, keep=False)
+            cov.json_report(multiline=True)
             """,
         )
 


### PR DESCRIPTION
I added the multiline map thing from html report for json report

I also added --multiline option with comment so it's optional.

Purpose: I'm doing a thing where I get coverage for base execution, then coverage for another execution, and I want to diff them. With the original coverage.py, I wouldn't get multiline statement and have to do extra static analysis to get the full statement