### PR TITLE
Fix find_spec crash with C extension loaders

### DIFF
--- a/coverage/inorout.py
+++ b/coverage/inorout.py
@@ -114,7 +114,9 @@ def file_and_path_for_module(modulename: str) -> tuple[str | None, list[str]]:
     path = []
     try:
         spec = importlib.util.find_spec(modulename)
-    except Exception:
+    except BaseException:
+        # C extensions can raise non-Exception crashes (e.g. Abort) that
+        # should not propagate. Also catch SystemExit etc. see #2189.
         pass
     else:
         if spec is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1100,6 +1100,22 @@ class SourceIncludeOmitTest(IncludeOmitTestsMixin, CoverageTest):
             self.coverage_usepkgs_counts(source_dirs=["i-do-not-exist"])
 
 
+
+    def test_file_and_path_for_module_handles_find_spec_crash(self) -> None:
+        # https://github.com/nedbat/coveragepy/issues/2189
+        # find_spec can raise BaseException (e.g. Abort from a C extension loader)
+        # when invoked on a submodule whose parent package loads a broken extension.
+        # file_and_path_for_module must not propagate such errors.
+        from coverage.inorout import file_and_path_for_module
+
+        with mock.patch("coverage.inorout.importlib.util.find_spec") as mock_find_spec:
+            mock_find_spec.side_effect = SystemExit("native crash")
+            # Must not raise SystemExit
+            filename, path = file_and_path_for_module("some.submodule")
+            assert filename is None
+            assert path == []
+
+
 class ReportIncludeOmitTest(IncludeOmitTestsMixin, CoverageTest):
     """Tests of the report include/omit functionality."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1099,8 +1099,6 @@ class SourceIncludeOmitTest(IncludeOmitTestsMixin, CoverageTest):
         ):
             self.coverage_usepkgs_counts(source_dirs=["i-do-not-exist"])
 
-
-
     def test_file_and_path_for_module_handles_find_spec_crash(self) -> None:
         # https://github.com/nedbat/coveragepy/issues/2189
         # find_spec can raise BaseException (e.g. Abort from a C extension loader)


### PR DESCRIPTION
Fixes #2189

When coverage calls importlib.util.find_spec() on a submodule
(e.g. pikepdf.form), it can trigger loading of the parent package
(pikepdf). If pikepdf's C extension raises a non-Exception error
(e.g. Abort from a broken nanobind extension), that error would
propagate through file_and_path_for_module() and crash the process.

The fix changes except Exception to except BaseException in
file_and_path_for_module(), so non-Python exceptions are caught
and the function gracefully returns (None, []).

Regression test included.