### PR TITLE
Fix default exclusion for multiline return type annotations with ellipsis body

### DIFF
--- a/coverage/config.py
+++ b/coverage/config.py
@@ -150,6 +150,7 @@ TConfigParser = HandyConfigParser | TomlConfigParser
 DEFAULT_EXCLUDE = [
     r"#\s*(pragma|PRAGMA)[:\s]?\s*(no|NO)\s*(cover|COVER)",
     r"^\s*(((async )?def .*?)?\)(\s*->.*?)?:\s*)?\.\.\.\s*(#|$)",
+        r"^\s*[\])]+\s*:\s*\.\.\.\s*(#|$)",
     r"if (typing\.)?TYPE_CHECKING:",
 ]
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1503,6 +1503,28 @@ class ExcludeTest(CoverageTest):
             lines=[1, 3, 5, 7, 9, 11, 19, 24, 25],
         )
 
+    def test_default_multiline_annotation(self) -> None:
+        # A return type annotation split across multiple lines should
+        # still be excluded when the body is `...`.
+        # https://github.com/coveragepy/coveragepy/issues/2185
+        self.check_coverage(
+            """\
+            from __future__ import annotations
+            a = 2
+            def method3() -> dict[
+                str, str
+            ]: ...
+            b = 6
+            def method7(
+                x: int,
+            ) -> list[
+                int
+            ]: ...
+            c = 12
+            """,
+            lines=[1, 2, 6, 12],
+        )
+
     def test_two_excludes(self) -> None:
         self.check_coverage(
             """\


### PR DESCRIPTION
Fixes #2185

When a return type annotation is split across multiple lines by a formatter
like ruff (e.g. `-> dict[\n    str, str\n]: ...`), the default exclusion
regex for ellipsis-body stubs fails to match the continuation line where
the closing bracket, colon, and `...` appear (e.g. `]: ...`).

The existing regex expects the `def` signature and `: ...` on the same
logical line, but formatters break long annotations so the closing
`]: ...` or `): ...` lands on a separate physical line.

## Changes

**coverage/config.py** - Added a new default exclusion regex:
`r"^\s*[\])]+\s*:\s*\.\.\.\s*(#|$)"`

This matches continuation lines that consist of closing brackets
followed by `: ...`, covering patterns like:
```python
def method() -> dict[
    str, str
]: ...          # now excluded
```

**tests/test_coverage.py** - Added `test_default_multiline_annotation`
to verify that multiline return type annotations with ellipsis bodies
are properly excluded from coverage measurement.