### PR TITLE
Fix #2185: exclude `...` bodies when the return annotation spans multiple lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,13 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
-Nothing yet.
+- Fix: a function whose body is only ``...`` is now excluded by the default
+  exclusion rules even when its return type annotation is split over multiple
+  lines, so the line with the body ends in a closing ``]``, ``)``, or ``}``
+  instead of the function's own ``)``.  Code formatters wrap long signatures
+  this way.  Fixes `issue 2185`_.
+
+.. _issue 2185: https://github.com/coveragepy/coveragepy/issues/2185
 
 
 .. start-releases

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -149,7 +149,7 @@ TConfigParser = HandyConfigParser | TomlConfigParser
 # The default line exclusion regexes.
 DEFAULT_EXCLUDE = [
     r"#\s*(pragma|PRAGMA)[:\s]?\s*(no|NO)\s*(cover|COVER)",
-    r"^\s*(((async )?def .*?)?\)(\s*->.*?)?:\s*)?\.\.\.\s*(#|$)",
+    r"^\s*(((async )?def .*?)?[)\]}](\s*->.*?)?:\s*)?\.\.\.\s*(#|$)",
     r"if (typing\.)?TYPE_CHECKING:",
 ]
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1503,6 +1503,34 @@ class ExcludeTest(CoverageTest):
             lines=[1, 3, 5, 7, 9, 11, 19, 24, 25],
         )
 
+    def test_excluding_multiline_return_annotations(self) -> None:
+        # A function whose body is only "..." is excluded by default even when
+        # its return annotation is split over multiple lines, so the line with
+        # the body ends in a closing bracket (`]`/`)`/`}`) instead of the
+        # def's own `)`.  Formatters such as black/ruff wrap signatures this
+        # way when the annotation is long.  https://github.com/coveragepy/coveragepy/issues/2185
+        self.check_coverage(
+            """\
+            a = 1
+            def f2() -> dict[
+                str, str
+            ]: ...
+            def g5() -> (
+                int
+            ): ...
+            async def h8() -> list[
+                int
+            ]: ...
+            def real11() -> dict[
+                str, int
+            ]:
+                return {}
+            x = 15
+            """,
+            lines=[1, 11, 14, 15],
+            missing="14",
+        )
+
     def test_two_excludes(self) -> None:
         self.check_coverage(
             """\


### PR DESCRIPTION
Fixes #2185.

### The problem

The default exclusion rule for functions whose body is only `...` expects the return type annotation to be on a single line. The relevant regex (`coverage/config.py`) anchors on the function's closing `)`:

```python
r"^\s*(((async )?def .*?)?\)(\s*->.*?)?:\s*)?\.\.\.\s*(#|$)"
```

When a long annotation is wrapped over several lines — as `black`/`ruff` do automatically — the line carrying the `...` body no longer starts with the def's `)`; it starts with the annotation's own closing bracket:

```python
class C:
    def f() -> dict[
        str, str
    ]: ...        # <- line begins with "]", not ")"
```

So the line never matches, and the function is reported as a missing statement even though its body is just `...`.

### The fix

Allow the closing token before the optional `-> ...:` to be any closing bracket — `)`, `]`, or `}` — instead of only `)`:

```python
r"^\s*(((async )?def .*?)?[)\]}](\s*->.*?)?:\s*)?\.\.\.\s*(#|$)"
```

This makes the wrapped form match its last line (`]: ...`) exactly the way the single-line form `) -> int: ...` already matches, and coverage's existing suite-exclusion logic then carries the exclusion to the whole signature.

### Why it's safe

The change stays within a single line (no `re.DOTALL`, no cross-line matching), so it cannot bleed into neighbouring statements. The rule still requires a literal `...` body after the `:`, so a function with a real body is never excluded — e.g. this is still fully measured:

```python
def real() -> dict[
    str, int
]:
    return {}   # not excluded
```

### Testing

- Added `ExcludeTest::test_excluding_multiline_return_annotations` covering subscript, parenthesised and `async` split annotations, plus a real-bodied function that must stay measured.
- `tests/test_coverage.py`, `tests/test_config.py`, `tests/test_parser.py` all pass (233 passed, 7 skipped) with the `sysmon` core.
- `ruff format --check`, `pylint`, `mypy --strict` on `coverage/config.py`, and `doc8`/`sphinx-lint` on `CHANGES.rst` are all clean.