### PR TITLE
Reject switch_context with sysmon core

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -678,38 +678,21 @@ class Coverage(TConfigurable):
             concurrency=concurrency,
         )
 
-    def _switch_to_tracing_core_for_contexts(self) -> None:
-        """Move off sysmon before explicit context switching."""
+    def _warn_no_sysmon_context_switching(self) -> bool:
+        """Warn when sysmon can't honor explicit context switching."""
         assert self._collector is not None
-        assert self._data is not None
         assert self._core is not None
 
         if self._core.tracer_class is not SysMonitor:
-            return
+            return False
 
-        self._collector.flush_data()
-        self._collector.stop()
         self._warn(
-            "Can't use core=sysmon: it doesn't yet support dynamic contexts, using pytrace core",
+            "Can't use switch_context() with core=sysmon: "
+            "it doesn't yet support dynamic contexts, keeping the current context",
             slug="no-sysmon",
             once=True,
         )
-
-        configured_core = self.config.core
-        self.config.core = "pytrace"
-        try:
-            self._collector = self._make_collector(
-                concurrency=self.config.concurrency,
-                dynamic_contexts=True,
-            )
-        finally:
-            self.config.core = configured_core
-        self._collector.use_data(self._data, self.config.context)
-        self._collector.start()
-        if self._core.systrace:
-            trace_fn = sys.gettrace()
-            if trace_fn is not None:
-                sys._getframe(2).f_trace = trace_fn
+        return True
 
     def _init_data(self, suffix: str | bool | None) -> None:
         """Create a data file if we don't have one yet."""
@@ -843,7 +826,8 @@ class Coverage(TConfigurable):
             raise CoverageException("Cannot switch context, coverage is not started")
 
         assert self._collector is not None
-        self._switch_to_tracing_core_for_contexts()
+        if self._warn_no_sysmon_context_switching():
+            return
         if self._collector.should_start_context:
             self._warn("Conflicting dynamic contexts", slug="dynamic-conflict", once=True)
 

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -57,6 +57,7 @@ from coverage.python import PythonFileReporter
 from coverage.report import SummaryReporter
 from coverage.report_core import render_report
 from coverage.results import Analysis, analysis_from_file_reporter
+from coverage.sysmon import SysMonitor
 from coverage.types import (
     FilePath,
     TConfigSectionIn,
@@ -301,6 +302,7 @@ class Coverage(TConfigurable):
         self._data_to_close: list[CoverageData] = []
         self._core: Core | None = None
         self._collector: Collector | None = None
+        self._should_start_context: Callable[[FrameType], str | None] | None = None
 
         self._file_mapper: Callable[[str], str] = abs_file
         self._data_suffix = self._run_suffix = None
@@ -569,7 +571,6 @@ class Coverage(TConfigurable):
 
     def _init_for_start(self) -> None:
         """Initialization for start()"""
-        # Construct the collector.
         concurrency: list[str] = self.config.concurrency
         if "multiprocessing" in concurrency:
             if self.config.config_file is None:
@@ -588,23 +589,10 @@ class Coverage(TConfigurable):
             plugin.dynamic_context for plugin in self._plugins.context_switchers
         )
 
-        should_start_context = combine_context_switchers(context_switchers)
-
-        self._core = Core(
-            warn=self._warn,
-            debug=(self._debug if self._debug.should("core") else None),
-            config=self.config,
-            dynamic_contexts=(should_start_context is not None),
-        )
-        self._collector = Collector(
-            core=self._core,
-            should_trace=self._should_trace,
-            check_include=self._check_include_omit_etc,
-            should_start_context=should_start_context,
-            file_mapper=self._file_mapper,
-            branch=self.config.branch,
-            warn=self._warn,
+        self._should_start_context = combine_context_switchers(context_switchers)
+        self._collector = self._make_collector(
             concurrency=concurrency,
+            dynamic_contexts=(self._should_start_context is not None),
         )
 
         suffix = self._data_suffix_specified
@@ -663,6 +651,63 @@ class Coverage(TConfigurable):
                     signal.SIGTERM,
                     self._on_sigterm,
                 )
+
+    def _make_collector(
+        self,
+        *,
+        concurrency: list[str],
+        dynamic_contexts: bool,
+    ) -> Collector:
+        """Create a collector for the current configuration."""
+        self._core = Core(
+            warn=self._warn,
+            debug=(self._debug if self._debug.should("core") else None),
+            config=self.config,
+            dynamic_contexts=dynamic_contexts,
+        )
+        return Collector(
+            core=self._core,
+            should_trace=self._should_trace,
+            check_include=self._check_include_omit_etc,
+            should_start_context=self._should_start_context,
+            file_mapper=self._file_mapper,
+            branch=self.config.branch,
+            warn=self._warn,
+            concurrency=concurrency,
+        )
+
+    def _switch_to_tracing_core_for_contexts(self) -> None:
+        """Move off sysmon before explicit context switching."""
+        assert self._collector is not None
+        assert self._data is not None
+        assert self._core is not None
+
+        if self._core.tracer_class is not SysMonitor:
+            return
+
+        self._collector.flush_data()
+        self._collector.stop()
+        self._warn(
+            "Can't use core=sysmon: it doesn't yet support dynamic contexts, using pytrace core",
+            slug="no-sysmon",
+            once=True,
+        )
+
+        configured_core = self.config.core
+        self.config.core = "pytrace"
+        try:
+            self._collector = self._make_collector(
+                concurrency=self.config.concurrency,
+                dynamic_contexts=True,
+            )
+        finally:
+            self.config.core = configured_core
+        self._collector.use_data(self._data, self.config.context)
+        self._collector.start()
+        if self._core.systrace:
+            trace_fn = sys.gettrace()
+            if trace_fn is not None:
+                sys._getframe(2).f_trace = trace_fn
 
     def _init_data(self, suffix: str | bool | None) -> None:
         """Create a data file if we don't have one yet."""
@@ -796,6 +841,7 @@ class Coverage(TConfigurable):
             raise CoverageException("Cannot switch context, coverage is not started")
 
         assert self._collector is not None
+        self._switch_to_tracing_core_for_contexts()
         if self._collector.should_start_context:
             self._warn("Conflicting dynamic contexts", slug="dynamic-conflict", once=True)
 

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -57,7 +57,6 @@ from coverage.python import PythonFileReporter
 from coverage.report import SummaryReporter
 from coverage.report_core import render_report
 from coverage.results import Analysis, analysis_from_file_reporter
-from coverage.sysmon import SysMonitor
 from coverage.types import (
     FilePath,
     TConfigSectionIn,
@@ -302,7 +301,6 @@ class Coverage(TConfigurable):
         self._data_to_close: list[CoverageData] = []
         self._core: Core | None = None
         self._collector: Collector | None = None
-        self._should_start_context: Callable[[FrameType], str | None] | None = None
 
         self._file_mapper: Callable[[str], str] = abs_file
         self._data_suffix = self._run_suffix = None
@@ -589,10 +587,23 @@ class Coverage(TConfigurable):
             plugin.dynamic_context for plugin in self._plugins.context_switchers
         )
 
-        self._should_start_context = combine_context_switchers(context_switchers)
-        self._collector = self._make_collector(
+        should_start_context = combine_context_switchers(context_switchers)
+
+        self._core = Core(
+            warn=self._warn,
+            debug=(self._debug if self._debug.should("core") else None),
+            config=self.config,
+            dynamic_contexts=(should_start_context is not None),
+        )
+        self._collector = Collector(
+            core=self._core,
+            should_trace=self._should_trace,
+            check_include=self._check_include_omit_etc,
+            should_start_context=should_start_context,
+            file_mapper=self._file_mapper,
+            branch=self.config.branch,
+            warn=self._warn,
             concurrency=concurrency,
-            dynamic_contexts=(self._should_start_context is not None),
         )
 
         suffix = self._data_suffix_specified
@@ -612,11 +623,8 @@ class Coverage(TConfigurable):
 
         assert self._data is not None
         self._collector.use_data(self._data, self.config.context)
-        assert self._core is not None
-        core = self._core
-
         # Early warning if we aren't going to be able to support plugins.
-        if self._plugins.file_tracers and not core.supports_plugins:
+        if self._plugins.file_tracers and not self._core.supports_plugins:
             self._warn(
                 "Plugin file tracers ({}) aren't supported with {}".format(
                     ", ".join(
@@ -636,7 +644,7 @@ class Coverage(TConfigurable):
             include_namespace_packages=self.config.include_namespace_packages,
         )
         self._inorout.plugins = self._plugins
-        self._inorout.disp_class = core.file_disposition_class
+        self._inorout.disp_class = self._core.file_disposition_class
 
         # It's useful to write debug info after initing for start.
         self._should_write_debug = True
@@ -653,46 +661,6 @@ class Coverage(TConfigurable):
                     signal.SIGTERM,
                     self._on_sigterm,
                 )
-
-    def _make_collector(
-        self,
-        *,
-        concurrency: list[str],
-        dynamic_contexts: bool,
-    ) -> Collector:
-        """Create a collector for the current configuration."""
-        self._core = Core(
-            warn=self._warn,
-            debug=(self._debug if self._debug.should("core") else None),
-            config=self.config,
-            dynamic_contexts=dynamic_contexts,
-        )
-        return Collector(
-            core=self._core,
-            should_trace=self._should_trace,
-            check_include=self._check_include_omit_etc,
-            should_start_context=self._should_start_context,
-            file_mapper=self._file_mapper,
-            branch=self.config.branch,
-            warn=self._warn,
-            concurrency=concurrency,
-        )
-
-    def _warn_no_sysmon_context_switching(self) -> bool:
-        """Warn when sysmon can't honor explicit context switching."""
-        assert self._collector is not None
-        assert self._core is not None
-
-        if self._core.tracer_class is not SysMonitor:
-            return False
-
-        self._warn(
-            "Can't use switch_context() with core=sysmon: "
-            "it doesn't yet support dynamic contexts, keeping the current context",
-            slug="no-sysmon",
-            once=True,
-        )
-        return True
 
     def _init_data(self, suffix: str | bool | None) -> None:
         """Create a data file if we don't have one yet."""
@@ -826,8 +794,11 @@ class Coverage(TConfigurable):
             raise CoverageException("Cannot switch context, coverage is not started")
 
         assert self._collector is not None
-        if self._warn_no_sysmon_context_switching():
-            return
+        if self._collector.tracer_name() == "SysMonitor":
+            raise CoverageException(
+                "Cannot switch context with core=sysmon: dynamic contexts are not supported, "
+                "use core=ctrace or core=pytrace instead",
+            )
         if self._collector.should_start_context:
             self._warn("Conflicting dynamic contexts", slug="dynamic-conflict", once=True)
 

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -612,9 +612,11 @@ class Coverage(TConfigurable):
 
         assert self._data is not None
         self._collector.use_data(self._data, self.config.context)
+        assert self._core is not None
+        core = self._core
 
         # Early warning if we aren't going to be able to support plugins.
-        if self._plugins.file_tracers and not self._core.supports_plugins:
+        if self._plugins.file_tracers and not core.supports_plugins:
             self._warn(
                 "Plugin file tracers ({}) aren't supported with {}".format(
                     ", ".join(
@@ -634,7 +636,7 @@ class Coverage(TConfigurable):
             include_namespace_packages=self.config.include_namespace_packages,
         )
         self._inorout.plugins = self._plugins
-        self._inorout.disp_class = self._core.file_disposition_class
+        self._inorout.disp_class = core.file_disposition_class
 
         # It's useful to write debug info after initing for start.
         self._should_write_debug = True

--- a/doc/contexts.rst
+++ b/doc/contexts.rst
@@ -67,6 +67,8 @@ There are three ways to enable dynamic contexts:
   :meth:`.Coverage.switch_context` method to set the context explicitly.
   The pytest plugin `pytest-cov`_ has a ``--cov-context`` option that uses this
   to set the dynamic context for each test.
+  This requires a settrace core such as ``ctrace`` or ``pytrace``;
+  ``core=sysmon`` does not support explicit context switching.
 
 .. _pytest-cov: https://pypi.org/project/pytest-cov/
 

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -154,6 +154,11 @@ Can't use core=sysmon: it doesn't yet support dynamic contexts, using default co
   This isn't supported by coverage.py yet.  A default core will be used
   instead.
 
+Can't use core=sysmon: it doesn't yet support dynamic contexts, using pytrace core (no-sysmon)
+  You requested dynamic contexts after starting measurement with the
+  sys.monitoring core. Coverage.py switches to the Python tracer so later
+  context changes are recorded correctly.
+
 Can't use core=sysmon: it doesn't support concurrency=ZZZ, using default core (no-sysmon)
   Your requested the sys.monitoring measurement core and also a particular
   concurrency setting, but that combination isn't supported.  A default core

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -154,10 +154,10 @@ Can't use core=sysmon: it doesn't yet support dynamic contexts, using default co
   This isn't supported by coverage.py yet.  A default core will be used
   instead.
 
-Can't use core=sysmon: it doesn't yet support dynamic contexts, using pytrace core (no-sysmon)
-  You requested dynamic contexts after starting measurement with the
-  sys.monitoring core. Coverage.py switches to the Python tracer so later
-  context changes are recorded correctly.
+Can't use switch_context() with core=sysmon: it doesn't yet support dynamic contexts, keeping the current context (no-sysmon)
+  You called :meth:`.Coverage.switch_context` while using the sys.monitoring
+  core. Coverage.py leaves the current context unchanged. Choose a different
+  core if you need dynamic contexts.
 
 Can't use core=sysmon: it doesn't support concurrency=ZZZ, using default core (no-sysmon)
   Your requested the sys.monitoring measurement core and also a particular

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -154,11 +154,6 @@ Can't use core=sysmon: it doesn't yet support dynamic contexts, using default co
   This isn't supported by coverage.py yet.  A default core will be used
   instead.
 
-Can't use switch_context() with core=sysmon: it doesn't yet support dynamic contexts, keeping the current context (no-sysmon)
-  You called :meth:`.Coverage.switch_context` while using the sys.monitoring
-  core. Coverage.py leaves the current context unchanged. Choose a different
-  core if you need dynamic contexts.
-
 Can't use core=sysmon: it doesn't support concurrency=ZZZ, using default core (no-sysmon)
   Your requested the sys.monitoring measurement core and also a particular
   concurrency setting, but that combination isn't supported.  A default core

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -857,8 +857,8 @@ class SwitchContextTest(CoverageTest):
 
 
 @pytest.mark.skipif(not env.PYBEHAVIOR.pep669, reason="No sys.monitoring core available.")
-class SwitchContextSysmonFallbackTest(CoverageTest):
-    """Tests for switching away from sysmon when contexts are requested."""
+class SwitchContextSysmonWarningTest(CoverageTest):
+    """Tests for switch_context() warnings under sysmon."""
 
     def make_test_files(self) -> None:
         """Create a tiny suite with a shared helper line."""
@@ -876,7 +876,7 @@ class SwitchContextSysmonFallbackTest(CoverageTest):
             """,
         )
 
-    def test_switch_context_falls_back_from_sysmon(self) -> None:
+    def test_switch_context_warns_and_keeps_sysmon(self) -> None:
         self.set_environ("COVERAGE_CORE", "sysmon")
         self.make_test_files()
 
@@ -886,27 +886,20 @@ class SwitchContextSysmonFallbackTest(CoverageTest):
             with pytest.warns(Warning) as warns:
                 cov.switch_context("multiply_zero")
                 assert cov._collector is not None
-                assert cov._collector.tracer_name() == "PyTracer"
+                assert cov._collector.tracer_name() == "SysMonitor"
                 suite.test_multiply_zero()
                 cov.switch_context("multiply_six")
                 suite.test_multiply_six()
 
         assert_coverage_warnings(
             warns,
-            "Can't use core=sysmon: it doesn't yet support dynamic contexts, using pytrace core"
+            "Can't use switch_context() with core=sysmon: "
+            "it doesn't yet support dynamic contexts, keeping the current context"
             " (no-sysmon)",
         )
 
         data = cov.get_data()
-        assert ["", "multiply_six", "multiply_zero"] == sorted(data.measured_contexts())
-
-        filenames = self.get_measured_filenames(data)
-        suite_filename = filenames["testsuite.py"]
-
-        data.set_query_context("multiply_six")
-        assert [2, 8] == sorted_lines(data, suite_filename)
-        data.set_query_context("multiply_zero")
-        assert [2, 5] == sorted_lines(data, suite_filename)
+        assert [""] == sorted(data.measured_contexts())
 
 
 class CurrentInstanceTest(CoverageTest):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -861,6 +861,7 @@ class SwitchContextSysmonFallbackTest(CoverageTest):
     """Tests for switching away from sysmon when contexts are requested."""
 
     def make_test_files(self) -> None:
+        """Create a tiny suite with a shared helper line."""
         self.make_file(
             "testsuite.py",
             """\

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -856,6 +856,58 @@ class SwitchContextTest(CoverageTest):
             cov.switch_context("test3")
 
 
+@pytest.mark.skipif(not env.PYBEHAVIOR.pep669, reason="No sys.monitoring core available.")
+class SwitchContextSysmonFallbackTest(CoverageTest):
+    """Tests for switching away from sysmon when contexts are requested."""
+
+    def make_test_files(self) -> None:
+        self.make_file(
+            "testsuite.py",
+            """\
+            def timestwo(x):
+                return x*2
+
+            def test_multiply_zero():
+                assert timestwo(0) == 0
+
+            def test_multiply_six():
+                assert timestwo(6) == 12
+            """,
+        )
+
+    def test_switch_context_falls_back_from_sysmon(self) -> None:
+        self.set_environ("COVERAGE_CORE", "sysmon")
+        self.make_test_files()
+
+        cov = coverage.Coverage()
+        with cov.collect():
+            suite = import_local_file("testsuite")
+            with pytest.warns(Warning) as warns:
+                cov.switch_context("multiply_zero")
+                assert cov._collector is not None
+                assert cov._collector.tracer_name() == "PyTracer"
+                suite.test_multiply_zero()
+                cov.switch_context("multiply_six")
+                suite.test_multiply_six()
+
+        assert_coverage_warnings(
+            warns,
+            "Can't use core=sysmon: it doesn't yet support dynamic contexts, using pytrace core"
+            " (no-sysmon)",
+        )
+
+        data = cov.get_data()
+        assert ["", "multiply_six", "multiply_zero"] == sorted(data.measured_contexts())
+
+        filenames = self.get_measured_filenames(data)
+        suite_filename = filenames["testsuite.py"]
+
+        data.set_query_context("multiply_six")
+        assert [2, 8] == sorted_lines(data, suite_filename)
+        data.set_query_context("multiply_zero")
+        assert [2, 5] == sorted_lines(data, suite_filename)
+
+
 class CurrentInstanceTest(CoverageTest):
     """Tests of Coverage.current()."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -857,49 +857,22 @@ class SwitchContextTest(CoverageTest):
 
 
 @pytest.mark.skipif(not env.PYBEHAVIOR.pep669, reason="No sys.monitoring core available.")
-class SwitchContextSysmonWarningTest(CoverageTest):
-    """Tests for switch_context() warnings under sysmon."""
+class SwitchContextSysmonErrorTest(CoverageTest):
+    """Tests for switch_context() errors under sysmon."""
 
-    def make_test_files(self) -> None:
-        """Create a tiny suite with a shared helper line."""
-        self.make_file(
-            "testsuite.py",
-            """\
-            def timestwo(x):
-                return x*2
-
-            def test_multiply_zero():
-                assert timestwo(0) == 0
-
-            def test_multiply_six():
-                assert timestwo(6) == 12
-            """,
-        )
-
-    def test_switch_context_warns_and_keeps_sysmon(self) -> None:
+    def test_switch_context_raises_with_sysmon(self) -> None:
         self.set_environ("COVERAGE_CORE", "sysmon")
-        self.make_test_files()
 
         cov = coverage.Coverage()
         with cov.collect():
-            suite = import_local_file("testsuite")
-            with pytest.warns(Warning) as warns:
+            with pytest.raises(
+                CoverageException,
+                match=(
+                    "Cannot switch context with core=sysmon: dynamic contexts are not supported, "
+                    "use core=ctrace or core=pytrace instead"
+                ),
+            ):
                 cov.switch_context("multiply_zero")
-                assert cov._collector is not None
-                assert cov._collector.tracer_name() == "SysMonitor"
-                suite.test_multiply_zero()
-                cov.switch_context("multiply_six")
-                suite.test_multiply_six()
-
-        assert_coverage_warnings(
-            warns,
-            "Can't use switch_context() with core=sysmon: "
-            "it doesn't yet support dynamic contexts, keeping the current context"
-            " (no-sysmon)",
-        )
-
-        data = cov.get_data()
-        assert [""] == sorted(data.measured_contexts())
 
 
 class CurrentInstanceTest(CoverageTest):


### PR DESCRIPTION
## Summary
- raise `CoverageException` if `switch_context()` is called while running on `core=sysmon`
- keep the existing startup-time fallback for configured dynamic contexts unchanged
- document that explicit context switching requires `ctrace` or `pytrace`, and add a regression test

## Problem
`switch_context()` worked under `ctrace`, but under `sysmon` a shared line hit by two contexts only kept the first one. The API path had no guard, so Python 3.14's default sysmon core could silently produce wrong context data.

## Solution
Instead of silently downgrading to a slower tracing core after measurement has already started, reject the API call and tell users to choose `core=ctrace` or `core=pytrace` explicitly when they need dynamic contexts.
