### PR TITLE
Don't emit 'Couldn't import C tracer' warning for 3.13t

### DIFF
--- a/coverage/env.py
+++ b/coverage/env.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import platform
 import sys
+import sysconfig
 from collections.abc import Iterable
 from typing import Any, Final
 
@@ -42,8 +43,14 @@ else:
 # Do we have a GIL?
 GIL = getattr(sys, "_is_gil_enabled", lambda: True)()
 
+# Is this a free-threaded build of CPython? Checks the build, not runtime GIL
+# state, since the GIL can be re-enabled at runtime on a free-threaded build.
+FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
 # Do we ship compiled coveragepy wheels for this version?
-SHIPPING_WHEELS = CPYTHON and PYVERSION[:2] <= (3, 14)
+SHIPPING_WHEELS = (
+    CPYTHON and PYVERSION[:2] <= (3, 14) and not (FREE_THREADED and PYVERSION[:2] == (3, 13))
+)
 
 # Should we default to sys.monitoring?
 SYSMON_DEFAULT = CPYTHON and PYVERSION >= (3, 14)


### PR DESCRIPTION
[coverage.py 7.14.2 no longer has 3.13t wheels](https://coverage.readthedocs.io/en/latest/changes.html#version-7-14-2-2026-06-20), and so falls back to the Python tracer and gives this warning:
```
coverage.exceptions.CoverageWarning: Couldn't import C tracer: No module named 'coverage.tracer' (no-ctracer); see https://coverage.readthedocs.io/en/7.14.2/messages.html#warning-no-ctracer
```

For example, https://github.com/prettytable/prettytable/actions/runs/27951172985/job/82708177859 with pytest config promoting warnings to errors.

The warning is only meant to be emitted when wheels are shipped, so update the constant.

However, we can't use the existing:

```python
GIL = getattr(sys, "_is_gil_enabled", lambda: True)()
```

because it's possible for the GIL can be re-enabled in a free-threaded build, so check for a free-threaded build instead:

```python
FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
```