### PR TITLE
Handle loop-completion arc before function exit

### DIFF
--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -771,6 +771,13 @@ CTracer_handle_return(CTracer *self, PyFrameObject *frame)
             real_return = !(is_yield || is_yield_from);
 #endif
             if (real_return) {
+                int lineno = PyFrame_GetLineNumber(frame);
+                if (lineno != self->pcur_entry->last_line) {
+                    if (CTracer_record_pair(self, self->pcur_entry->last_line, lineno) < 0) {
+                        goto error;
+                    }
+                    self->pcur_entry->last_line = lineno;
+                }
                 int first = MyFrame_BorrowCode(frame)->co_firstlineno;
                 if (CTracer_record_pair(self, self->pcur_entry->last_line, -first) < 0) {
                     goto error;

--- a/coverage/ctracer/tracer.c
+++ b/coverage/ctracer/tracer.c
@@ -771,12 +771,14 @@ CTracer_handle_return(CTracer *self, PyFrameObject *frame)
             real_return = !(is_yield || is_yield_from);
 #endif
             if (real_return) {
-                int lineno = PyFrame_GetLineNumber(frame);
-                if (lineno != self->pcur_entry->last_line) {
-                    if (CTracer_record_pair(self, self->pcur_entry->last_line, lineno) < 0) {
-                        goto error;
+                if (self->pcur_entry->file_tracer == Py_None) {
+                    int lineno = PyFrame_GetLineNumber(frame);
+                    if (lineno != self->pcur_entry->last_line) {
+                        if (CTracer_record_pair(self, self->pcur_entry->last_line, lineno) < 0) {
+                            goto error;
+                        }
+                        self->pcur_entry->last_line = lineno;
                     }
-                    self->pcur_entry->last_line = lineno;
                 }
                 int first = MyFrame_BorrowCode(frame)->co_firstlineno;
                 if (CTracer_record_pair(self, self->pcur_entry->last_line, -first) < 0) {

--- a/coverage/pytracer.py
+++ b/coverage/pytracer.py
@@ -295,6 +295,9 @@ class PyTracer(Tracer):
                     else:
                         real_return = True
                 if real_return:
+                    if frame.f_lineno != self.last_line:
+                        cast(set_TArc, self.cur_file_data).add((self.last_line, frame.f_lineno))
+                        self.last_line = frame.f_lineno
                     first = frame.f_code.co_firstlineno
                     cast(set_TArc, self.cur_file_data).add((self.last_line, -first))
 

--- a/tests/test_arcs.py
+++ b/tests/test_arcs.py
@@ -217,6 +217,23 @@ class SimpleArcTest(CoverageTest):
         )
         assert self.stdout() == "5\n"
 
+    def test_bug_2168(self) -> None:
+        self.check_coverage(
+            """\
+            def foo(*x):
+                for i in x:
+                    if i:
+                        break
+                pass
+
+            foo()
+            foo(0)
+            foo(1)
+            """,
+            branchz="23 25 32 34",
+            branchz_missing="",
+        )
+
     def test_bug_576(self) -> None:
         self.check_coverage(
             """\


### PR DESCRIPTION
## Summary
- fix the missing loop-completion arc on Python 3.14 when a `break` exits the final loop iteration immediately before function return
- apply the same correction in both the C tracer and Python tracer
- add a focused regression covering the `break` case

## Problem
Fixes #2168.

`coverage report -m` could show a missing branch after a `break`-driven loop exit on Python 3.14 even though the code path was executed.

## Solution
Record the current line as the final arc before emitting the function-exit arc when returning from a loop-completion path.
