### PR TITLE
Skip excluded functions in LCOV function totals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,12 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
-Nothing yet.
+- Fix: the LCOV report would incorrectly count excluded functions as uncovered,
+  as described in `issue 2205`_. This is now fixed thanks to, `Martin Kuntz
+  Jacobsen <pull 2206_>`_.
+
+.. _issue 2205:  https://github.com/coveragepy/coveragepy/issues/2205
+.. _pull 2206: https://github.com/coveragepy/coveragepy/pull/2206
 
 
 .. start-releases

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -166,6 +166,7 @@ Mariatta
 Marius Gedminas
 Mark van der Wal
 Martin Fuzzey
+Martin Kuntz Jacobsen
 Mathieu Kniewallner
 Matt Bachmann
 Matthew Boehm

--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -100,9 +100,8 @@ def lcov_functions(
         outfile.write(f"FN:{first_line},{last_line},{region.name}\n")
         outfile.write(f"FNDA:{hit},{region.name}\n")
 
-    if functions_found:
-        outfile.write(f"FNF:{functions_found}\n")
-        outfile.write(f"FNH:{functions_hit}\n")
+    outfile.write(f"FNF:{functions_found}\n")
+    outfile.write(f"FNH:{functions_hit}\n")
 
 
 def lcov_arcs(

--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -84,19 +84,25 @@ def lcov_functions(
     narrower.add_regions(r.lines for _, _, r in functions)
 
     functions.sort()
+    functions_found = 0
     functions_hit = 0
     for first_line, last_line, region in functions:
         # A function counts as having been executed if any of it has been
         # executed.
         analysis = narrower.narrow(region.lines)
+        if analysis.numbers.n_statements == 0:
+            continue
+
+        functions_found += 1
         hit = int(analysis.numbers.n_executed > 0)
         functions_hit += hit
 
         outfile.write(f"FN:{first_line},{last_line},{region.name}\n")
         outfile.write(f"FNDA:{hit},{region.name}\n")
 
-    outfile.write(f"FNF:{len(functions)}\n")
-    outfile.write(f"FNH:{functions_hit}\n")
+    if functions_found:
+        outfile.write(f"FNF:{functions_found}\n")
+        outfile.write(f"FNH:{functions_hit}\n")
 
 
 def lcov_arcs(

--- a/tests/test_lcov.py
+++ b/tests/test_lcov.py
@@ -388,6 +388,64 @@ class LcovTest(CoverageTest):
         actual_result = self.get_lcov_report_content()
         assert expected_result == actual_result
 
+    def test_excluded_functions(self) -> None:
+        self.make_file(
+            ".coveragerc",
+            """\
+            [report]
+            exclude_also =
+                @(abc\\.)?abstractmethod
+                raise NotImplementedError
+            """,
+        )
+        self.make_file(
+            "runme.py",
+            """\
+            from abc import ABC, abstractmethod
+
+            class Base(ABC):
+                @abstractmethod
+                def excluded_abstract(self):
+                    raise NotImplementedError
+
+                def covered(self):
+                    return 1
+
+            class Concrete(Base):
+                def excluded_abstract(self):
+                    return 2
+
+            assert Concrete().covered() == 1
+            assert Concrete().excluded_abstract() == 2
+            """,
+        )
+        cov = coverage.Coverage(source=".")
+        self.start_import_stop(cov, "runme")
+        cov.lcov_report()
+        expected_result = textwrap.dedent("""\
+            SF:runme.py
+            DA:1,1
+            DA:3,1
+            DA:8,1
+            DA:9,1
+            DA:11,1
+            DA:12,1
+            DA:13,1
+            DA:15,1
+            DA:16,1
+            LF:9
+            LH:9
+            FN:8,9,Base.covered
+            FNDA:1,Base.covered
+            FN:12,13,Concrete.excluded_abstract
+            FNDA:1,Concrete.excluded_abstract
+            FNF:2
+            FNH:2
+            end_of_record
+            """)
+        actual_result = self.get_lcov_report_content()
+        assert expected_result == actual_result
+
     def test_exit_branches(self) -> None:
         self.make_file(
             "runme.py",

--- a/tests/test_lcov.py
+++ b/tests/test_lcov.py
@@ -446,6 +446,43 @@ class LcovTest(CoverageTest):
         actual_result = self.get_lcov_report_content()
         assert expected_result == actual_result
 
+    def test_all_functions_excluded(self) -> None:
+        self.make_file(
+            ".coveragerc",
+            """\
+            [report]
+            exclude_also =
+                raise NotImplementedError
+            """,
+        )
+        self.make_file(
+            "runme.py",
+            """\
+            x = 1
+
+            def excluded():
+                raise NotImplementedError
+
+            assert x == 1
+            """,
+        )
+        cov = coverage.Coverage(source=".")
+        self.start_import_stop(cov, "runme")
+        cov.lcov_report()
+        expected_result = textwrap.dedent("""\
+            SF:runme.py
+            DA:1,1
+            DA:3,1
+            DA:6,1
+            LF:3
+            LH:3
+            FNF:0
+            FNH:0
+            end_of_record
+            """)
+        actual_result = self.get_lcov_report_content()
+        assert expected_result == actual_result
+
     def test_exit_branches(self) -> None:
         self.make_file(
             "runme.py",


### PR DESCRIPTION
Fixes #2205.

## Summary

- Skip LCOV function records when a function region has no reportable statements after exclusions are applied.
- Count `FNF` from emitted functions rather than all discovered function regions.
- Add a regression test for an excluded `@abstractmethod` that raises `NotImplementedError`.

## Details

Line records already respect report exclusions. Function records were still generated from all discovered function code regions, so a fully excluded abstract method could appear as `FNDA:0` and reduce downstream LCOV function coverage even when the text report shows 100% line coverage.

This narrows each function region before emission and skips regions with `n_statements == 0`, matching the line-reporting behavior for fully excluded code.

## Tests

- `.venv/bin/python -m pytest tests/test_lcov.py::LcovTest::test_excluded_functions -q -n 0`
- `.venv/bin/python -m pytest tests/test_lcov.py -q -n 0`
