### PR TITLE
Start attaching the loader on `__spec__`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,9 +32,17 @@ Unreleased
   as described in `issue 2205`_. This is now fixed thanks to `Martin Kuntz
   Jacobsen <pull 2206_>`_.
 
+- When running your program, coverage now correctly sets
+  ``yourmodule.__spec__.loader`` as `strongly recommended <--loader--_>`_,
+  avoiding the deprecation warning described in `issue 2208`_. Thanks, `A5rocks
+  <pull 2209_>`_.
+
+.. _--loader--: https://docs.python.org/3/reference/datamodel.html#module.__loader__
 .. _issue 2198:  https://github.com/coveragepy/coveragepy/issues/2198
 .. _issue 2205:  https://github.com/coveragepy/coveragepy/issues/2205
 .. _pull 2206: https://github.com/coveragepy/coveragepy/pull/2206
+.. _issue 2208:  https://github.com/coveragepy/coveragepy/issues/2208
+.. _pull 2209: https://github.com/coveragepy/coveragepy/pull/2209
 
 
 .. start-releases

--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -140,7 +140,7 @@ class PyRunner:
             if self.spec is not None:
                 self.modulename = self.spec.name
             self.loader = DummyLoader(self.modulename)
-            self.spec.loader = self.loader
+            self.spec.loader = self.loader  # type: ignore[assignment]
             assert pathname is not None
             self.pathname = os.path.abspath(pathname)
             self.args[0] = self.arg0 = self.pathname
@@ -163,7 +163,11 @@ class PyRunner:
             self.loader = DummyLoader("__main__")
 
             # Make a spec. I don't know if this is the right way to do it.
-            self.spec = importlib.machinery.ModuleSpec("__main__", self.loader, origin=try_filename)
+            self.spec = importlib.machinery.ModuleSpec(
+                "__main__",
+                self.loader,  # type: ignore[arg-type]
+                origin=try_filename,
+            )
             self.spec.has_location = True
         else:
             self.loader = DummyLoader("__main__")

--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -140,6 +140,7 @@ class PyRunner:
             if self.spec is not None:
                 self.modulename = self.spec.name
             self.loader = DummyLoader(self.modulename)
+            self.spec.loader = self.loader
             assert pathname is not None
             self.pathname = os.path.abspath(pathname)
             self.args[0] = self.arg0 = self.pathname
@@ -157,12 +158,13 @@ class PyRunner:
             else:
                 raise NoSource(f"Can't find '__main__' module in '{self.arg0}'")
 
-            # Make a spec. I don't know if this is the right way to do it.
             try_filename = python_reported_file(try_filename)
-            self.spec = importlib.machinery.ModuleSpec("__main__", None, origin=try_filename)
-            self.spec.has_location = True
             self.package = ""
             self.loader = DummyLoader("__main__")
+
+            # Make a spec. I don't know if this is the right way to do it.
+            self.spec = importlib.machinery.ModuleSpec("__main__", self.loader, origin=try_filename)
+            self.spec.has_location = True
         else:
             self.loader = DummyLoader("__main__")
 

--- a/tests/modules/checkspec.py
+++ b/tests/modules/checkspec.py
@@ -1,1 +1,1 @@
-assert __spec__.loader == __loader__
+assert __spec__.loader == __loader__  # type: ignore[name-defined]

--- a/tests/modules/checkspec.py
+++ b/tests/modules/checkspec.py
@@ -1,0 +1,1 @@
+assert __spec__.loader == __loader__

--- a/tests/test_execfile.py
+++ b/tests/test_execfile.py
@@ -342,3 +342,10 @@ class RunModuleTest(UsingModulesMixin, CoverageTest):
     def test_no_main(self) -> None:
         with pytest.raises(NoSource):
             run_python_module(["pkg2", "hi"])
+
+    def test_no_spec_deprecation(self) -> None:
+        # https://github.com/coveragepy/coveragepy/issues/2208
+        run_python_module(["checkspec"])
+        out, err = self.stdouterr()
+        assert out == ""
+        assert err == ""


### PR DESCRIPTION
Fixes https://github.com/coveragepy/coveragepy/issues/2208

[The documentation for `__loader__`](https://docs.python.org/3/reference/datamodel.html#module.__loader__) says:
> Deprecated since version 3.12, will be removed in version 3.16: Setting `__loader__` on a module while failing to set `__spec__.loader` is deprecated. In Python 3.16, `__loader__` will cease to be set or taken into consideration by the import system or the standard library.