### PR TITLE
Preserve isolated sys.path on Python 3.10

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,12 +37,19 @@ Unreleased
   avoiding the deprecation warning described in `issue 2208`_. Thanks, `A5rocks
   <pull 2209_>`_.
 
+- Fix: with Python 3.10, running with the ``-I`` (isolated mode) option didn't
+  correctly omit the current directory from the module search path, as
+  described in `issue 2103`_. That is now fixed thanks to `Ilia Sorokin <pull
+  2211_>`_.
+
 .. _--loader--: https://docs.python.org/3/reference/datamodel.html#module.__loader__
+.. _issue 2103:  https://github.com/coveragepy/coveragepy/issues/2103
 .. _issue 2198:  https://github.com/coveragepy/coveragepy/issues/2198
 .. _issue 2205:  https://github.com/coveragepy/coveragepy/issues/2205
 .. _pull 2206: https://github.com/coveragepy/coveragepy/pull/2206
 .. _issue 2208:  https://github.com/coveragepy/coveragepy/issues/2208
 .. _pull 2209: https://github.com/coveragepy/coveragepy/pull/2209
+.. _pull 2211: https://github.com/coveragepy/coveragepy/pull/2211
 
 
 .. start-releases

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,6 +106,7 @@ Holger Krekel
 Hugo van Kemenade
 Ian Moore
 Ilia Meerovich
+Ilia Sorokin
 Imri Goldberg
 Ionel Cristian Mărieș
 Ivan Ciuvalschii

--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -92,6 +92,8 @@ class PyRunner:
         """
         path0: str | None
         if getattr(sys.flags, "safe_path", False) or getattr(sys.flags, "isolated", False):
+            # Python 3.10 isolated mode predates sys.flags.safe_path.
+            # Remove the isolated fallback when coverage drops 3.10 support.
             # See https://docs.python.org/3/using/cmdline.html#cmdoption-P
             path0 = None
         elif self.as_module:

--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -92,6 +92,7 @@ class PyRunner:
         """
         path0: str | None
         if getattr(sys.flags, "safe_path", False) or getattr(sys.flags, "isolated", False):
+            # PYVERSION
             # Python 3.10 isolated mode predates sys.flags.safe_path.
             # Remove the isolated fallback when coverage drops 3.10 support.
             # See https://docs.python.org/3/using/cmdline.html#cmdoption-P

--- a/coverage/execfile.py
+++ b/coverage/execfile.py
@@ -91,7 +91,7 @@ class PyRunner:
         This needs to happen before any importing, and without importing anything.
         """
         path0: str | None
-        if getattr(sys.flags, "safe_path", False):
+        if getattr(sys.flags, "safe_path", False) or getattr(sys.flags, "isolated", False):
             # See https://docs.python.org/3/using/cmdline.html#cmdoption-P
             path0 = None
         elif self.as_module:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1000,6 +1000,12 @@ class EnvironmentTest(CoverageTest):
         actual = self.run_command("python -m coverage run run_me.py")
         self.assert_tryexecfile_output(expected, actual)
 
+    def test_isolated_dashm_runme(self) -> None:
+        self.make_file("run_me.py", TRY_EXECFILE_CODE)
+        expected = self.run_command("python -I run_me.py")
+        actual = self.run_command("python -Im coverage run run_me.py")
+        self.assert_tryexecfile_output(expected, actual)
+
     @pytest.mark.skipif(env.PYVERSION < (3, 11), reason="PYTHONSAFEPATH is new in 3.11")
     def test_pythonsafepath_dashm(self) -> None:
         self.make_file("with_main/__main__.py", TRY_EXECFILE_CODE)


### PR DESCRIPTION
## Summary
- preserve isolated-mode `sys.path` handling in `PyRunner.prepare()` even on Python versions without `sys.flags.safe_path`
- add a process-level regression that compares `python -I run_me.py` with `python -Im coverage run run_me.py`

## Problem
Fixes #2103.

On Python 3.10, `python -Im coverage run poc.py` was re-inserting the working directory at `sys.path[0]`, unlike plain `python -I poc.py`. That also displaced the interpreter's normal isolated-mode zip entry.

## Solution
Honor `sys.flags.isolated` alongside `sys.flags.safe_path` so isolated-mode runs keep the same path layout that plain Python uses.
