### PR TITLE
Import local plugins during combine

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -866,6 +866,9 @@ class CoverageScript:
             return self.do_run(options, args)
 
         elif options.action == "combine":
+            # We need to be able to import from the current directory, because
+            # plugins may live next to the config file being used.
+            sys.path.insert(0, "")
             if options.append:
                 self.coverage.load()
             data_paths = args or None

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1542,6 +1542,42 @@ class CmdLineDebugDataTest(BaseCmdLineTest):
             """)
 
 
+class CmdLineLocalPluginTest(CoverageTest):
+    """Command-line tests for importing local plugins from the current directory."""
+
+    run_in_temp_dir = True
+
+    def test_combine_imports_local_plugin(self) -> None:
+        self.make_file(
+            "pyproject.toml",
+            """\
+            [tool.coverage.run]
+            plugins = ["my_local_plugin"]
+            parallel = true
+            """,
+        )
+        self.make_file(
+            "my_local_plugin.py",
+            """\
+            def coverage_init(reg, options):
+                pass
+            """,
+        )
+        self.make_file("foo.py", "x = 1\n")
+
+        self.command_line("run foo.py")
+        self.assert_file_count(".coverage.*", 1)
+
+        self.command_line("combine")
+        assert "Combined 1 file" in self.stderr()
+        assert os.path.exists(".coverage")
+
+        cov = coverage.Coverage()
+        cov.load()
+        measured = cov.get_data().measured_files()
+        assert any(filename.endswith("foo.py") for filename in measured)
+
+
 class CmdLineStdoutTest(BaseCmdLineTest):
     """Test the command line with real stdout output."""
 


### PR DESCRIPTION
Fixes #1979.

## Problem
`coverage combine` reloads configured plugins before it makes the current working directory importable. Projects that keep a local plugin next to `pyproject.toml` can run `coverage run`, but `coverage combine` then fails with `ModuleNotFoundError` for that same plugin.

## Solution
Add the current directory to `sys.path` for the `combine` command before plugin loading starts, matching the existing behavior used by the reporting commands.
