### PR TITLE
Remove a cast that occurs in the hot path in AstArcAnalyzer

### DIFF
--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -752,9 +752,8 @@ class AstArcAnalyzer:
 
         """
         node_name = node.__class__.__name__
-        handler = cast(
-            Optional[Callable[[ast.AST], TLineNo]],
-            getattr(self, f"_line__{node_name}", None),
+        handler: Callable[[ast.AST], TLineNo] | None = getattr(
+            self, f"_line__{node_name}", None,
         )
         if handler is not None:
             line = handler(node)
@@ -836,9 +835,8 @@ class AstArcAnalyzer:
 
         """
         node_name = node.__class__.__name__
-        handler = cast(
-            Optional[Callable[[ast.AST], set[ArcStart]]],
-            getattr(self, f"_handle__{node_name}", None),
+        handler: Callable[[ast.AST], set[ArcStart]] | None = getattr(
+            self, f"_handle__{node_name}", None,
         )
         if handler is not None:
             arc_starts = handler(node)

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -753,7 +753,9 @@ class AstArcAnalyzer:
         """
         node_name = node.__class__.__name__
         handler: Callable[[ast.AST], TLineNo] | None = getattr(
-            self, f"_line__{node_name}", None,
+            self,
+            f"_line__{node_name}",
+            None,
         )
         if handler is not None:
             line = handler(node)
@@ -836,7 +838,9 @@ class AstArcAnalyzer:
         """
         node_name = node.__class__.__name__
         handler: Callable[[ast.AST], set[ArcStart]] | None = getattr(
-            self, f"_handle__{node_name}", None,
+            self,
+            f"_handle__{node_name}",
+            None,
         )
         if handler is not None:
             arc_starts = handler(node)


### PR DESCRIPTION
I'm not sure why this was a cast, but it doesn't appear to be necessary any more. Since cast() evaluates its first argument, this constructs a new `collections.abc.Callable` on every call. This change speeds up arc analysis somewhere around 10% for pyca/cryptography (which is, admittedly, only about 100-200ms).