### PR TITLE
enable only sys.monitoring events that have registered callbacks

### DIFF
--- a/coverage/sysmon.py
+++ b/coverage/sysmon.py
@@ -359,7 +359,8 @@ class SysMonitor(Tracer):
                 finally:
                     self.unlock_data()
                 file_data = self.data[tracename]
-                b2l = bytes_to_lines(code)
+                # byte_to_line is only read by the arc callbacks
+                b2l = bytes_to_lines(code) if self.trace_arcs else None
             else:
                 file_data = None
                 b2l = None
@@ -381,10 +382,12 @@ class SysMonitor(Tracer):
                 with self.lock:
                     if self.sysmon_on:
                         assert sys_monitoring is not None
-                        local_events = events.PY_RETURN | events.PY_RESUME | events.LINE
+                        local_events = events.LINE
                         if self.trace_arcs:
                             assert env.PYBEHAVIOR.branch_right_left
-                            local_events |= events.BRANCH_RIGHT | events.BRANCH_LEFT
+                            local_events |= (
+                                events.PY_RETURN | events.BRANCH_RIGHT | events.BRANCH_LEFT
+                            )
                         sys_monitoring.set_local_events(self.myid, code, local_events)
 
                         if LOG:  # pragma: debugging


### PR DESCRIPTION
Local events included `PY_RETURN|PY_RESUME`  even in modes that register no callback for them. Enabled events with no callback still dispatch on every hit, and never get disabled since only a callback can return DISABLE -- so every return/resume of traced code paid dispatch cost Line mode also skips the byte-to-line map now, which only arc callbacks read.

Some benchmarks (all values relative to an uninstrumented Python 3.14.6).

### Line mode

| workload | overhead before | overhead after |
|---|---:|---:|
| generators, sysmon_bench micro (generator resumes) | 1.29x | 1.02x |
| nqueens, pyperformance | 1.26x | 1.14x |
| richards, pyperformance | 1.20x | 1.02x |

### Branch mode

| workload  | overhead before | overhead after |
|---|---:|---:|
| generators, sysmon_bench micro (generator resumes) | 1.29x | 1.00x |
| nqueens, pyperformance | 1.26x | 1.14x |
| richards, pyperformance | 1.03x | 1.02x | 


I'm sorry about all these separate PRs @nedbat, let me know if there's anything I can do to make this easier (or just stop until you've had time to digest them!).