### PR TITLE
resolve sysmon branch events lazily, one pair at a time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,8 @@ Unreleased
 
 - A number of performance improvements thanks to Paul Kehrer, in pull requests
   `2213 <pull 2213_>`_, `2214 <pull 2214_>`_, `2215 <pull 2215_>`_, `2216
-  <pull 2216_>`_, `2218 <pull 2218_>`_, and `2220 <pull 2220_>`_.
+  <pull 2216_>`_, `2218 <pull 2218_>`_, `2220 <pull 2220_>`_, and `2221 <pull
+  2221_>`_.
 
 .. _pull 2213: https://github.com/coveragepy/coveragepy/pull/2213
 .. _pull 2214: https://github.com/coveragepy/coveragepy/pull/2214
@@ -38,6 +39,7 @@ Unreleased
 .. _pull 2216: https://github.com/coveragepy/coveragepy/pull/2216
 .. _pull 2218: https://github.com/coveragepy/coveragepy/pull/2218
 .. _pull 2220: https://github.com/coveragepy/coveragepy/pull/2220
+.. _pull 2221: https://github.com/coveragepy/coveragepy/pull/2221
 .. _pull 2224: https://github.com/coveragepy/coveragepy/pull/2224
 
 .. start-releases

--- a/coverage/bytecode.py
+++ b/coverage/bytecode.py
@@ -5,11 +5,9 @@
 
 from __future__ import annotations
 
-import collections
 import dis
 from collections.abc import Iterable, Mapping
 from types import CodeType
-from typing import Optional
 
 from coverage.types import TArc, TLineNo, TOffset
 
@@ -108,148 +106,103 @@ RETURNS = op_set(
     "RETURN_GENERATOR",
 )
 
-# Opcodes that do nothing.
-NOPS = op_set(
-    "NOP",
-    "NOT_TAKEN",
-)
+
+# CACHE doesn't exist in Python 3.10, but the branch resolver is only used
+# on 3.14+, so a placeholder value is fine.
+_CACHE = dis.opmap.get("CACHE", -1)
+_EXTENDED_ARG = dis.opmap["EXTENDED_ARG"]
+
+# All opcodes with a jump target.
+JUMPS = set(dis.hasjrel) | set(dis.hasjabs)
+
+# Opcodes that jump backwards.
+BACKWARD_JUMPS = {op for op in JUMPS if "JUMP_BACKWARD" in dis.opname[op]}
 
 
-class InstructionWalker:
-    """Utility to step through trails of instructions.
+class BranchArcResolver:
+    """Resolve branch events to line arcs, one (source, dest) pair at a time.
 
-    We have two reasons to need sequences of instructions from a code object:
-    First, in strict sequence to visit all the instructions in the object.
-    This is `walk(follow_jumps=False)`.  Second, we want to follow jumps to
-    understand how execution will flow: `walk(follow_jumps=True)`.
+    Branch events are one-shot (they are DISABLEd after firing), so each
+    (source offset, destination offset) pair is resolved at most a couple of
+    times per code object.  Resolving pairs on demand is much cheaper than
+    precomputing trails for every branch in the code object, most of which
+    never fire.  We walk the raw bytecode bytes so that we never need to
+    disassemble whole code objects with `dis`.
+
+    To resolve one pair:
+    starting from the destination, follow the trail of instructions (through
+    unconditional jumps) until we reach an instruction on a new source line
+    (giving us the arc), a return (an arc to leaving the code object), or
+    another branch possibility (no arc: that branch will produce its own
+    events).
+
     """
 
-    def __init__(self, code: CodeType) -> None:
+    def __init__(
+        self,
+        code: CodeType,
+        byte_to_line: Mapping[TOffset, TLineNo],
+        multiline_map: Mapping[TLineNo, TLineNo],
+    ) -> None:
         self.code = code
-        self.insts: dict[TOffset, dis.Instruction] = {}
+        # co_code re-copies the bytes on each access, so fetch it once.
+        self.co_code = code.co_code
+        self.byte_to_line = byte_to_line
+        self.multiline_map = multiline_map
 
-        inst = None
-        for inst in dis.get_instructions(code):
-            self.insts[inst.offset] = inst
+    def line_at(self, offset: TOffset) -> TLineNo | None:
+        """The source line of the instruction at `offset`, de-multilined."""
+        line = self.byte_to_line.get(offset)
+        if line is not None:
+            line = self.multiline_map.get(line, line)
+        return line
 
-        assert inst is not None
-        self.max_offset = inst.offset
-
-    def walk(
-        self, *, start_at: TOffset = 0, follow_jumps: bool = True
-    ) -> Iterable[dis.Instruction]:
-        """
-        Yield instructions starting from `start_at`.  Follow unconditional
-        jumps if `follow_jumps` is true.
-        """
-        seen = set()
-        offset = start_at
-        while offset < self.max_offset + 1:
-            if offset in seen:
-                break
-            seen.add(offset)
-            if inst := self.insts.get(offset):
-                yield inst
-                if follow_jumps and inst.opcode in ALWAYS_JUMPS:
-                    offset = inst.jump_target
-                    continue
-            offset += 2
-
-
-TBranchTrailsOneSource = dict[Optional[TArc], set[TOffset]]
-TBranchTrails = dict[TOffset, TBranchTrailsOneSource]
-
-
-def branch_trails(
-    code: CodeType,
-    multiline_map: Mapping[TLineNo, TLineNo],
-) -> TBranchTrails:
-    """
-    Calculate branch trails for `code`.
-
-    `multiline_map` maps line numbers to the first line number of a
-    multi-line statement.
-
-    Instructions can have a jump_target, where they might jump to next.  Some
-    instructions with a jump_target are unconditional jumps (ALWAYS_JUMPS), so
-    they aren't interesting to us, since they aren't the start of a branch
-    possibility.
-
-    Instructions that might or might not jump somewhere else are branch
-    possibilities.  For each of those, we track a trail of instructions.  These
-    are lists of instruction offsets, the next instructions that can execute.
-    We follow the trail until we get to a new source line.  That gives us the
-    arc from the original instruction's line to the new source line.
-
-    """
-    the_trails: TBranchTrails = collections.defaultdict(lambda: collections.defaultdict(set))
-    iwalker = InstructionWalker(code)
-    for inst in iwalker.walk(follow_jumps=False):
-        if not inst.jump_target:
-            # We only care about instructions with jump targets.
-            continue
-        if inst.opcode in ALWAYS_JUMPS:
-            # We don't care about unconditional jumps.
-            continue
-
-        from_line = inst.line_number
+    def resolve(self, source: TOffset, dest: TOffset) -> TArc | None:
+        """Turn a branch event's (source, dest) offsets into an arc, or None."""
+        from_line = self.line_at(source)
         if from_line is None:
-            continue
-        from_line = multiline_map.get(from_line, from_line)
-
-        def add_one_branch_trail(
-            trails: TBranchTrailsOneSource,
-            start_at: TOffset,
-        ) -> None:
-            # pylint: disable=cell-var-from-loop
-            inst_offsets: set[TOffset] = set()
-            to_line = None
-            for inst2 in iwalker.walk(start_at=start_at, follow_jumps=True):
-                inst_offsets.add(inst2.offset)
-                l2 = inst2.line_number
-                if l2 is not None:
-                    l2 = multiline_map.get(l2, l2)
-                if l2 and l2 != from_line:
-                    to_line = l2
-                    break
-                elif inst2.jump_target and (inst2.opcode not in ALWAYS_JUMPS):
-                    break
-                elif inst2.opcode in RETURNS:
-                    to_line = -code.co_firstlineno
-                    break
-            if to_line is not None:
-                trails[(from_line, to_line)].update(inst_offsets)
-            else:
-                trails[None] = set()
-
-        # Calculate two trails: one from the next instruction, and one from the
-        # jump_target instruction.
-        trails: TBranchTrailsOneSource = collections.defaultdict(set)
-        add_one_branch_trail(trails, start_at=inst.offset + 2)
-        add_one_branch_trail(trails, start_at=inst.jump_target)
-        the_trails[inst.offset] = trails
-
-        # Sometimes we get BRANCH_RIGHT or BRANCH_LEFT events from instructions
-        # other than the original jump possibility instruction.  Register each
-        # trail under all of their offsets so we can pick up in the middle of a
-        # trail if need be.
-        for arc, offsets in trails.items():
-            for offset in offsets:
-                the_trails[offset][arc].update(offsets)
-
-    return the_trails
-
-
-def always_jumps(code: CodeType) -> dict[TOffset, TOffset]:
-    """Make a map of unconditional bytecodes jumping to others.
-
-    Only include bytecodes that do no work and go to another bytecode.
-    """
-    jumps = {}
-    iwalker = InstructionWalker(code)
-    for inst in iwalker.walk(follow_jumps=False):
-        if inst.opcode in ALWAYS_JUMPS:
-            jumps[inst.offset] = inst.jump_target
-        elif inst.opcode in NOPS:
-            jumps[inst.offset] = inst.offset + 2
-    return jumps
+            return None
+        co_code = self.co_code
+        max_offset = len(co_code)
+        byte_to_line = self.byte_to_line
+        multiline_map = self.multiline_map
+        offset = dest
+        ext_arg = 0
+        seen: set[TOffset] = set()
+        while 0 <= offset < max_offset and offset not in seen:
+            seen.add(offset)
+            op = co_code[offset]
+            if op == _CACHE:
+                offset += 2
+                continue
+            if op == _EXTENDED_ARG:
+                ext_arg = (ext_arg | co_code[offset + 1]) << 8
+                offset += 2
+                continue
+            line = byte_to_line.get(offset)
+            if line is not None:
+                line = multiline_map.get(line, line)
+                if line and line != from_line:
+                    return (from_line, line)
+            if op in JUMPS:
+                if op in ALWAYS_JUMPS:
+                    arg = ext_arg | co_code[offset + 1]
+                    # Jump distances are measured from the end of the
+                    # instruction's inline CACHE entries, which appear in
+                    # co_code as CACHE opcodes immediately following it.
+                    next_offset = offset + 2
+                    while next_offset < max_offset and co_code[next_offset] == _CACHE:
+                        next_offset += 2
+                    if op in BACKWARD_JUMPS:
+                        offset = next_offset - 2 * arg
+                    else:
+                        offset = next_offset + 2 * arg
+                    ext_arg = 0
+                    continue
+                # Another branch possibility: it will get its own events.
+                return None
+            if op in RETURNS:
+                return (from_line, -self.code.co_firstlineno)
+            ext_arg = 0
+            offset += 2
+        return None

--- a/coverage/sysmon.py
+++ b/coverage/sysmon.py
@@ -20,7 +20,7 @@ from types import CodeType
 from typing import Any, NewType, Optional, cast
 
 from coverage import env
-from coverage.bytecode import TBranchTrails, always_jumps, branch_trails, bytes_to_lines
+from coverage.bytecode import BranchArcResolver, bytes_to_lines
 from coverage.debug import short_filename, short_stack
 from coverage.exceptions import NoSource
 from coverage.misc import isolate_module
@@ -177,17 +177,9 @@ class CodeInfo:
     file_data: TTraceFileData | None
     byte_to_line: dict[TOffset, TLineNo] | None
 
-    # Keys are start instruction offsets for branches.
-    # Values are dicts:
-    #   {
-    #       (from_line, to_line): {offset, offset, ...},
-    #       (from_line, to_line): {offset, offset, ...},
-    #   }
-    branch_trails: TBranchTrails
-
-    # Always-jumps are bytecode offsets that do no work but move
-    # to another offset.
-    always_jumps: dict[TOffset, TOffset]
+    # Lazily-created resolver of branch events to arcs, created on the
+    # first branch event in the code object.
+    branch_resolver: BranchArcResolver | None
 
 
 class SysMonitor(Tracer):
@@ -374,8 +366,7 @@ class SysMonitor(Tracer):
                 tracing=tracing_code,
                 file_data=file_data,
                 byte_to_line=b2l,
-                branch_trails={},
-                always_jumps={},
+                branch_resolver=None,
             )
             self.code_infos[id(code)] = code_info
             self.code_objects.append(code)
@@ -460,34 +451,21 @@ class SysMonitor(Tracer):
         code_info = self.code_infos[id(code)]
         # code_info is not None and code_info.file_data is not None, since we
         # wouldn't have enabled this event if they were.
-        if not code_info.branch_trails:
+        resolver = code_info.branch_resolver
+        if resolver is None:
             if self.stats is not None:
                 self.stats["branch_trails"] += 1
-            multiline_map = self.get_multiline_map(code.co_filename)
-            code_info.branch_trails = branch_trails(code, multiline_map=multiline_map)
-            code_info.always_jumps = always_jumps(code)
-            # log(f"branch_trails for {code}:\n{ppformat(code_info.branch_trails)}")
-        added_arc = False
-        dest_info = code_info.branch_trails.get(instruction_offset)
-
-        # Re-map the destination offset through always-jumps to deal with NOP etc.
-        dests = {destination_offset}
-        while (dest := code_info.always_jumps.get(destination_offset)) is not None:
-            destination_offset = dest
-            dests.add(destination_offset)
-
-        # log(f"dest_info = {ppformat(dest_info)}")
-        if dest_info is not None:
-            for arc, offsets in dest_info.items():
-                if arc is None:
-                    continue
-                if dests & offsets:
-                    code_info.file_data.add(arc)  # type: ignore
-                    # log(f"adding {arc=}")
-                    added_arc = True
-                    break
-
-        if not added_arc:
+            assert code_info.byte_to_line is not None
+            resolver = code_info.branch_resolver = BranchArcResolver(
+                code,
+                code_info.byte_to_line,
+                self.get_multiline_map(code.co_filename),
+            )
+        arc = resolver.resolve(instruction_offset, destination_offset)
+        if arc is not None:
+            code_info.file_data.add(arc)  # type: ignore
+            # log(f"adding {arc=}")
+        else:
             # This could be an exception jumping from line to line.
             assert code_info.byte_to_line is not None
             l1 = code_info.byte_to_line.get(instruction_offset)


### PR DESCRIPTION
Like #2220, this PR was generated via claude but has undergone significant review and changes based on that review before submission.

sysmon branch mode currently pre-analyzes every branch site in a code object on that object's first branch event. This is two `dis.get_instructions()` decodes plus trail walks per conditional jump. Since branch events are one-shot (each site/direction is DISABLEd after first fire), at most two (source, destination) pairs per site ever need resolving, so this PR drops the precompute and resolves each pair lazily as its event arrives by walking the raw co_code bytes from the destination; `branch_trails()`, `always_jumps()`, and `InstructionWalker` are removed.

This results in a quite significant performance improvement in cryptography's test suite (these numbers do not include the other performance optimizations that have recently landed as I ran them before rebasing to main)

| Configuration | Wall time | Overhead|
-- | -- | --
No coverage | 35.44 s | —
sysmon branch, main | 47.90 s | +35.2%
sysmon branch, this PR | 38.33 s | +8.2%

In conjunction with #2220 it looks like we'll have branch coverage down to a similar overhead as line coverage with the sysmon core.

I'm very open to ideas on how we can improve the confidence in correctness/reviewability for this! 😄  I've run it against both this branch and latest coverage.py on several suites without seeing regression, but LLM-driven significant refactors like this (even with ongoing human feedback during the process, as this had) make me nervous since I lack a deep understanding. I've reviewed this and at the very least it isn't clearly wrong, but that's not a sufficient bar.