### PR TITLE
Fix false missing branch for one-line class body with sysmon core (#2167)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ Unreleased
   `2213 <pull 2213_>`_, `2214 <pull 2214_>`_, `2215 <pull 2215_>`_, `2216
   <pull 2216_>`_, and `2218 <pull 2218_>`_.
 
+- Fix: a one-line class body immediately followed by another statement (such as
+  ``class Foo: ...`` on its own line) was incorrectly reported as a missing
+  branch with the sys.monitoring core, which is the default on Python 3.14, as
+  described in `issue 2167`_. This is now fixed.
+
+.. _issue 2167: https://github.com/coveragepy/coveragepy/issues/2167
 .. _pull 2213: https://github.com/coveragepy/coveragepy/pull/2213
 .. _pull 2214: https://github.com/coveragepy/coveragepy/pull/2214
 .. _pull 2215: https://github.com/coveragepy/coveragepy/pull/2215

--- a/coverage/sysmon.py
+++ b/coverage/sysmon.py
@@ -187,6 +187,10 @@ class CodeInfo:
     # to another offset.
     always_jumps: dict[TOffset, TOffset]
 
+    # The last line seen executing in this code object, used to record
+    # sequential fall-through arcs that aren't the result of a branch.
+    last_line: TLineNo | None = None
+
 
 class SysMonitor(Tracer):
     """Python implementation of the raw data tracer for PEP669 implementations."""
@@ -416,6 +420,11 @@ class SysMonitor(Tracer):
             arc = (last_line, -code.co_firstlineno)
             code_info.file_data.add(arc)  # type: ignore
             # log(f"adding {arc=}")
+        # This frame is ending, so the next line seen in this code object
+        # belongs to a different frame (e.g. another recursion of the same
+        # function).  Forget the last line so we don't join two frames with a
+        # bogus sequential arc.
+        code_info.last_line = None  # type: ignore
         return DISABLE
 
     @panopticon("code", "line")
@@ -442,6 +451,18 @@ class SysMonitor(Tracer):
         # wouldn't have enabled this event if they were.
         arc = (line_number, line_number)
         code_info.file_data.add(arc)  # type: ignore
+
+        # The self-arc above is later resolved to a real branch arc, but only
+        # when the line has a single possible destination.  A line with a
+        # single-line class or function body (e.g. ``class C: ...``) can fall
+        # through to the next statement while also being the source of the
+        # nested body's exit arc, giving it two possible destinations.  Record
+        # the true sequential transition between consecutive lines in this frame
+        # so that fall-through isn't misreported as a missing branch.  #2167
+        last_line = code_info.last_line
+        if last_line is not None and last_line != line_number:
+            code_info.file_data.add((last_line, line_number))  # type: ignore
+        code_info.last_line = line_number
         # log(f"adding {arc=}")
         return DISABLE
 

--- a/tests/test_arcs.py
+++ b/tests/test_arcs.py
@@ -239,6 +239,45 @@ class SimpleArcTest(CoverageTest):
         )
         assert self.stdout() == "Done\n"
 
+    def test_bug_2167(self) -> None:
+        # A one-line class body followed by another statement was reported as
+        # missing the fall-through branch ("line 1 didn't jump to line 4") with
+        # the sys.monitoring core, because the class body's exit arc gives the
+        # class line a second destination that defeated the resolution of the
+        # sequential fall-through.  The class line is fully covered.
+        self.check_coverage(
+            """\
+            class Foo: ...
+
+
+            pass
+            """,
+            branchz="1. 14",
+            branchz_missing="",
+        )
+        # It happens for any one-line class body, not just `...`.
+        self.check_coverage(
+            """\
+            class Foo: x = 1
+
+
+            pass
+            """,
+            branchz="1. 14",
+            branchz_missing="",
+        )
+        # And when the following statement is itself a branch.
+        self.check_coverage(
+            """\
+            class A: ...
+            if len([]) == 0:
+                x = 1
+            print(x)
+            """,
+            branchz="1. 12 23 24",
+            branchz_missing="24",
+        )
+
 
 class WithTest(CoverageTest):
     """Arc-measuring tests involving context managers."""


### PR DESCRIPTION
## Summary

On Python 3.14 (the default `sys.monitoring` core), a one-line class body immediately followed by another statement is wrongly reported as an uncovered branch, e.g. `line 1 didn't jump to line 4`. This is `class Foo: ...` (or any one-line body such as `x = 1`) on its own line, followed by any statement. Reported in #2167.

```python
class Foo: ...


pass
```

Before: `1->4` reported as a missing branch (75%). After: 100%, matching the `ctrace` core, Python 3.13, EOF, and multi-line class forms.

## Fix

The `sysmon` core records sequential (non-branch) transitions as self-arcs `(n, n)` and relies on a later pass to resolve them to the real destination, but only when the line has a single possible destination. A one-line class body's exit arc `(1, -1)` gives the class line a *second* possible destination, so the fall-through self-arc `(1, 1)` was never resolved to `(1, 4)`, and `1->4` was reported missing.

The fix records the true sequential transition between consecutive lines in a frame (like the `ctrace` and `pytracer` cores already do), in `sysmon_line_arcs`. `last_line` is tracked per `CodeInfo` and cleared on `PY_RETURN` so recursive frames of the same code object aren't joined by a bogus arc. The change is localized to `coverage/sysmon.py` and touches neither the parser's arc analysis nor the C tracer.

## Tests

Added `SimpleArcTest.test_bug_2167` in `tests/test_arcs.py` using the existing arc-testing helpers. It covers the exact 3-line repro, a non-`...` one-line body, and a following branch statement. The test fails on `main` (`Wrong missing branches: [] != [(1, 4)]`) and passes with the fix.

Verified locally on CPython 3.14.6:
- New test passes; `test_arcs.py`, `test_coverage.py`, `test_results.py`, `test_parser.py`, `test_api.py`, `test_html.py` all green.
- A differential check across 23 constructs (recursion, loops, generators, `match`, comprehensions, `try`/`except`, decorators, `with`) confirms `sysmon` now matches both the `ctrace` core and Python 3.13 exactly, with no new false positives or negatives.
- `ruff format --check` clean; `pylint` clean; `mypy --python-version=3.14 --strict coverage` clean.
- Added a `CHANGES.rst` entry.

Disclosure: prepared with AI assistance; reviewed and verified locally.
