### PR TITLE
fix: escape context labels in html report inline script block

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,11 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
+- Fix: in the HTML report with ``show_contexts`` enabled, a context label
+  containing ``</script>`` (for example a parametrized pytest node id) could
+  close the inline ``<script>`` element in a file page early, injecting markup.
+  Context labels are now escaped for that context.
+
 - A number of performance improvements thanks to Paul Kehrer, in pull requests
   `2213 <pull 2213_>`_, `2214 <pull 2214_>`_, `2215 <pull 2215_>`_, `2216
   <pull 2216_>`_, and `2218 <pull 2218_>`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Unreleased
 - Fix: in the HTML report with ``show_contexts`` enabled, a context label
   containing ``</script>`` (for example a parametrized pytest node id) could
   close the inline ``<script>`` element in a file page early, injecting markup.
-  Context labels are now escaped for that context.
+  Context labels are now fully escaped. Thanks, `Rajath Mohare <pull 2224_>`_.
 
 - A number of performance improvements thanks to Paul Kehrer, in pull requests
   `2213 <pull 2213_>`_, `2214 <pull 2214_>`_, `2215 <pull 2215_>`_, `2216
@@ -37,6 +37,7 @@ Unreleased
 .. _pull 2215: https://github.com/coveragepy/coveragepy/pull/2215
 .. _pull 2216: https://github.com/coveragepy/coveragepy/pull/2216
 .. _pull 2218: https://github.com/coveragepy/coveragepy/pull/2218
+.. _pull 2224: https://github.com/coveragepy/coveragepy/pull/2224
 
 .. start-releases
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -213,6 +213,7 @@ Peter Baughman
 Peter Ebden
 Peter Portante
 Phebe Polk
+Rajath Mohare
 Reya B
 Ricardo Newbery
 Robert Harris

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -492,9 +492,9 @@ class HtmlReporter:
                     {encode_int(v): k for (k, v) in context_codes.items()},
                     indent=2,
                 )
-                .replace("<", "\\u003c")
-                .replace(">", "\\u003e")
-                .replace("&", "\\u0026")
+                .replace("<", r"\u003c")
+                .replace(">", r"\u003e")
+                .replace("&", r"\u0026")
             )
         else:
             contexts_json = None

--- a/coverage/html.py
+++ b/coverage/html.py
@@ -483,9 +483,18 @@ class HtmlReporter:
         contexts = collections.Counter(c for cline in file_data.lines for c in cline.contexts)
         context_codes = {y: i for (i, y) in enumerate(x[0] for x in contexts.most_common())}
         if context_codes:
-            contexts_json = json.dumps(
-                {encode_int(v): k for (k, v) in context_codes.items()},
-                indent=2,
+            # This JSON is dropped straight into an inline <script> element, so
+            # the HTML-significant characters have to be escaped as \uXXXX to keep
+            # a context label like "</script>" from closing the element early.
+            # The escapes are still valid JSON, so the parsed values are unchanged.
+            contexts_json = (
+                json.dumps(
+                    {encode_int(v): k for (k, v) in context_codes.items()},
+                    indent=2,
+                )
+                .replace("<", "\\u003c")
+                .replace(">", "\\u003e")
+                .replace("&", "\\u0026")
             )
         else:
             contexts_json = None

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -25,6 +25,7 @@ import coverage.html
 from coverage import env, Coverage
 from coverage.exceptions import NoDataError, NotPython, NoSource
 from coverage.files import abs_file, flat_rootname
+from coverage.misc import import_local_file
 from coverage.report_core import get_analysis_to_report
 from coverage.types import TLineNo, TMorf
 
@@ -1549,17 +1550,13 @@ class HtmlWithContextsTest(HtmlTestHelpers, CoverageTest):
         # switch_context takes an arbitrary string (pytest-cov passes test node
         # ids), so a label can contain "</script>".  It's dropped into an inline
         # <script> block in the file page, and must not close the element early.
-        from coverage.misc import import_local_file
-
         label = "</script><img src=x onerror=alert(1)>"
         self.make_file("two_tests.py", self.SOURCE)
         cov = coverage.Coverage(source=["."])
         cov.set_option("html:show_contexts", True)
-        cov.start()
-        cov.switch_context(label)
-        mod = import_local_file("two_tests")
-        cov.stop()
-        cov.save()
+        with cov.collect():
+            cov.switch_context(label)
+            mod = import_local_file("two_tests")
         cov.html_report(mod, directory="htmlcov")
 
         html = self.get_html_report_content("two_tests.py")

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1545,6 +1545,31 @@ class HtmlWithContextsTest(HtmlTestHelpers, CoverageTest):
             ]
             assert sorted(expected) == sorted(actual)
 
+    def test_context_labels_cant_break_out_of_script(self) -> None:
+        # switch_context takes an arbitrary string (pytest-cov passes test node
+        # ids), so a label can contain "</script>".  It's dropped into an inline
+        # <script> block in the file page, and must not close the element early.
+        from coverage.misc import import_local_file
+
+        label = "</script><img src=x onerror=alert(1)>"
+        self.make_file("two_tests.py", self.SOURCE)
+        cov = coverage.Coverage(source=["."])
+        cov.set_option("html:show_contexts", True)
+        cov.start()
+        cov.switch_context(label)
+        mod = import_local_file("two_tests")
+        cov.stop()
+        cov.save()
+        cov.html_report(mod, directory="htmlcov")
+
+        html = self.get_html_report_content("two_tests.py")
+        assert label not in html
+        assert "\\u003c/script\\u003e" in html
+        # The escaped JSON still decodes to the original label.
+        blob = re.search(r"contexts = (\{.*?\n\s*\})", html, re.DOTALL)
+        assert blob is not None
+        assert label in json.loads(blob.group(1)).values()
+
 
 class HtmlHelpersTest(HtmlTestHelpers, CoverageTest):
     """Tests of the helpers in HtmlTestHelpers."""


### PR DESCRIPTION
With `coverage html --show-contexts`, each file page carries its context labels as JSON inside an inline `<script>` element. `switch_context` takes any string (pytest-cov feeds it test node ids, which can hold arbitrary characters through parametrization), so a label like `</script>...` closes the script element early and the browser parses whatever follows as live markup in the published report.

Escape the HTML-significant characters in that JSON as `\uXXXX` right where it's built. The escapes are still valid JSON, so `coverage_html.js` reads the same label values back, and keeping the escaping at the serialization point covers every label without each context producer having to sanitize its own strings.