### PR TITLE
fix: neutralize control characters in lcov report fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
+- Fix: the LCOV report wrote file names and other fields into its
+  line-oriented records without neutralizing control characters. A measured
+  file whose name contained a newline (legal on POSIX) could forge extra
+  records, inflating the coverage seen by tools that read the report. Control
+  characters in a field are now replaced.
+
 - Fix: in the HTML report with ``show_contexts`` enabled, a context label
   containing ``</script>`` (for example a parametrized pytest node id) could
   close the inline ``<script>`` element in a file page early, injecting markup.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,8 +28,16 @@ Unreleased
   and prev/next links, so it could close the attribute early and inject markup.
   Page URLs are now escaped. Thanks, `Rajath Mohare <pull 2227_>`_.
 
+- Fix: the LCOV report wrote file names and other fields into its
+  line-oriented records without neutralizing control characters. A measured
+  file whose name contained a newline (legal on POSIX) could forge extra
+  records, inflating the coverage seen by tools that read the report. Control
+  characters in a field are now replaced. Thanks, `Rajath Mohare <pull
+  2226_>`_.
+
 - Wheels are now provided for Python 3.15.
 
+.. _pull 2226: https://github.com/coveragepy/coveragepy/pull/2226
 .. _pull 2227: https://github.com/coveragepy/coveragepy/pull/2227
 
 

--- a/coverage/lcovreport.py
+++ b/coverage/lcovreport.py
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
     from coverage import Coverage
 
 
+def lcov_field(text: str) -> str:
+    """Make `text` safe to write as a field in a single LCOV record.
+
+    LCOV records are newline-delimited and the format has no escaping, so a
+    value carrying a newline (a legal character in a POSIX file name) would
+    spill into fabricated records. Replace any control characters, which can't
+    appear in a valid one-line field, and leave printable text untouched.
+    """
+    if text.isprintable():
+        return text
+    return "".join(ch if ch.isprintable() else "?" for ch in text)
+
+
 def line_hash(line: str) -> str:
     """Produce a hash of a source line for use in the LCOV file."""
     # The LCOV file format optionally allows each line to be MD5ed as a
@@ -97,8 +110,9 @@ def lcov_functions(
         hit = int(analysis.numbers.n_executed > 0)
         functions_hit += hit
 
-        outfile.write(f"FN:{first_line},{last_line},{region.name}\n")
-        outfile.write(f"FNDA:{hit},{region.name}\n")
+        name = lcov_field(region.name)
+        outfile.write(f"FN:{first_line},{last_line},{name}\n")
+        outfile.write(f"FNDA:{hit},{name}\n")
 
     outfile.write(f"FNF:{functions_found}\n")
     outfile.write(f"FNH:{functions_hit}\n")
@@ -145,7 +159,7 @@ def lcov_arcs(
         destinations.sort(key=lambda d: (d[0] < 0, d))
 
         for dst, hit in destinations:
-            branch = fr.arc_description(line, dst)
+            branch = lcov_field(fr.arc_description(line, dst))
             outfile.write(f"BRDA:{line},0,{branch},{hit}\n")
 
     # Summary of the branch coverage.
@@ -207,7 +221,7 @@ class LcovReporter:
             if self.config.skip_empty:
                 return
 
-        outfile.write(f"SF:{rel_fname}\n")
+        outfile.write(f"SF:{lcov_field(rel_fname)}\n")
 
         lines = sorted(analysis.statements)
         if self.config.lcov_line_checksums:

--- a/tests/test_lcov.py
+++ b/tests/test_lcov.py
@@ -6,9 +6,13 @@
 from __future__ import annotations
 
 import math
+import os
 import textwrap
 
+import pytest
+
 import coverage
+from coverage import env
 
 from tests.coveragetest import CoverageTest
 
@@ -124,6 +128,27 @@ class LcovTest(CoverageTest):
             """)
         actual_result = self.get_lcov_report_content()
         assert expected_result == actual_result
+
+    @pytest.mark.skipif(env.WINDOWS, reason="Newlines are disallowed in Windows filenames.")
+    def test_newline_in_filename_does_not_inject_records(self) -> None:
+        # A POSIX file name may contain a newline. Written verbatim into the
+        # line-oriented LCOV format it would forge extra records (a fake file,
+        # inflated hit counts), so control characters in a field are replaced.
+        evil = "a\nLH:9999\nSF:injected.py\nend_of_record\nreal.py"
+        self.make_file(evil, "a = 1\nb = 2\n")
+        self.make_data_file(lines={os.path.abspath(evil): [1, 2]})
+        cov = coverage.Coverage()
+        cov.load()
+        cov.lcov_report()
+        expected_result = textwrap.dedent("""\
+            SF:a?LH:9999?SF:injected.py?end_of_record?real.py
+            DA:1,1
+            DA:2,1
+            LF:2
+            LH:2
+            end_of_record
+            """)
+        assert expected_result == self.get_lcov_report_content()
 
     def test_simple_line_coverage_two_files(self) -> None:
         # Test that line coverage is created when coverage is run,


### PR DESCRIPTION
The lcov writer drops file names and the function and branch fields straight into its newline-delimited records with no escaping, unlike the html, markdown, xml, and json reports which each neutralize untrusted values. A source file whose name contains a newline (legal on POSIX, and reachable whenever coverage measures a tree you don't fully control) spills past the `SF:` line and forges its own `SF`/`DA`/`LH` records, so a downstream reader like genhtml or a CI coverage gate sees fabricated files and inflated hit counts.

`lcov_field` replaces control characters in each field right before it's written, keeping the value on one line while leaving normal names (printable, including non-ASCII) untouched. Keeping the guard at the write sites covers every field the format treats as free text in one spot, with no change to valid output. The added test measures a file whose name embeds a fake record and checks the report stays a single `SF` record.