### PR TITLE
fix: reduce memory use during reporting. #2229

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,12 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
-Nothing yet.
+- Fix: one of the performance improvements in 7.15.1 (pull 2215) dramatically
+  increased memory use during reporting for large projects. Now we use a
+  different approach that is both faster and slimmer than 7.15.0. Fixes `issue
+  2229`_.
+
+.. _issue 2229:  https://github.com/coveragepy/coveragepy/issues/2229
 
 
 .. start-releases

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -304,8 +304,6 @@ class Coverage(TConfigurable):
         self._file_mapper: Callable[[str], str] = abs_file
         self._data_suffix = self._run_suffix = None
         self._exclude_re: dict[str, str] = {}
-        self._analysis_cache: dict[TMorf, Analysis] = {}
-        self._file_reporter_cache: dict[TMorf, FileReporter] = {}
         self._old_sigterm: Callable[[int, FrameType | None], Any] | None = None
 
         # State machine variables:
@@ -567,7 +565,6 @@ class Coverage(TConfigurable):
         if not should_skip:
             assert self._data is not None
             self._data.read()
-        self._clear_analysis_caches()
 
     def _init_for_start(self) -> None:
         """Initialization for start()"""
@@ -780,7 +777,6 @@ class Coverage(TConfigurable):
         self._data.erase(parallel=self.config.parallel)
         self._data = None
         self._inited_for_start = False
-        self._clear_analysis_caches()
 
     def switch_context(self, new_context: str) -> None:
         """Switch to a new dynamic context.
@@ -913,7 +909,6 @@ class Coverage(TConfigurable):
             keep=keep,
             message=self._message,
         )
-        self._clear_analysis_caches()
 
     def get_data(self) -> CoverageData:
         """Get the collected data.
@@ -935,7 +930,6 @@ class Coverage(TConfigurable):
                     self._collector.plugin_was_disabled(plugin)
 
             if self._collector.flush_data():
-                self._clear_analysis_caches()
                 self._post_save_work()
 
         assert self._data is not None
@@ -1004,26 +998,17 @@ class Coverage(TConfigurable):
             analysis.missing_formatted(),
         )
 
-    def _analyze(self, morf: TMorf) -> Analysis:
+    def _analyze(self, morf: TMorf, file_reporter: FileReporter | None = None) -> Analysis:
         """Analyze a module or file.  Private for now."""
-        analysis = self._analysis_cache.get(morf)
-        if analysis is not None:
-            return analysis
-
         self._init()
         self._post_init()
 
         data = self.get_data()
-        file_reporter = self._get_file_reporter(morf)
+        if file_reporter is None:
+            file_reporter = self._get_file_reporter(morf)
         filename = self._file_mapper(file_reporter.filename)
         analysis = analysis_from_file_reporter(data, self.config.precision, file_reporter, filename)
-        self._analysis_cache[morf] = analysis
         return analysis
-
-    def _clear_analysis_caches(self) -> None:
-        """Forget cached analyses and file reporters, because data changed."""
-        self._analysis_cache.clear()
-        self._file_reporter_cache.clear()
 
     def branch_stats(self, morf: TMorf) -> dict[TLineNo, tuple[int, int]]:
         """Get branch statistics about a module.
@@ -1041,9 +1026,6 @@ class Coverage(TConfigurable):
 
     def _get_file_reporter(self, morf: TMorf) -> FileReporter:
         """Get a FileReporter for a module or file name."""
-        cached = self._file_reporter_cache.get(morf)
-        if cached is not None:
-            return cached
         assert self._data is not None
         plugin = None
         file_reporter: str | FileReporter = "python"
@@ -1068,7 +1050,6 @@ class Coverage(TConfigurable):
             file_reporter = PythonFileReporter(morf, self)
 
         assert isinstance(file_reporter, FileReporter)
-        self._file_reporter_cache[morf] = file_reporter
         return file_reporter
 
     def _get_file_reporters(
@@ -1093,7 +1074,6 @@ class Coverage(TConfigurable):
         if not isinstance(morfs, (list, tuple, set)):
             morfs = [morfs]  # type: ignore[list-item]
 
-        morfs = sorted(morfs, key=lambda m: m if isinstance(m, str) else m.__name__)
         return [(self._get_file_reporter(morf), morf) for morf in morfs]
 
     def _prepare_data_for_reporting(self) -> None:

--- a/coverage/parser.py
+++ b/coverage/parser.py
@@ -336,8 +336,10 @@ class PythonParser:
         `_all_arcs` is the set of arcs in the code.
 
         """
-        assert self._ast_root is not None
-        aaa = AstArcAnalyzer(self.filename, self._ast_root, self.raw_statements, self.multiline_map)
+        ast_root = self._ast_root
+        if ast_root is None:
+            ast_root = ast.parse(self.text)
+        aaa = AstArcAnalyzer(self.filename, ast_root, self.raw_statements, self.multiline_map)
         aaa.analyze()
         arcs = aaa.arcs
         self._with_jump_fixers = aaa.with_jump_fixers()
@@ -352,6 +354,10 @@ class PythonParser:
                 self._all_arcs.add((fl1, fl2))
 
         self._missing_arc_fragments = aaa.missing_arc_fragments
+
+        # The AST is large and no longer needed: everything derived from it is
+        # memoized above.  Release it so long-lived parsers don't hold it.
+        self._ast_root = None
 
     def fix_with_jumps(self, arcs: Iterable[TArc]) -> set[TArc]:
         """Adjust arcs to fix jumps leaving `with` statements.

--- a/coverage/python.py
+++ b/coverage/python.py
@@ -172,7 +172,6 @@ class PythonFileReporter(FileReporter):
 
         self._source: str | None = None
         self._parser: PythonParser | None = None
-        self._excluded = None
 
     def __repr__(self) -> str:
         return f"<PythonFileReporter {self.filename!r}>"

--- a/coverage/report_core.py
+++ b/coverage/report_core.py
@@ -93,9 +93,15 @@ def get_analysis_to_report(
     if not fr_morfs:
         raise NoDataError("No data to report.")
 
-    for fr, morf in sorted(fr_morfs):
+    # fr_morfs is a complete list of all files. FileReporters start very small,
+    # but when you use one, it becomes large. We don't want to hold onto them
+    # longer than we need to, so instead of a for loop, we'll pop and discard
+    # the file reporters as we go.
+    fr_morfs.sort(reverse=True)
+    while fr_morfs:
+        fr, morf = fr_morfs.pop()
         try:
-            analysis = coverage._analyze(morf)
+            analysis = coverage._analyze(morf, file_reporter=fr)
         except NotPython:
             # Only report errors for .py files, and only if we didn't
             # explicitly suppress those errors.


### PR DESCRIPTION
Reduce FileReporter memory usage. No need for caches. This is both faster and smaller than 7.15.0. Using the reproducer from #2229:
- 7.15.0: 35.19s,   206Mb mem
- 7.15.1: 33.65s, 1,243Mb mem
- this PR: 26.38s, 160Mb mem

This approach drops objects that aren't needed anymore to reduce the memory footprint, and uses existing FileReporters where we already have them rather than re-creating them.

I thought about not making a complete list of FileReporters, but they are small at first. If we think that could be a benefit, that can come later.