### PR TITLE
Generate implicit aliases for nested relative paths

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -531,10 +531,10 @@ class PathAliases:
             path = relative_filename(path)
 
         if self.relative and not isabs_anywhere(path):
-            # Auto-generate a pattern to implicitly match relative files
+            # Auto-generate patterns to implicitly match relative files.
             parts = re.split(r"[/\\]", path)
-            if len(parts) > 1:
-                dir1 = parts[0]
+            generated = False
+            for dir1 in parts[:-1]:
                 pattern = f"*/{dir1}"
                 regex_pat = rf"^(.*[\\/])?{re.escape(dir1)}[\\/]"
                 result = f"{dir1}{os.sep}"
@@ -544,7 +544,9 @@ class PathAliases:
                         f"Generating rule: {pattern!r} -> {result!r} using regex {regex_pat!r}",
                     )
                     self.aliases.append((pattern, re.compile(regex_pat), result))
-                    return self.map(path, exists=exists)
+                    generated = True
+            if generated:
+                return self.map(path, exists=exists)
 
         self.debugfn(f"No rules match, path {path!r} is unchanged")
         return path

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -688,6 +688,14 @@ class PathAliasesTest(CoverageTest):
             r"project\module\tests\file.py",
         )
 
+    def test_implicit_relative_path_uses_existing_suffix(self) -> None:
+        # https://github.com/coveragepy/coveragepy/issues/2195
+        aliases = PathAliases(relative=True)
+        filename = os_sep("work/project/project/src/pkg/module.py")
+        expected = os_sep("src/pkg/module.py")
+
+        assert aliases.map(filename, exists=lambda path: path == expected) == expected
+
     def test_multiple_wildcard(self, rel_yn: bool) -> None:
         aliases = PathAliases(relative=rel_yn)
         aliases.add("/home/jenkins/*/a/*/b/*/django", "./django")


### PR DESCRIPTION
## What changed

- Generate implicit relative-path aliases for every directory component instead of only the first component.
- Add a regression test for a combined path whose usable local source is a deeper existing suffix.

## Why

With `relative_files = true`, the first relative filename seen during combine could generate an alias such as `*/work -> work/`. If that target did not exist locally, the path stayed unchanged even when a deeper suffix such as `src/pkg/module.py` did exist. Because input file ordering can vary, this produced intermittent `No source for code` errors.

Fixes #2195

## Tests

- `python -m pytest tests/test_files.py::PathAliasesTest::test_implicit_relative_path_uses_existing_suffix -q`
- `python -m pytest tests/test_files.py -q`
- `tox -q -e py313` (C tracer: 1592 passed; Python tracer: 1561 passed; sys.monitoring: 1542 passed)
- `tox -q -e lint`
- `tox -q -e mypy`
- `pre-commit run --files coverage/files.py tests/test_files.py`