### PR TITLE
Warn when sysmon cannot switch dynamic contexts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,19 @@ upgrading your version of coverage.py.
     ..  Version 9.8.1 — 2027-07-27
     ..  --------------------------
 
+Unreleased
+----------
+
+- Fix: the sysmon core is incompatible with dynamic contexts. Previously, the
+  combination would be prevented when read from the coverage.py configuration.
+  But using the context API as pytest-cov does, contexts would be silently
+  dropped. Now a warning is issued, thanks to `Jisang Han <pull 2234_>`_.
+  Closes `issue 2200`_.
+
+.. _issue 2200: https://github.com/coveragepy/coveragepy/issues/2200
+.. _pull 2234: https://github.com/coveragepy/coveragepy/pull/2234
+
+
 .. start-releases
 
 .. _changes_7-15-2:

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -123,6 +123,7 @@ Jeremy Fleischman
 Jerin Peter George
 Jessamyn Smith
 Jianrong Zhao
+Jisang Han
 Joanna Ejzel
 Joe Doherty
 Joe Jevnik

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -795,6 +795,14 @@ class Coverage(TConfigurable):
             raise CoverageException("Cannot switch context, coverage is not started")
 
         assert self._collector is not None
+        assert self._core is not None
+        if not self._core.supports_dynamic_contexts:
+            self._warn(
+                "switch_context() is not supported with core=sysmon; "
+                "context data may be incomplete",
+                slug="no-sysmon-context",
+                once=True,
+            )
         if self._collector.should_start_context:
             self._warn("Conflicting dynamic contexts", slug="dynamic-conflict", once=True)
 

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -797,7 +797,8 @@ class Coverage(TConfigurable):
         assert self._core is not None
         if not self._core.supports_dynamic_contexts:
             self._warn(
-                "Dynamic contexts aren't supported with core=sysmon; context data may be incomplete",
+                "Dynamic contexts aren't supported with core=sysmon; "
+                + "context data may be incomplete",
                 slug="no-sysmon-context",
                 once=True,
             )

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -794,15 +794,14 @@ class Coverage(TConfigurable):
         if not self._started:  # pragma: part started
             raise CoverageException("Cannot switch context, coverage is not started")
 
-        assert self._collector is not None
         assert self._core is not None
         if not self._core.supports_dynamic_contexts:
             self._warn(
-                "switch_context() is not supported with core=sysmon; "
-                "context data may be incomplete",
+                "Dynamic contexts aren't supported with core=sysmon; context data may be incomplete",
                 slug="no-sysmon-context",
                 once=True,
             )
+        assert self._collector is not None
         if self._collector.should_start_context:
             self._warn("Conflicting dynamic contexts", slug="dynamic-conflict", once=True)
 

--- a/coverage/core.py
+++ b/coverage/core.py
@@ -51,6 +51,7 @@ class Core:
     tracer_kwargs: dict[str, Any]
     file_disposition_class: type[TFileDisposition]
     supports_plugins: bool
+    supports_dynamic_contexts: bool
     packed_arcs: bool
     systrace: bool
 
@@ -116,18 +117,21 @@ class Core:
             self.tracer_class = SysMonitor
             self.file_disposition_class = FileDisposition
             self.supports_plugins = False
+            self.supports_dynamic_contexts = False
             self.packed_arcs = False
             self.systrace = False
         elif core_name == "ctrace":
             self.tracer_class = coverage.tracer.CTracer
             self.file_disposition_class = coverage.tracer.CFileDisposition
             self.supports_plugins = True
+            self.supports_dynamic_contexts = True
             self.packed_arcs = True
             self.systrace = True
         elif core_name == "pytrace":
             self.tracer_class = PyTracer
             self.file_disposition_class = FileDisposition
             self.supports_plugins = False
+            self.supports_dynamic_contexts = True
             self.packed_arcs = False
             self.systrace = True
         else:

--- a/doc/messages.rst
+++ b/doc/messages.rst
@@ -155,9 +155,16 @@ Can't use core=sysmon: it doesn't yet support dynamic contexts, using default co
   instead.
 
 Can't use core=sysmon: it doesn't support concurrency=ZZZ, using default core (no-sysmon)
-  Your requested the sys.monitoring measurement core and also a particular
+  You requested the sys.monitoring measurement core and also a particular
   concurrency setting, but that combination isn't supported.  A default core
   will be used instead.
+
+.. _warning_no_sysmon_context:
+
+Dynamic contexts aren't supported with core=sysmon; context data may be incomplete (no-sysmon-context)
+  You are using the sys.monitoring measurement core, and are changing the
+  dynamic context. Those two features are incompatible. Context data will be
+  lost. Change your configuration to use the ctrace core.
 
 
 Disabling warnings

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -735,6 +735,19 @@ class ApiTest(CoverageTest):
             d = dict(cov.sys_info())
         assert cast(str, d["data_file"]).endswith(".coverage")
 
+    @pytest.mark.skipif(not testenv.SYS_MON, reason="Only sysmon drops dynamic contexts.")
+    def test_switch_context_sysmon_warning(self) -> None:
+        cov = coverage.Coverage(config_file=False)
+        with cov.collect():
+            with pytest.warns(Warning) as warns:
+                cov.switch_context("test_a")
+                cov.switch_context("test_b")
+        assert_coverage_warnings(
+            warns,
+            "switch_context() is not supported with core=sysmon; "
+            "context data may be incomplete (no-sysmon-context)",
+        )
+
 
 @pytest.mark.skipif(not testenv.DYN_CONTEXTS, reason="No dynamic contexts with this core.")
 class SwitchContextTest(CoverageTest):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -744,8 +744,7 @@ class ApiTest(CoverageTest):
                 cov.switch_context("test_b")
         assert_coverage_warnings(
             warns,
-            "switch_context() is not supported with core=sysmon; "
-            "context data may be incomplete (no-sysmon-context)",
+            "Dynamic contexts aren't supported with core=sysmon; context data may be incomplete (no-sysmon-context)",
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -742,11 +742,11 @@ class ApiTest(CoverageTest):
             with pytest.warns(Warning) as warns:
                 cov.switch_context("test_a")
                 cov.switch_context("test_b")
-        assert_coverage_warnings(
-            warns,
-            "Dynamic contexts aren't supported with core=sysmon; "
-            + "context data may be incomplete (no-sysmon-context)",
-        )
+            assert_coverage_warnings(
+                warns,
+                "Dynamic contexts aren't supported with core=sysmon; "
+                + "context data may be incomplete (no-sysmon-context)",
+            )
 
 
 @pytest.mark.skipif(not testenv.DYN_CONTEXTS, reason="No dynamic contexts with this core.")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -744,7 +744,8 @@ class ApiTest(CoverageTest):
                 cov.switch_context("test_b")
         assert_coverage_warnings(
             warns,
-            "Dynamic contexts aren't supported with core=sysmon; context data may be incomplete (no-sysmon-context)",
+            "Dynamic contexts aren't supported with core=sysmon; "
+            + "context data may be incomplete (no-sysmon-context)",
         )
 
 


### PR DESCRIPTION
## What

Add an explicit core capability for dynamic contexts and warn once when `switch_context()` is used with the sys.monitoring core.

## Why

The sysmon core cannot currently honor dynamic context switches. Programmatic calls previously continued silently, which could produce incomplete per-context data without any indication to the caller.

Fixes #2200

## Tests

- `COVERAGE_CORE=sysmon python -m pytest -q tests/test_api.py::ApiTest::test_switch_context_sysmon_warning`
- `COVERAGE_CORE=ctrace python -m pytest -q tests/test_api.py::SwitchContextTest`
- `COVERAGE_CORE=pytrace python -m pytest -q tests/test_api.py::SwitchContextTest`
- `HYPOTHESIS_PROFILE=ci tox -q -e py314`
- `python -m mypy --python-version=3.14 --strict coverage tests setup.py`
- `ruff format --check coverage/control.py coverage/core.py tests/test_api.py`
- `python -m pylint --notes= coverage/control.py coverage/core.py tests/test_api.py`
- `pre-commit run --files coverage/control.py coverage/core.py tests/test_api.py`