### PR TITLE
Add Coverage.clear_data() for lightweight data reset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,14 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
-Nothing yet.
+- Added :meth:`Coverage.clear_data <coverage.Coverage.clear_data>`, a
+  lighter-weight alternative to :meth:`~coverage.Coverage.erase` for clearing
+  collected data between measurement cycles. Unlike ``erase()``, it doesn't
+  force the next ``start()`` to redo the collector/tracer setup, which makes
+  repeated start/stop/clear loops on the same ``Coverage`` object much
+  cheaper. Closes `issue 2139`_.
+
+.. _issue 2139: https://github.com/coveragepy/coveragepy/issues/2139
 
 
 .. start-releases

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -778,6 +778,35 @@ class Coverage(TConfigurable):
         self._data = None
         self._inited_for_start = False
 
+    def clear_data(self) -> None:
+        """Clear collected coverage data, without discarding start() setup.
+
+        Unlike :meth:`erase`, this does not force the next :meth:`start` to
+        redo the (potentially expensive) initialization performed by the
+        first :meth:`start`. This is useful when repeatedly starting and
+        stopping measurement with the same :class:`Coverage` object, and
+        only a fresh slate of data is needed between cycles, with no change
+        in configuration.
+
+        .. versionadded:: ???
+
+        """
+        self._init()
+        self._post_init()
+        if self._collector is not None:
+            self._collector.reset()
+        self._close_data()
+        self._init_data(suffix=None)
+        assert self._data is not None
+        if self._collector is not None:
+            self._collector.use_data(self._data, self.config.context)
+
+    def _close_data(self) -> None:
+        """Close our current `CoverageData`, if any, and forget it."""
+        if self._data is not None:
+            self._data.close(force=True)
+            self._data = None
+
     def switch_context(self, new_context: str) -> None:
         """Switch to a new dynamic context.
 

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -788,7 +788,7 @@ class Coverage(TConfigurable):
         only a fresh slate of data is needed between cycles, with no change
         in configuration.
 
-        .. versionadded:: ???
+        .. versionadded:: 7.16
 
         """
         self._init()
@@ -805,6 +805,8 @@ class Coverage(TConfigurable):
         """Close our current `CoverageData`, if any, and forget it."""
         if self._data is not None:
             self._data.close(force=True)
+            if self._data in self._data_to_close:
+                self._data_to_close.remove(self._data)
             self._data = None
 
     def switch_context(self, new_context: str) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -422,6 +422,18 @@ class ApiTest(CoverageTest):
         cov.clear_data()
         assert cov.get_data().measured_files() == set()
 
+    def test_clear_data_doesnt_accumulate_data_objects(self) -> None:
+        # clear_data() closes the old CoverageData and makes a fresh one, but
+        # it shouldn't leave the closed objects piling up in _data_to_close
+        # for the life of the process.
+        cov = coverage.Coverage(data_file=None)
+        cov.start()
+        cov.stop()
+        before = len(cov._data_to_close)
+        for _ in range(10):
+            cov.clear_data()
+        assert len(cov._data_to_close) == before
+
     def test_empty_reporting(self) -> None:
         # empty summary reports raise exception, just like the xml report
         cov = coverage.Coverage()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -367,6 +367,61 @@ class ApiTest(CoverageTest):
         self.assert_doesnt_exist(".coverage")
         assert os.listdir(".") == []
 
+    def test_clear_data(self) -> None:
+        # https://github.com/coveragepy/coveragepy/issues/2139
+        cov = coverage.Coverage(data_file=None)
+
+        def f1() -> None:  # pragma: nested
+            a = 1  # pylint: disable=unused-variable
+
+        one_line_number = f1.__code__.co_firstlineno + 1
+        lines = []
+
+        def run_one_function(f: Callable[[], None]) -> None:
+            cov.clear_data()
+            with cov.collect():
+                f()
+
+            fs = cov.get_data().measured_files()
+            lines.append(cov.get_data().lines(list(fs)[0]))
+
+        run_one_function(f1)
+        run_one_function(f1)
+        run_one_function(f1)
+        assert lines == [[one_line_number]] * 3
+        self.assert_doesnt_exist(".coverage")
+        assert os.listdir(".") == []
+
+    def test_clear_data_keeps_start_setup(self) -> None:
+        # clear_data() shouldn't force re-running _init_for_start(): the
+        # collector/core/inorout objects built by the first start() should
+        # still be in use after a clear_data() + start() cycle.
+        cov = coverage.Coverage(data_file=None)
+        cov.start()
+        cov.stop()
+        collector_before = cov._collector
+        core_before = cov._core
+        inorout_before = cov._inorout
+        assert cov._inited_for_start
+
+        cov.clear_data()
+        assert cov._inited_for_start
+
+        cov.start()
+        cov.stop()
+        assert cov._collector is collector_before
+        assert cov._core is core_before
+        assert cov._inorout is inorout_before
+
+    def test_clear_data_gives_fresh_data(self) -> None:
+        self.make_file("clear_data_1.py", "a = 1\nb = 2\n")
+        cov = coverage.Coverage(data_file=None)
+        self.start_import_stop(cov, "clear_data_1")
+        assert cov.get_data().measured_files()
+
+        cov.clear_data()
+        assert cov.get_data().measured_files() == set()
+
     def test_empty_reporting(self) -> None:
         # empty summary reports raise exception, just like the xml report
         cov = coverage.Coverage()


### PR DESCRIPTION
## Summary

`erase()` clears collected coverage data, but it also sets things up so
the next `start()` reruns `_init_for_start()` — rebuilding `Core`,
`Collector`, and `InOrOut`, and re-registering the atexit/sigterm
handlers. For code that starts/stops measurement on the same
`Coverage` instance many times in a row and only needs a clean slate
of data between cycles (tracing configuration doesn't change), that
reinitialization is pure overhead.

This adds `Coverage.clear_data()`: it closes and replaces the current
`CoverageData`, but leaves the existing collector/tracer setup alone
so the next `start()` doesn't redo the expensive part.

Closes #2139, which includes a benchmark showing the reinitialization
overhead and the speedup from avoiding it.

## Changes

- `coverage/control.py`: new `Coverage.clear_data()` method, plus a
  small `_close_data()` helper it shares the "close and forget the
  current CoverageData" logic with.
- `tests/test_api.py`: tests that `clear_data()` gives a fresh data set,
  that repeated cycles behave like the existing `erase()`-based test,
  and that the collector/core/inorout objects from the first `start()`
  are still the ones in use after a `clear_data()` + `start()` cycle.
- `CHANGES.rst`: entry under "Unreleased".

## Test plan

- `pytest tests/test_api.py tests/test_data.py tests/test_collector.py` — all passing
- `ruff format --check`, `pylint`, and `mypy --strict` all clean on the touched files
- Ran the benchmark script from the issue with `clear_data()` substituted for the manual workaround; confirms the same order-of-magnitude speedup and no extra atexit-callback accumulation