### PR TITLE
Set dynamic_context for static and class method tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,12 @@ upgrading your version of coverage.py.
 Unreleased
 ----------
 
-Nothing yet.
+- Fix: with ``dynamic_context = test_function``, tests written as
+  ``@staticmethod`` or ``@classmethod`` were not getting their own dynamic
+  context, so their coverage was attributed to no context at all. This now
+  works correctly. Fixes `issue 1923`_.
+
+.. _issue 1923: https://github.com/coveragepy/coveragepy/issues/1923
 
 
 .. start-releases

--- a/coverage/context.py
+++ b/coverage/context.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 from collections.abc import Sequence
 from types import FrameType
 
@@ -56,19 +58,31 @@ def qualname_from_frame(frame: FrameType) -> str | None:
     co = frame.f_code
     fname = co.co_name
     method = None
-    if co.co_argcount and co.co_varnames[0] == "self":
-        self = frame.f_locals.get("self", None)
-        method = getattr(self, fname, None)
+    if co.co_argcount and co.co_varnames[0] in ("self", "cls"):
+        first_arg = frame.f_locals.get(co.co_varnames[0], None)
+        method = getattr(first_arg, fname, None)
 
     if method is None:
         func = frame.f_globals.get(fname)
         if func is None:
+            # `frame` might be a plain function or a static method, neither of
+            # which will be found in f_globals if they are nested inside a
+            # class (or another function).  Code objects for functions are
+            # marked as "optimized" (they use fast locals), while code
+            # objects for module and class bodies are not.  Use that to tell
+            # a genuine (but unreachable-by-name) function apart from a
+            # class body executing a function-like statement, which is the
+            # case `test_bug_829` guards against.
+            if co.co_flags & inspect.CO_OPTIMIZED:
+                module = frame.f_globals.get("__name__", "")
+                qualname = co.co_qualname if hasattr(co, "co_qualname") else fname
+                return f"{module}.{qualname}" if module else qualname
             return None
         return f"{func.__module__}.{fname}"
 
     func = getattr(method, "__func__", None)
     if func is None:
-        cls = self.__class__
+        cls = first_arg if isinstance(first_arg, type) else first_arg.__class__
         return f"{cls.__module__}.{cls.__name__}.{fname}"
 
     return f"{func.__module__}.{func.__qualname__}"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -232,6 +232,14 @@ class Parent:
     def a_property(self) -> str | None:
         return get_qualname()
 
+    @staticmethod
+    def a_static_method() -> str | None:
+        return get_qualname()
+
+    @classmethod
+    def a_class_method(cls) -> str | None:
+        return get_qualname()
+
 
 class Child(Parent):
     pass
@@ -292,6 +300,20 @@ class QualnameTest(CoverageTest):
 
     def test_property(self) -> None:
         assert Parent().a_property == "tests.test_context.Parent.a_property"
+
+    def test_static_method(self) -> None:
+        assert Parent.a_static_method() == "tests.test_context.Parent.a_static_method"
+        assert Parent().a_static_method() == "tests.test_context.Parent.a_static_method"
+
+    def test_class_method(self) -> None:
+        assert Parent.a_class_method() == "tests.test_context.Parent.a_class_method"
+        assert Parent().a_class_method() == "tests.test_context.Parent.a_class_method"
+
+    def test_inherited_static_method(self) -> None:
+        assert Child.a_static_method() == "tests.test_context.Parent.a_static_method"
+
+    def test_inherited_class_method(self) -> None:
+        assert Child.a_class_method() == "tests.test_context.Parent.a_class_method"
 
     def test_changeling(self) -> None:
         c = Child()


### PR DESCRIPTION
`qualname_from_frame()` only recognized test methods with a `self` first
argument. Tests written as `@staticmethod` or `@classmethod` never got a
dynamic context: they don't match the `self` lookup, and (for static
methods especially) they also aren't reachable through `f_globals` when
nested inside a class, so `None` was returned and the line's coverage
ended up attributed to no context at all.

This adds:
- `cls` alongside `self` for the classmethod case.
- For static methods (or any other function-like frame not found in
  `f_globals`), a check of the code object's `CO_OPTIMIZED` flag to tell
  a genuine function frame apart from a class or module body executing a
  function-like statement — which is the scenario `test_bug_829` guards
  against. When that flag is set, the name comes from `co_qualname`
  (Python 3.11+), falling back to the plain function name on older
  versions.

Verified against the repro in the issue: contexts are now recorded for
both `@staticmethod` and `@classmethod` test methods, and the existing
`qualname_from_frame` test suite (including the `test_bug_829` and
`test_bug_1210` regression tests) still passes. Added new tests for the
static/classmethod cases, including inherited methods.

Fixes #1923.