### PR TITLE
Prevent sys.modules cleanup during concurrent imports

### DIFF
--- a/coverage/misc.py
+++ b/coverage/misc.py
@@ -70,11 +70,15 @@ class SysModuleSaver:
 @contextlib.contextmanager
 def sys_modules_saved() -> Iterator[None]:
     """A context manager to remove any modules imported during a block."""
-    saver = SysModuleSaver()
-    try:
-        yield
-    finally:
-        saver.restore()
+    # Importing installs a module in sys.modules before executing it.  Hold the
+    # import lock while saving and restoring so that we can't delete a module
+    # another thread is still importing.
+    with importlib._bootstrap._ImportLockContext():  # type: ignore[attr-defined]
+        saver = SysModuleSaver()
+        try:
+            yield
+        finally:
+            saver.restore()
 
 
 def import_third_party(modname: str) -> tuple[ModuleType, bool]:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
+import threading
+import types
 from typing import Any
 from unittest import mock
 
@@ -18,6 +21,7 @@ from coverage.misc import (
     human_sorted,
     human_sorted_items,
     import_third_party,
+    sys_modules_saved,
     stdout_link,
     substitute_variables,
 )
@@ -168,6 +172,49 @@ class ImportThirdPartyTest(CoverageTest):
         _, has = import_third_party("xyzzy")
         assert not has
         assert "xyzzy" not in sys.modules
+
+
+class SysModulesSavedTest(CoverageTest):
+    """Test saving sys.modules around imports."""
+
+    def test_doesnt_interrupt_another_thread_importing(self) -> None:
+        module_name = "slow_import"
+        control_name = "slow_import_control"
+        started = threading.Event()
+        proceed = threading.Event()
+        release_saver = threading.Event()
+        control = types.ModuleType(control_name)
+        control.started = started
+        control.proceed = proceed
+        sys.modules[control_name] = control
+        self.make_file(
+            f"{module_name}.py",
+            f"import {control_name}\n{control_name}.started.set()\n{control_name}.proceed.wait()\n",
+        )
+        sys.path.insert(0, str(self.temp_dir))
+
+        saver_started = threading.Event()
+
+        def save_modules() -> None:
+            with sys_modules_saved():
+                saver_started.set()
+                release_saver.wait()
+
+        saver = threading.Thread(target=save_modules)
+        importer = threading.Thread(target=importlib.import_module, args=(module_name,))
+        try:
+            saver.start()
+            assert saver_started.wait(1)
+            importer.start()
+            assert not started.wait(0.1)
+        finally:
+            proceed.set()
+            release_saver.set()
+            saver.join()
+            importer.join()
+            sys.path.pop(0)
+            sys.modules.pop(module_name, None)
+            sys.modules.pop(control_name, None)
 
 
 HUMAN_DATA = [

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
+import threading
+import types
 from typing import Any
 from unittest import mock
 
@@ -13,7 +16,7 @@ import pytest
 
 from coverage.exceptions import CoverageException
 from coverage.misc import file_be_gone
-from coverage.misc import Hasher, substitute_variables, import_third_party
+from coverage.misc import Hasher, substitute_variables, import_third_party, sys_modules_saved
 from coverage.misc import human_sorted, human_sorted_items, stdout_link
 
 from tests import testenv
@@ -164,6 +167,49 @@ class ImportThirdPartyTest(CoverageTest):
         _, has = import_third_party("xyzzy")
         assert not has
         assert "xyzzy" not in sys.modules
+
+
+class SysModulesSavedTest(CoverageTest):
+    """Test saving sys.modules around imports."""
+
+    def test_doesnt_interrupt_another_thread_importing(self) -> None:
+        module_name = "slow_import"
+        control_name = "slow_import_control"
+        started = threading.Event()
+        proceed = threading.Event()
+        release_saver = threading.Event()
+        control = types.ModuleType(control_name)
+        control.started = started
+        control.proceed = proceed
+        sys.modules[control_name] = control
+        self.make_file(
+            f"{module_name}.py",
+            f"import {control_name}\n{control_name}.started.set()\n{control_name}.proceed.wait()\n",
+        )
+        sys.path.insert(0, str(self.temp_dir))
+
+        saver_started = threading.Event()
+
+        def save_modules() -> None:
+            with sys_modules_saved():
+                saver_started.set()
+                release_saver.wait()
+
+        saver = threading.Thread(target=save_modules)
+        importer = threading.Thread(target=importlib.import_module, args=(module_name,))
+        try:
+            saver.start()
+            assert saver_started.wait(1)
+            importer.start()
+            assert not started.wait(0.1)
+        finally:
+            proceed.set()
+            release_saver.set()
+            saver.join()
+            importer.join()
+            sys.path.pop(0)
+            sys.modules.pop(module_name, None)
+            sys.modules.pop(control_name, None)
 
 
 HUMAN_DATA = [

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -184,8 +184,8 @@ class SysModulesSavedTest(CoverageTest):
         proceed = threading.Event()
         release_saver = threading.Event()
         control = types.ModuleType(control_name)
-        control.started = started
-        control.proceed = proceed
+        setattr(control, "started", started)
+        setattr(control, "proceed", proceed)
         sys.modules[control_name] = control
         self.make_file(
             f"{module_name}.py",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -179,8 +179,8 @@ class SysModulesSavedTest(CoverageTest):
         proceed = threading.Event()
         release_saver = threading.Event()
         control = types.ModuleType(control_name)
-        control.started = started
-        control.proceed = proceed
+        setattr(control, "started", started)
+        setattr(control, "proceed", proceed)
         sys.modules[control_name] = control
         self.make_file(
             f"{module_name}.py",


### PR DESCRIPTION
## Summary

Prevent `sys_modules_saved()` from removing a module while another thread is still importing it. The context now holds Python's import lock through the save/restore window, with a regression test covering the interleaving.

Fixes #2247

## Verification

- Ran the issue's deterministic reproducer against current `main`; it fails before the fix and prints `no failure` with the branch.
- `uv run --with-editable . --with-requirements requirements/pytest.pip --with-requirements requirements/pip.pip pytest tests/test_misc.py -q`
- `uv run --with ruff ruff format --check coverage/misc.py tests/test_misc.py`
- `git diff --check`