### PR TITLE
fix: close in-memory mapped data for a report-only Coverage

### DIFF
--- a/coverage/control.py
+++ b/coverage/control.py
@@ -652,9 +652,7 @@ class Coverage(TConfigurable):
         self._should_write_debug = True
 
         # Register our clean-up handlers.
-        if not self._atexit_registered:
-            atexit.register(self._atexit)
-            self._atexit_registered = True
+        self._register_atexit()
         if self.config.sigterm:
             is_main = (threading.current_thread() == threading.main_thread())  # fmt: skip
             if is_main and not env.WINDOWS:
@@ -755,6 +753,12 @@ class Coverage(TConfigurable):
             self.save()
         for d in self._data_to_close:
             d.close(force=True)
+
+    def _register_atexit(self) -> None:
+        """Register the process-shutdown cleanup handler once."""
+        if not self._atexit_registered:
+            atexit.register(self._atexit)
+            self._atexit_registered = True
 
     def _on_sigterm(self, signum_unused: int, frame_unused: FrameType | None) -> None:
         """A handler for signal.SIGTERM."""
@@ -1092,14 +1096,12 @@ class Coverage(TConfigurable):
                 mapped_data.update(self._data, map_path=self._make_aliases().map)
             self._data = mapped_data
             self._data_to_close.append(mapped_data)
-            if not self._atexit_registered:
-                # A Coverage object that only reports never went through
-                # _init_for_start, so nothing has registered a handler to drain
-                # _data_to_close.  These no_disk connections are only closed by
-                # close(force=True), so without this they leak to interpreter
-                # shutdown as "ResourceWarning: unclosed database".
-                atexit.register(self._atexit)
-                self._atexit_registered = True
+            # A Coverage object that only reports never went through
+            # _init_for_start, so nothing has registered a handler to drain
+            # _data_to_close.  These no_disk connections are only closed by
+            # close(force=True), so without this they leak to interpreter
+            # shutdown as "ResourceWarning: unclosed database".
+            self._register_atexit()
 
     def report(
         self,

--- a/coverage/control.py
+++ b/coverage/control.py
@@ -298,6 +298,7 @@ class Coverage(TConfigurable):
         self._plugin_override = cast(Iterable[TCoverageInit] | None, plugins)
         self._data: CoverageData | None = None
         self._data_to_close: list[CoverageData] = []
+        self._atexit_registered = False
         self._core: Core | None = None
         self._collector: Collector | None = None
 
@@ -651,7 +652,9 @@ class Coverage(TConfigurable):
         self._should_write_debug = True
 
         # Register our clean-up handlers.
-        atexit.register(self._atexit)
+        if not self._atexit_registered:
+            atexit.register(self._atexit)
+            self._atexit_registered = True
         if self.config.sigterm:
             is_main = (threading.current_thread() == threading.main_thread())  # fmt: skip
             if is_main and not env.WINDOWS:
@@ -1089,6 +1092,14 @@ class Coverage(TConfigurable):
                 mapped_data.update(self._data, map_path=self._make_aliases().map)
             self._data = mapped_data
             self._data_to_close.append(mapped_data)
+            if not self._atexit_registered:
+                # A Coverage object that only reports never went through
+                # _init_for_start, so nothing has registered a handler to drain
+                # _data_to_close.  These no_disk connections are only closed by
+                # close(force=True), so without this they leak to interpreter
+                # shutdown as "ResourceWarning: unclosed database".
+                atexit.register(self._atexit)
+                self._atexit_registered = True
 
     def report(
         self,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1327,6 +1327,22 @@ class FailUnderNoFilesTest(CoverageTest):
         assert st == 1
 
 
+class ReportOnlyCleanupTest(CoverageTest):
+    """Test that a report-only run closes its in-memory data."""
+
+    def test_no_unclosed_database_warning(self) -> None:
+        # https://github.com/coveragepy/coveragepy/issues/2251
+        # With [paths] configured, reporting maps data through an in-memory
+        # CoverageData.  A Coverage that only reports never called start(), so
+        # nothing used to drain _data_to_close, and the connection was still
+        # open at interpreter shutdown.
+        self.make_file(".coveragerc", "[paths]\nsource =\n    dummy\n")
+        st, out = self.run_command_status("python -Werror -m coverage report")
+        assert "unclosed database" not in out
+        assert "No data to report." in out
+        assert st == 1
+
+
 class FailUnderEmptyFilesTest(CoverageTest):
     """Test that empty files produce the proper fail_under exit status."""
 


### PR DESCRIPTION
Closes #2251

With `[paths]` configured, `_prepare_data_for_reporting()` creates a `CoverageData(no_disk=True)` and appends it to `_data_to_close`, but for `no_disk` data `SqliteDb.close()` is a no-op unless `force=True` — and the only caller passing `force=True` is `_atexit`, which was registered solely from `_init_for_start()`. A `Coverage` that only reports (the `coverage report` CLI, or pytest-cov's never-started `combining_cov`) therefore never drained the list, leaving the connection open at shutdown: `ResourceWarning: unclosed database`, which fails a `-Werror` job.

This registers the handler from `_prepare_data_for_reporting()` too, guarded by a new `_atexit_registered` flag so start-and-report can't register it twice. `ReportOnlyCleanupTest` in `tests/test_process.py` runs the issue's reproducer and fails without the `control.py` change; `tests/test_api.py` and `tests/test_data.py` stay green.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
