### PR TITLE
Fix: local plugins are importable for erase and combine

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -852,6 +852,12 @@ class CoverageScript:
             messages=not options.quiet,
         )
 
+        # We need to be able to import from the current directory, because
+        # plugins may try to, for example, to read Django settings.  The "run"
+        # command is excluded: PyRunner.prepare() owns sys.path[0] there.
+        if options.action != "run":
+            sys.path.insert(0, "")
+
         if options.action == "debug":
             return self.do_debug(args)
 
@@ -878,10 +884,6 @@ class CoverageScript:
             include=include,
             contexts=contexts,
         )
-
-        # We need to be able to import from the current directory, because
-        # plugins may try to, for example, to read Django settings.
-        sys.path.insert(0, "")
 
         self.coverage.load()
         self.coverage.combine(strict=False, keep=bool(options.keep_combined))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -314,6 +314,37 @@ class PluginTest(CoverageTest):
         out = self.run_command("coverage html -q")  # sneak in a test of -q
         assert out == ""
 
+    def test_local_files_are_importable_for_erase_and_combine(self) -> None:
+        # https://github.com/coveragepy/coveragepy/issues/1726
+        self.make_file(
+            "importing_plugin.py",
+            """\
+            from coverage import CoveragePlugin
+            import local_module
+            class MyPlugin(CoveragePlugin):
+                pass
+            def coverage_init(reg, options):
+                reg.add_noop(MyPlugin())
+            """,
+        )
+        self.make_file("local_module.py", "CONST = 1")
+        self.make_file(
+            ".coveragerc",
+            """\
+            [run]
+            plugins = importing_plugin
+            parallel = True
+            """,
+        )
+        self.make_file("main_file.py", "print('MAIN')")
+
+        out = self.run_command("coverage run main_file.py")
+        assert out == "MAIN\n"
+        out = self.run_command("coverage combine")
+        assert "ModuleNotFoundError" not in out
+        out = self.run_command("coverage erase")
+        assert out == ""
+
     def test_coverage_init_plugins(self) -> None:
         called = False
 


### PR DESCRIPTION
Closes #1726.

cmdline.py inserts "" into sys.path with the comment that plugins may need to import from the current directory, but the insert sits below the erase and combine branches, both of which return before reaching it. Both commands construct Coverage, which loads configured plugins, so a plugin living in the project directory raises ModuleNotFoundError.

The report in issue 1726 is about erase; combine is broken by the same defect, which matters more - it is the core of parallel mode.

Only the console script is affected: python -m coverage puts the CWD on sys.path itself.

Move the block above the action dispatch, keeping run excluded: there sys.path[0] is owned by PyRunner.prepare(), and run never reached the old line anyway, so its behaviour is unchanged.