### PR TITLE
fix(xml): keep same-named files from different source roots (closes #1291)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,13 @@ Unreleased
 
 - The :meth:`.Coverage.switch_context` method now returns the previous context.
 
+- Fixed: when two source roots each contained a package with the same name, the
+  XML report kept only one of the same-named files while still counting the
+  lines of both, so ``lines-valid`` disagreed with the ``<line>`` elements in
+  the document.  Closes `issue 1291`_.
+
+.. _issue 1291: https://github.com/nedbat/coveragepy/issues/1291
+
 
 .. start-releases
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,11 @@ Unreleased
   Windows.  The original extension is now restored on the annotated copy (`pull
   2265`_).
 
+- Fixed: when two source roots each contained a package with the same name, the
+  XML report kept only one of the same-named files while still counting the
+  lines of both, so ``lines-valid`` disagreed with the ``<line>`` elements in
+  the document.  Closes `issue 1291`_.
+
 .. _pull 2261: https://github.com/coveragepy/coveragepy/pull/2261
 .. _pull 2262: https://github.com/coveragepy/coveragepy/pull/2262
 .. _pull 2263: https://github.com/coveragepy/coveragepy/pull/2263
@@ -71,6 +76,7 @@ Unreleased
 .. _issue 2266: https://github.com/coveragepy/coveragepy/issues/2266
 .. _pull 2268: https://github.com/coveragepy/coveragepy/pull/2268
 .. _pull 2270: https://github.com/coveragepy/coveragepy/pull/2270
+.. _issue 1291: https://github.com/nedbat/coveragepy/issues/1291
 
 
 .. start-releases

--- a/coverage/xmlreport.py
+++ b/coverage/xmlreport.py
@@ -251,7 +251,12 @@ class XmlReporter:
             branch_rate = "0"
         xclass.setAttribute("branch-rate", branch_rate)
 
-        package.elements[rel_name] = xclass
+        # Key on the absolute filename, not `rel_name`. Two source roots can each
+        # hold a package of the same name, and their files then have the same
+        # name relative to their own root, so keying on `rel_name` dropped one of
+        # them while still counting its lines below. That produced an XML report
+        # whose `lines-valid` did not match the `<line>` elements it contained.
+        package.elements[filename] = xclass
         package.hits += class_hits
         package.lines += class_lines
         package.br_hits += class_br_hits

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -384,6 +384,26 @@ def unbackslash(v: Any) -> Any:
 class XmlPackageStructureTest(XmlTestHelpers, CoverageTest):
     """Tests about the package structure reported in the coverage.xml file."""
 
+    def test_same_package_name_in_two_source_roots(self) -> None:
+        # Two source roots can each hold a package with the same name. Their files
+        # then have identical names relative to their own root, and the XML writer
+        # keyed classes on that relative name, so the second file replaced the
+        # first while its lines were still counted, leaving a report that claimed
+        # more lines than it contained. https://github.com/nedbat/coveragepy/issues/1291
+        self.make_file("project/settings/__init__.py", "A = 1\nB = 2\nC = 3\n")
+        self.make_file("testing/settings/__init__.py", "D = 4\nE = 5\nF = 6\n")
+        self.make_file("main.py", "import project.settings\nimport testing.settings\n")
+        self.make_file(".coveragerc", "[run]\nsource = project, testing/\n")
+
+        cov = coverage.Coverage()
+        self.start_import_stop(cov, "main")
+        cov.xml_report()
+
+        dom = ElementTree.parse("coverage.xml")
+        assert len(dom.findall(".//class")) == 2
+        # the header must agree with what the document actually contains
+        assert int(dom.getroot().get("lines-valid")) == len(dom.findall(".//line"))
+
     def package_and_class_tags(self, cov: Coverage) -> Iterable[tuple[str, dict[str, Any]]]:
         """Run an XML report on `cov`, and get the package and class tags."""
         cov.xml_report()

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -382,6 +382,26 @@ def unbackslash(v: Any) -> Any:
 class XmlPackageStructureTest(XmlTestHelpers, CoverageTest):
     """Tests about the package structure reported in the coverage.xml file."""
 
+    def test_same_package_name_in_two_source_roots(self) -> None:
+        # Two source roots can each hold a package with the same name. Their files
+        # then have identical names relative to their own root, and the XML writer
+        # keyed classes on that relative name, so the second file replaced the
+        # first while its lines were still counted, leaving a report that claimed
+        # more lines than it contained. https://github.com/nedbat/coveragepy/issues/1291
+        self.make_file("project/settings/__init__.py", "A = 1\nB = 2\nC = 3\n")
+        self.make_file("testing/settings/__init__.py", "D = 4\nE = 5\nF = 6\n")
+        self.make_file("main.py", "import project.settings\nimport testing.settings\n")
+        self.make_file(".coveragerc", "[run]\nsource = project, testing/\n")
+
+        cov = coverage.Coverage()
+        self.start_import_stop(cov, "main")
+        cov.xml_report()
+
+        dom = ElementTree.parse("coverage.xml")
+        assert len(dom.findall(".//class")) == 2
+        # the header must agree with what the document actually contains
+        assert int(dom.getroot().get("lines-valid")) == len(dom.findall(".//line"))
+
     def package_and_class_tags(self, cov: Coverage) -> Iterable[tuple[str, dict[str, Any]]]:
         """Run an XML report on `cov`, and get the package and class tags."""
         cov.xml_report()

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -400,7 +400,9 @@ class XmlPackageStructureTest(XmlTestHelpers, CoverageTest):
         dom = ElementTree.parse("coverage.xml")
         assert len(dom.findall(".//class")) == 2
         # the header must agree with what the document actually contains
-        assert int(dom.getroot().get("lines-valid")) == len(dom.findall(".//line"))
+        lines_valid = dom.getroot().get("lines-valid")
+        assert lines_valid is not None
+        assert int(lines_valid) == len(dom.findall(".//line"))
 
     def package_and_class_tags(self, cov: Coverage) -> Iterable[tuple[str, dict[str, Any]]]:
         """Run an XML report on `cov`, and get the package and class tags."""

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -402,7 +402,9 @@ class XmlPackageStructureTest(XmlTestHelpers, CoverageTest):
         dom = ElementTree.parse("coverage.xml")
         assert len(dom.findall(".//class")) == 2
         # the header must agree with what the document actually contains
-        assert int(dom.getroot().get("lines-valid")) == len(dom.findall(".//line"))
+        lines_valid = dom.getroot().get("lines-valid")
+        assert lines_valid is not None
+        assert int(lines_valid) == len(dom.findall(".//line"))
 
     def package_and_class_tags(self, cov: Coverage) -> Iterable[tuple[str, dict[str, Any]]]:
         """Run an XML report on `cov`, and get the package and class tags."""


### PR DESCRIPTION
Closes #1291.

### The bug

`coverage report` and `coverage xml` disagree about which files exist. With two
source roots that each contain a package of the same name:

```
project/settings/__init__.py    3 statements
testing/settings/__init__.py    3 statements
.coveragerc:  [run]  source = project, testing/
```

`coverage report` lists both files, TOTAL 6 statements. `coverage xml` emits one
`<class filename="settings/__init__.py">` holding 3 `<line>` elements. The other
file is absent.

The report is also internally inconsistent, which is the part that needs no
judgement call:

```xml
<coverage ... lines-valid="6" lines-covered="6">   <!-- says 6 -->
```

The document contains 3 `<line>` elements. Cobertura XML is what CI services read,
so a file silently vanishes from the artifact that gates merges while the totals
still count it.

### Cause

`xml_file()` computes `rel_name` relative to whichever source root matched, then
stores the element as `package.elements[rel_name]`. Both files reduce to
`settings/__init__.py`, so the second replaces the first. The counters just below
it (`package.lines`, `package.hits`) are accumulated separately and still see both
files, which is exactly why the header and the body disagree.

### Fix

Key on `filename`, the absolute path, which is unique per file. The `<class
filename=...>` attribute still carries `rel_name`, so consumers resolve it against
the `<sources>` roots that are already emitted, and both roots are listed there.

Emitting two classes with the same relative name is not a new convention: as the
reporter notes, `source = .` already produces `settings` twice today.

**Ordering is unchanged for the ordinary single-root case.** The key is only used
for sorting, and with one root `filename` is `source_path + "/" + rel_name`, a
constant prefix, so the sort is identical. I checked this on a project with
`pkg/zeta.py`, `pkg/alpha.py`, `pkg/mid.py` and `pkg/sub/deep.py`, and the emitted
order is byte-for-byte the same before and after. Only the multi-root case
reorders, and that is the case that was broken.

### Verification

- The reproduction above now emits 2 classes and 6 `<line>` elements, and
  `lines-valid` matches.
- `tests/test_xml.py`: 31 passed, 1 skipped, against 30 passed, 1 skipped on an
  unmodified checkout, the difference being the new test.
- The new test fails on `main` with `assert 1 == 2`.

The regression test asserts both that two classes are emitted and that
`lines-valid` equals the number of `<line>` elements, since the second is the
clearest statement of the defect.
