### PR TITLE
html: clamp JS-recomputed footer percentage to mirror display_covered

### DIFF
--- a/coverage/htmlfiles/coverage_html.js
+++ b/coverage/htmlfiles/coverage_html.js
@@ -237,10 +237,24 @@ coverage.wire_up_filter = function () {
                 const places = match ? match[1].length : 0;
                 const { numer, denom } = totals[column];  // nosemgrep: eslint.detect-object-injection
                 cell.dataset.ratio = `${numer} ${denom}`;
-                // Check denom to prevent NaN if filtered files contain no statements
-                cell.textContent = denom
-                    ? `${(numer * 100 / denom).toFixed(places)}%`
-                    : `${(100).toFixed(places)}%`;
+                // Check denom to prevent NaN if filtered files contain no statements.
+                // Also mirror coverage.results.display_covered's clamp so the
+                // JS-recomputed footer can never round to "0" or "100" — keeping
+                // the heading and footer from disagreeing. See issue #2256.
+                let pc = denom
+                    ? (numer * 100 / denom)
+                    : 100;
+                if (places >= 0) {
+                    const near0 = 1 / Math.pow(10, places);
+                    if (pc > 0 && pc < near0) {
+                        pc = near0;
+                    } else if (pc < 100 && pc > (100 - near0)) {
+                        pc = 100 - near0;
+                    } else {
+                        pc = Math.round(pc * Math.pow(10, places)) / Math.pow(10, places);
+                    }
+                }
+                cell.textContent = `${pc.toFixed(places)}%`;
             }
             else {
                 cell.textContent = totals[column];  // nosemgrep: eslint.detect-object-injection


### PR DESCRIPTION
Fixes #2256.

The HTML index's `<tfoot>` Total percentage is recomputed in
`coverage_html.js` with `toFixed()`, which can round to `0` or `100%`
even when actual coverage is not exactly 0 or 100. The `<h1>` heading
on the same page is server-rendered via `coverage.results.display_covered`,
which documents the invariant that "0" is only returned when the value
is truly zero, and "100" is only returned when the value is truly 100.
Rounding can never result in either "0" or "100".

Since the JS handler also runs on page load (it dispatches an `input`
event unconditionally to reapply stored filters; see the comment at
the bottom of the same function), the footer is overwritten on every
page view, so the bug shows up even without typing anything into the
filter.

This patch mirrors `display_covered`'s clamp in JS:

1. If `pc > 0` and `pc < 1/10**places`, nudge up to `1/10**places`.
2. Else if `pc < 100` and `pc > 100 - 1/10**places`, nudge down to
   `100 - 1/10**places`.
3. Else round to the configured precision.

This keeps the JS-recomputed footer from disagreeing with the
server-rendered heading or the text-mode report.

---

Disclosed: this contribution was prepared with the help of Claude
(a large language model). The human in the loop reviewed the diff and
verified the change matches the invariant documented in
`coverage/results.py::display_covered`.
