### PR TITLE
fix: validate the --contexts regexes up front

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,11 @@ Unreleased
 - fix: negative precision settings now always cause useful error messages
   (`pull 2261`_).
 
+- fix: an invalid regex in the ``--contexts`` option (or the ``[report]
+  contexts`` setting) reported a confusing "Couldn't use data file ...:
+  user-defined function raised exception" error. Now it raises a proper
+  configuration error naming the bad regex, like other regex settings do.
+
 .. _pull 2261: https://github.com/coveragepy/coveragepy/pull/2261
 
 

--- a/coverage/sqldata.py
+++ b/coverage/sqldata.py
@@ -26,7 +26,7 @@ from collections.abc import Callable, Collection, Mapping, Sequence
 from typing import Any, Concatenate, ParamSpec, TypeAlias, TypeVar, cast
 
 from coverage.debug import NoDebugging, auto_repr, file_summary
-from coverage.exceptions import CoverageException, DataError
+from coverage.exceptions import ConfigError, CoverageException, DataError
 from coverage.misc import Hasher, file_be_gone, isolate_module
 from coverage.numbits import (
     numbits_to_nums,
@@ -1009,6 +1009,11 @@ class CoverageData:
         """
         self._start_using()
         if contexts:
+            for context in contexts:
+                try:
+                    re.compile(context)
+                except re.error as e:
+                    raise ConfigError(f"Invalid context regex {context!r}: {e}") from e
             with self._connect() as con:
                 context_clause = " or ".join(["context REGEXP ?"] * len(contexts))
                 with con.execute("SELECT id FROM context WHERE " + context_clause, contexts) as cur:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -25,7 +25,7 @@ from coverage.data import (
     combine_parallel_data,
     line_counts,
 )
-from coverage.exceptions import DataError, NoDataError
+from coverage.exceptions import ConfigError, DataError, NoDataError
 from coverage.files import PathAliases, canonical_filename
 from coverage.types import FilePathClasses, FilePathType, TArc, TLineNo
 from tests import osinfo
@@ -242,6 +242,14 @@ class CoverageDataTest(CoverageTest):
         assert covdata.lines("a.py") == [1, 2]
         covdata.set_query_contexts(["other"])
         assert covdata.lines("a.py") == []
+
+    def test_set_query_contexts_bad_regex(self) -> None:
+        covdata = DebugCoverageData()
+        covdata.set_context("test_a")
+        covdata.add_lines(LINES_1)
+        msg = r"Invalid context regex 'foo\(': missing \)"
+        with pytest.raises(ConfigError, match=msg):
+            covdata.set_query_contexts(["foo("])
 
     def test_no_lines_vs_unmeasured_file(self) -> None:
         covdata = DebugCoverageData()


### PR DESCRIPTION
An invalid regex in `--contexts` reports a confusing error that blames the data file.

```
$ coverage report --contexts='foo('
Couldn't use data file '/tmp/covtest/.coverage': user-defined function raised exception
```

After:

```
Invalid context regex 'foo(': missing ), unterminated subpattern at position 3
```

The data file is fine. The regex goes straight to the SQLite `REGEXP` user function, where `re.search` raises inside sqlite, and sqlite reports only that some user function failed. Same for `coverage json --contexts=`, `coverage html --contexts=`, the `[report] contexts` config setting, and `Coverage.report(contexts=[...])`.

## The fix

`process_regexlist` in `config.py` already does exactly this for every other regex-valued setting:

```python
try:
    re.compile(value)
except re.error as e:
    raise ConfigError(f"Invalid [{name}].{option} value {value!r}: {e}") from e
```

`contexts` is the one that never got it, because it is not compiled at config time, it is handed to sqlite later. So the same check runs in `set_query_contexts`, which is the point every entry path funnels through.

## Testing

`test_set_query_contexts_bad_regex` in `tests/test_data.py`.

Removing only the validation loop fails it, and the failure is the original symptom rather than a message mismatch:

```
        with pytest.raises(ConfigError, match=msg):
>           raise DataError(f"Couldn't use data file {self.filename!r}: {msg}") from exc
E           coverage.exceptions.DataError: Couldn't use data file '...': user-defined function raised exception
```

`pytest tests/test_data.py` is 4 passed for the selected tests.

## Pre-existing failures

The full suite is `143 failed, 1450 passed, 23 skipped, 14 errors` on a clean checkout here, and `143 failed, 1451 passed, 23 skipped, 14 errors` with this change. A diff of the sorted FAILED lists is empty, so every one of those is pre-existing in this environment, which has no C extension built and lacks the venv/subprocess test dependencies.

*Disclosure: written with AI assistance (Claude Code). I reproduced the confusing error at the CLI, checked all four entry paths, confirmed the pre-existing failures by diffing against a stashed tree, and ran the mutation check myself.*
