### PR TITLE
fix: a non-string value in a TOML setting exits with a traceback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,14 @@ Unreleased
 
 .. _pull 2261: https://github.com/coveragepy/coveragepy/pull/2261
 
+- fix: non-string values in TOML configuration settings now produce a helpful
+  error message instead of a traceback.  This affects list settings whose
+  elements aren't strings (like ``omit``, ``exclude_lines``, or a ``[paths]``
+  entry), file settings like ``data_file``, and any wrong-typed value in the
+  ``[paths]`` section (`pull 2263`_).
+
+.. _pull 2263: https://github.com/coveragepy/coveragepy/pull/2263
+
 
 .. start-releases
 

--- a/coverage/config.py
+++ b/coverage/config.py
@@ -353,9 +353,12 @@ class CoverageConfig(TConfigurable, TPluginConfig):
 
         # [paths] is special
         if cp.has_section("paths"):
-            for option in cp.options("paths"):
-                self.paths[option] = cp.getlist("paths", option)
-                any_set = True
+            try:
+                for option in cp.options("paths"):
+                    self.paths[option] = cp.getlist("paths", option)
+                    any_set = True
+            except ValueError as err:
+                raise ConfigError(f"Couldn't read config file {filename}: {err}") from err
 
         # plugins can have options
         for plugin in self.plugins:

--- a/coverage/tomlconfig.py
+++ b/coverage/tomlconfig.py
@@ -181,14 +181,21 @@ class TomlConfigParser:
         return self._check_type(name, option, value, bool, bool_strings.__getitem__, "a boolean")
 
     def getfile(self, section: str, option: str) -> str:
-        _, value = self._get_single(section, option)
+        name, value = self._get_single(section, option)
+        value = self._check_type(name, option, value, str, None, "a string")
         return config.process_file_value(value)
 
     def _get_list(self, section: str, option: str) -> tuple[str, list[str]]:
         """Get a list of strings, substituting environment variables in the elements."""
         name, values = self._get(section, option)
         values = self._check_type(name, option, values, list, None, "a list")
-        values = [substitute_variables(value, os.environ) for value in values]
+        values = [
+            substitute_variables(
+                self._check_type(name, option, value, str, None, "a list of strings"),
+                os.environ,
+            )
+            for value in values
+        ]
         return name, values
 
     def getlist(self, section: str, option: str) -> list[str]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -299,6 +299,26 @@ class ConfigTest(CoverageTest):
             ('[tool.coverage.run]\nconcurrency="foo"', "not a list"),
             ("[tool.coverage.report]\nprecision=1.23", "not an integer"),
             ('[tool.coverage.report]\nfail_under="s"', "couldn't convert to a float"),
+            (
+                "[tool.coverage.run]\nomit=[1, 2]",
+                r"Option \[tool.coverage.run\]omit is not a list of strings: 1",
+            ),
+            (
+                "[tool.coverage.report]\nexclude_lines=[17]",
+                r"Option \[tool.coverage.report\]exclude_lines is not a list of strings: 17",
+            ),
+            (
+                "[tool.coverage.run]\ndata_file=3",
+                r"Option \[tool.coverage.run\]data_file is not a string: 3",
+            ),
+            (
+                '[tool.coverage.paths]\nsource="not-a-list"',
+                r"Option \[tool.coverage.paths\]source is not a list: 'not-a-list'",
+            ),
+            (
+                "[tool.coverage.paths]\nsource=[1, 2]",
+                r"Option \[tool.coverage.paths\]source is not a list of strings: 1",
+            ),
         ],
     )
     def test_toml_parse_errors(self, filename: str, bad_config: str, msg: str) -> None:


### PR DESCRIPTION
A non-string value in a TOML setting exits with a traceback instead of the
"Couldn't read config file" message coverage.py uses for every other config
error.

`.coveragerc.toml` containing `[tool.coverage.paths]` / `source = ["src", 2]`:

```
before:
Traceback (most recent call last):
  ...
  File ".../coverage/config.py", line 357, in from_file
    self.paths[option] = cp.getlist("paths", option)
  File ".../coverage/tomlconfig.py", line 191, in _get_list
    values = [substitute_variables(value, os.environ) for value in values]
  File ".../coverage/misc.py", line 284, in substitute_variables
    text = re.sub(dollar_pattern, dollar_replace, text)
TypeError: expected string or bytes-like object, got 'int'

after:
Couldn't read config file .coveragerc.toml: Option [tool.coverage.paths]source is not a list of strings: 2
```

Both exit 1. TOML makes this easy to hit by accident, since it has real integers
and booleans where the ini parser only ever produced strings.

## Cause

Three gaps, all in the same shape:

1. `_get_list` checks that the value is a list, then passes each element
   straight to `substitute_variables`, which calls `re.sub` on it. A non-string
   element raises `TypeError` from the `re` module. This reaches `omit`,
   `exclude_lines`, `source`, and every other list setting.
2. `getfile` does not type-check at all, so `data_file = 3` raises from
   `os.path` instead.
3. `[paths]` is read outside the `try/except ValueError` in `from_file` that
   converts these into `ConfigError`, so even the existing checks escaped as
   tracebacks there.

## The fix

Reuse the existing `_check_type` helper for list elements and for `getfile`, so
the message matches the ones the other settings already produce, and move the
`[paths]` loop inside the same `try/except ValueError` the rest of `from_file`
uses. No new error machinery.

## Verification

`test_toml_parse_errors` gains 10 parametrized cases, each run against both
`.coveragerc.toml` and `pyproject.toml`.

Two mutations, because the change has two independent halves:

Reverting the `tomlconfig.py` guards fails 8 of them:

```
E       TypeError: expected string or bytes-like object, got 'int'
/usr/lib/python3.12/re/__init__.py:186: TypeError
```

Reverting only the `config.py` `try/except` fails the remaining 2:

```
E       ValueError: Option [tool.coverage.paths]source is not a list: 'not-a-list'
coverage/tomlconfig.py:174: ValueError
```

Both are exceptions escaping `pytest.raises(ConfigError)`, not import or
collection errors.

`tests/test_config.py` goes from 88 passed to 98 passed, 6 skipped, 0 failed.
`ruff format --check`, `ruff check` and `mypy` are clean on the changed files.

On the rest of the suite: the failure set is byte-identical before and after
(122 failures both ways, `diff` of the sorted names is empty). They are
environmental here, no C extension and no network, and are present on unmodified
`main`. `tests/test_venv.py` was excluded for needing network. Only Python 3.12
is available on this machine.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by running the real `coverage` CLI, and ran both mutation checks and the before/after failure-set comparison myself.*
