### PR TITLE
fix: annotate -d crashes on a file that is not .py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Unreleased
   (`pull 2265`_).
 
 .. _pull 2265: https://github.com/coveragepy/coveragepy/pull/2265
+
 - fix: an invalid regex in the ``--contexts`` option (or the ``[report]
   contexts`` setting) reported a confusing "Couldn't use data file ...:
   user-defined function raised exception" error. Now it raises a proper

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,13 @@ Unreleased
 - fix: negative precision settings now always cause useful error messages
   (`pull 2261`_).
 
+- Fix: ``coverage annotate -d DIR`` raised an ``AssertionError`` if any
+  measured file had an extension other than ``.py``, such as a ``.pyw`` file
+  on Windows.  The original extension is now restored on the annotated copy
+  (`pull 2265`_).
+
 .. _pull 2261: https://github.com/coveragepy/coveragepy/pull/2261
+.. _pull 2265: https://github.com/coveragepy/coveragepy/pull/2265
 
 
 .. start-releases

--- a/coverage/annotate.py
+++ b/coverage/annotate.py
@@ -75,9 +75,14 @@ class AnnotateReporter:
 
         if self.directory:
             ensure_dir(self.directory)
-            dest_file = os.path.join(self.directory, flat_rootname(fr.relative_filename()))
-            assert dest_file.endswith("_py")
-            dest_file = dest_file[:-3] + ".py"
+            rel_fname = fr.relative_filename()
+            dest_file = os.path.join(self.directory, flat_rootname(rel_fname))
+            # flat_rootname turned the dot of the extension into an underscore.
+            # Put the original extension back, whatever it is: .py, .pyw, or
+            # something a plugin measures.
+            ext = os.path.splitext(rel_fname)[1]
+            if ext:
+                dest_file = dest_file[: -len(ext)] + ext
         else:
             dest_file = fr.filename
         dest_file += ",cover"

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+
 import coverage
 from tests.coveragetest import CoverageTest
 from tests.goldtest import compare, gold_path
@@ -59,6 +61,16 @@ class AnnotationGoldTest(CoverageTest):
         self.start_import_stop(cov, "multi")
         cov.annotate(directory="out_anno_dir")
         compare(gold_path("annotate/anno_dir"), "out_anno_dir", "*,cover")
+
+    def test_annotate_dir_pyw(self) -> None:
+        # A .pyw file has an extension other than .py, and annotating it into a
+        # directory used to raise an AssertionError.
+        self.make_file("main.py", "print('hello')\n")
+        self.make_file("mod.pyw", "print('never run')\n")
+        cov = coverage.Coverage(source=["."])
+        self.start_import_stop(cov, "main")
+        cov.annotate(directory="out_anno_dir")
+        assert sorted(os.listdir("out_anno_dir")) == ["main.py,cover", "mod.pyw,cover"]
 
     def test_encoding(self) -> None:
         self.make_file(


### PR DESCRIPTION
`coverage annotate -d DIR` crashes with a bare `AssertionError` when any measured
file has an extension other than `.py`.

A directory with `run.py` and a measured `mod.pyw`:

```
$ python -m coverage annotate -d ann
before:
  File ".../coverage/annotate.py", line 79, in annotate_file
    assert dest_file.endswith("_py")
AssertionError

after:
$ ls ann
mod.pyw,cover  run.py,cover
```

The same command without `-d` works, so this is specific to the directory path.

## Cause

`flat_rootname` turns the dot of the extension into an underscore, so
`mod.pyw` becomes `..._mod_pyw`, not `..._mod_py`. `annotate_file` assumes
otherwise:

```python
dest_file = os.path.join(self.directory, flat_rootname(fr.relative_filename()))
assert dest_file.endswith("_py")
dest_file = dest_file[:-3] + ".py"
```

That assert came from `84baf6e1`, "refactor: remove an untaken branch in
annotate.py", which replaced an `if dest_file.endswith("_py")` guard with an
assertion. The branch was taken after all, just not by anything in the test
suite: a `.pyw` file, or a file measured by a plugin, reaches it.

## The fix

Put the file's own extension back, whatever it is, instead of assuming `.py`.

## Verification, in plain terms

I added `test_annotate_dir_pyw`, which measures a `.pyw` file and runs
`annotate -d`.

Then I put the buggy code back exactly as it reads on `main` today and re-ran
that test. It failed:

```
>           assert dest_file.endswith("_py")
E           AssertionError
coverage/annotate.py:79: AssertionError
```

I also tried a subtler wrong fix, hardcoding `".py"` instead of reading the
file's real extension. That does not crash, it just writes the wrong filename,
and the test caught that too:

```
>       assert sorted(os.listdir("out_anno_dir")) == ["main.py,cover", "mod.pyw,cover"]
E       AssertionError: assert ['main.py,cover', 'mod_.py,cover'] == ['main.py,cover', 'mod.pyw,cover']
```

So the test fails both for the original bug and for a near-miss fix, and passes
only with the real one.

`tests/test_annotate.py` is 6 passed. `ruff check` and `ruff format --check` are
clean, no line over 100 characters.

On the rest of the suite: 194 failures before the change and the same 194 after,
with an empty `diff` between the two sorted lists. They are pre-existing in this
environment, which has no C extension built and no network.

The test runs on Linux: it exercises the reporting path for a `.pyw` file, which
is where the crash is, without needing Windows to execute one.

*Disclosure: written with AI assistance (Claude Code). I reproduced the crash and the fix by running the real `coverage annotate -d` command against a measured `.pyw` file, and ran both checks above and the before/after failure-set comparison myself.*
