### PR TITLE
Map only the matched prefix in PathAliases

### DIFF
--- a/coverage/files.py
+++ b/coverage/files.py
@@ -506,7 +506,7 @@ class PathAliases:
 
         for original_pattern, regex, result in self.aliases:
             if m := regex.match(path):
-                new = path.replace(m[0], result)
+                new = path[:m.start()] + result + path[m.end():]
                 new = new.replace(sep(path), sep(result))
                 if not self.relative:
                     new = canonical_filename(new)

--- a/coverage/files.py
+++ b/coverage/files.py
@@ -506,7 +506,7 @@ class PathAliases:
 
         for original_pattern, regex, result in self.aliases:
             if m := regex.match(path):
-                new = path[:m.start()] + result + path[m.end():]
+                new = path.replace(m[0], result, 1)
                 new = new.replace(sep(path), sep(result))
                 if not self.relative:
                     new = canonical_filename(new)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -530,7 +530,7 @@ class PathAliasesTest(CoverageTest):
         self.assert_mapped(
             aliases,
             "/ci/src/vendor/ci/src/a.py",
-            os_sep("./mysrc/vendor/ci/src/a.py"),
+            "./mysrc/vendor/ci/src/a.py",
         )
 
     def test_no_map_if_not_exist(self, rel_yn: bool) -> None:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -523,6 +523,16 @@ class PathAliasesTest(CoverageTest):
         aliases.add("/home/*/src", "./mysrc")
         self.assert_unchanged(aliases, "/home/foo/srcetc")
 
+    def test_maps_only_the_matched_prefix(self, rel_yn: bool) -> None:
+        # Only the part the rule matched is replaced, not every occurrence of it.
+        aliases = PathAliases(relative=rel_yn)
+        aliases.add("/ci/src", "./mysrc")
+        self.assert_mapped(
+            aliases,
+            "/ci/src/vendor/ci/src/a.py",
+            os_sep("./mysrc/vendor/ci/src/a.py"),
+        )
+
     def test_no_map_if_not_exist(self, rel_yn: bool) -> None:
         aliases = PathAliases(relative=rel_yn)
         aliases.add("/ned/home/*/src", "./mysrc")


### PR DESCRIPTION
`PathAliases.map` substitutes with `str.replace`, so once a rule matches it rewrites every occurrence of the matched text, not just the part that matched:

```python
new = path.replace(m[0], result)
```

```python
aliases.add("/ci/src", "./mysrc")
aliases.map("/ci/src/vendor/ci/src/a.py", exists=lambda _: True)
# ./mysrc/vendor./mysrc/a.py
# want ./mysrc/vendor/ci/src/a.py
```

The second `/ci/src` is part of the file's real location, and it gets rewritten too. The separator normalisation on the next line then runs over the damage, which is where the `vendor./mysrc` comes from. Combining across machines is where this shows up, since the mapped path either fails the `exists` check and falls through to the next rule, or lands on the wrong file.

The regex is anchored with `match`, so slicing at the match bounds is the same thing the code already means.

Two open PRs touch this file, #2120 and #2233, and both change which rule matches, not the substitution. Different line, different failure. Happy to rebase behind either if you would rather land those first.

Tests are 425 passing across `test_files.py`, `test_api.py` and `test_data.py`. Reverting just the `files.py` line fails the new test in both its relative and absolute forms and nothing else, with the skip count at 7 either way.
