### PR TITLE
test: restore HTML JavaScript test suite

### DIFF
--- a/coverage/htmlfiles/coverage_html.js
+++ b/coverage/htmlfiles/coverage_html.js
@@ -503,20 +503,23 @@ coverage.to_prev_chunk = function () {
         chunk_indicator = c.chunk_indicator(probe_line);
     }
 
+    // There is no previous highlighted chunk.
+    if (!chunk_indicator) {
+        return;
+    }
+
     // There's a prev chunk, `probe` points to its last line.
     var end = probe+1;
 
     // Find the beginning of this chunk.
-    var prev_indicator = chunk_indicator;
-    while (prev_indicator === chunk_indicator) {
-        probe--;
-        if (probe <= 0) {
-            return;
+    while (probe > 1) {
+        probe_line = c.line_elt(probe-1);
+        if (c.chunk_indicator(probe_line) !== chunk_indicator) {
+            break;
         }
-        probe_line = c.line_elt(probe);
-        prev_indicator = c.chunk_indicator(probe_line);
+        probe--;
     }
-    c.set_sel(probe+1, end);
+    c.set_sel(probe, end);
     c.show_selection();
 };
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -74,6 +74,12 @@ these steps:
 Running the tests
 -----------------
 
+Most of the tests are for the Python code, but we also have JavaScript tests
+for the JavaScript in the HTML reports.
+
+Python tests
+............
+
 .. To get the test output:
     # Use the lowest of the PYVERSIONS
     # Resize terminal width to 95
@@ -81,8 +87,10 @@ Running the tests
 
 .. with COVERAGE_ONE_CORE=
 
-The tests are written mostly as standard unittest-style tests, and are run with
-pytest running under `tox`_::
+The Python tests are a mix of unittest-style tests and pytest-style tests. They
+are run with pytest running under `tox`_. They will run automatically via
+GitHub actions when you push your changes to GitHub, but it's also a good idea
+to run them locally for faster feedback::
 
     % python3 -m tox -e py310
     py310: pip-26.0.1-py3-none-any.whl already present in /Users/ned/.cache/virtualenv/wheel/3.10/embed/3/pip.json
@@ -221,6 +229,14 @@ as a simple terminal interface to see and set them.
 Of course, run all the tests on every version of Python you have before
 submitting a change.
 
+JavaScript tests
+................
+
+The JavaScript tests are run by loading tests/js/index.html in a web browser.
+You should see nearly 100 tests, all passing. These tests are not run
+automatically, so be sure to run them if you have changed any aspect of the
+HTML reports.
+
 
 Lint, etc
 ---------
@@ -268,8 +284,9 @@ output.  The top of the file you edited will have instructions.
 Continuous integration
 ----------------------
 
-When you make a pull request, `GitHub actions`__ will run all of the tests and
-quality checks on your changes.  If any fail, either fix them or ask for help.
+When you make a pull request, `GitHub actions`__ will run all of the Python
+tests and quality checks on your changes.  If any fail, either fix them or ask
+for help.
 
 __ https://github.com/coveragepy/coveragepy/actions
 

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -1,39 +1,21 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Coverage.py Javascript Test Suite</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.9.2.css">
-    <script type="text/javascript" src="../../coverage/htmlfiles/jquery.min.js"></script>
-    <script type='text/javascript' src="../../coverage/htmlfiles/jquery.isonscreen.js"></script>
     <script type="text/javascript" src="../../coverage/htmlfiles/coverage_html.js"></script>
-    <script type="text/javascript" src="../qunit/jquery.tmpl.min.js"></script>
-
-    <!-- Templates for the coverage report output -->
-    <script id="fixture-template" type="text/x-jquery-tmpl">
-        <table cellspacing='0' cellpadding='0'>
-            <tr>
-                <td class='linenos' valign='top'>
-                    <!-- #lineno-template goes here -->
-                </td>
-                <td class='text' valign='top'>
-                    <!-- #text-template goes here -->
-                </td>
-            </tr>
-        </table>
-    </script>
-
-    <script id="lineno-template" type="text/x-jquery-tmpl">
-        <p id='n${number}' class='${klass}'><a href='#n${number}'>${number}</a></p>
-    </script>
-
-    <script id="text-template" type="text/x-jquery-tmpl">
-        <p id='t${number}' class='${klass}{{if klass !== "w"}} show_${klass}{{/if}}'>Hello, world!</p>
-    </script>
 
 </head>
-<body>
+<body class="pyfile">
+    <!-- The report script expects these elements on a generated pyfile page. -->
+    <header>
+        <div class="content">
+            <h2></h2>
+        </div>
+    </header>
+    <main id="source"></main>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
     <script src="https://code.jquery.com/qunit/qunit-2.9.2.js"></script>

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Coverage.py Javascript Test Suite</title>
+    <title>Coverage.py JavaScript Test Suite</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.9.2.css">

--- a/tests/js/tests.js
+++ b/tests/js/tests.js
@@ -2,7 +2,7 @@
 /* For details: https://github.com/coveragepy/coveragepy/blob/main/NOTICE.txt */
 
 // Tests of coverage.py HTML report chunk navigation.
-/*global coverage, jQuery, $ */
+/*global QUnit, coverage */
 
 // Test helpers
 
@@ -15,21 +15,33 @@ function raw_selection_is(assert, sel, check_highlight) {
     assert.equal(coverage.sel_begin, beg);
     assert.equal(coverage.sel_end, end);
     if (check_highlight) {
-        assert.equal($(".linenos .highlight").length, end-beg);
+        assert.equal(document.querySelectorAll("#source .n.highlight").length, end-beg);
     }
 }
 
 // The spec is a list of "rbw" letters, indicating colors of successive lines.
 // We set the show_r and show_b classes for r and b.
 function build_fixture(spec) {
-    var i, data;
-    $("#fixture-template").tmpl().appendTo("#qunit-fixture");
-    for (i = 0; i < spec.length; i++) {
-        data = {number: i+1, klass: spec.substr(i, 1)};
-        $("#lineno-template").tmpl(data).appendTo("#qunit-fixture .linenos");
-        $("#text-template").tmpl(data).appendTo("#qunit-fixture .text");
+    const fixture = document.getElementById("source");
+    fixture.replaceChildren();
+
+    for (let i = 0; i < spec.length; i++) {
+        const number = i + 1;
+        const line = document.createElement("p");
+        const klass = spec[i];
+        line.className = klass === "w" ? klass : `${klass} show_${klass}`;
+
+        const line_number = document.createElement("span");
+        line_number.className = "n";
+        const link = document.createElement("a");
+        link.id = `t${number}`;
+        link.href = `#t${number}`;
+        link.textContent = number;
+        line_number.append(link);
+        line.append(line_number);
+        fixture.append(line);
     }
-    coverage.pyfile_ready(jQuery);
+    coverage.set_sel(0);
 }
 
 // Tests
@@ -55,13 +67,13 @@ QUnit.test("No first chunk to select", function (assert) {
 
 // One-chunk tests
 
-$.each([
+[
     ['rrrrr', [1,6]],
     ['r', [1,2]],
     ['wwrrrr', [3,7]],
     ['wwrrrrww', [3,7]],
     ['rrrrww', [1,5]]
-], function (i, params) {
+].forEach(function (params) {
 
     // Each of these tests uses a fixture with one highlighted chunks.
     var id = params[0];
@@ -98,14 +110,14 @@ $.each([
 
 // Two-chunk tests
 
-$.each([
+[
     ['rrwwrrrr', [1,3], [5,9]],
     ['rb', [1,2], [2,3]],
     ['rbbbbbbbbbb', [1,2], [2,12]],
     ['rrrrrrrrrrb', [1,11], [11,12]],
     ['wrrwrrrrw', [2,4], [5,9]],
     ['rrrbbb', [1,4], [4,7]]
-], function (i, params) {
+].forEach(function (params) {
 
     // Each of these tests uses a fixture with two highlighted chunks.
     var id = params[0];
@@ -176,7 +188,7 @@ QUnit.test("Jump from a line selected", function (assert) {
 
 // Tests of select_line_or_chunk.
 
-$.each([
+[
     // The data for each test: a spec for the fixture to build, and an array
     // of the selection that will be selected by select_line_or_chunk for
     // each line in the fixture.
@@ -188,7 +200,7 @@ $.each([
     ['wwwrrr', [[1,2], [2,3], [3,4], [4,7], [4,7], [4,7]]],
     ['rrrwww', [[1,4], [1,4], [1,4], [4,5], [5,6], [6,7]]],
     ['rrrbbb', [[1,4], [1,4], [1,4], [4,7], [4,7], [4,7]]]
-], function (i, params) {
+].forEach(function (params) {
 
     // Each of these tests uses a fixture with two highlighted chunks.
     var id = params[0];
@@ -200,10 +212,10 @@ $.each([
         }
     });
 
-    $.each(sels, function (i, sel) {
-        i++;
-        QUnit.test("Select line " + i, function (assert) {
-            coverage.select_line_or_chunk(i);
+    sels.forEach(function (sel, i) {
+        const line_number = i + 1;
+        QUnit.test("Select line " + line_number, function (assert) {
+            coverage.select_line_or_chunk(line_number);
             raw_selection_is(assert, sel);
         });
     });

--- a/tests/js/tests.js
+++ b/tests/js/tests.js
@@ -23,7 +23,6 @@ function raw_selection_is(assert, sel, check_highlight) {
 // We set the show_r and show_b classes for r and b.
 function build_fixture(spec) {
     const fixture = document.getElementById("source");
-    fixture.replaceChildren();
 
     for (let i = 0; i < spec.length; i++) {
         const number = i + 1;
@@ -43,6 +42,12 @@ function build_fixture(spec) {
     }
     coverage.set_sel(0);
 }
+
+// After every test, clear out the source lines we injected with build_fixture.
+QUnit.testDone(function() {
+    const fixture = document.getElementById("source");
+    fixture.replaceChildren();
+});
 
 // Tests
 


### PR DESCRIPTION
In [#2257](https://github.com/coveragepy/coveragepy/pull/2257), Ned asked for a separate PR to get coverage.py's JavaScript tests working again. The suite was stopping before it could run because `tests/js/index.html` still loaded local jQuery and template files that have been removed from the repository.

This PR:

- updates the fixture to match the current generated `pyfile` markup (`p > span.n > a`);
- replaces the jQuery/template helpers with native DOM APIs;
- removes the stale local asset references; and
- fixes the existing `to_prev_chunk()` boundary case where the previous highlighted chunk starts on line 1. Restoring the existing tests exposed that early return; the normal selection behavior is unchanged.

This is intentionally separate from the percentage calculation work in [#2257](https://github.com/coveragepy/coveragepy/pull/2257) and [#2259](https://github.com/coveragepy/coveragepy/pull/2259).

### Verification

- Browser QUnit suite: 96 tests, 253 assertions, 0 failures, with no console errors or warnings.
- `python -m pytest -n 0 tests/test_html.py -q` (67 passed).
- `node --check tests/js/tests.js`.
- `node --check coverage/htmlfiles/coverage_html.js`.
- `pre-commit run --all-files`.
- `git diff --check`.

OpenAI Codex assisted with the implementation and verification of this change.
